### PR TITLE
fix: display existing signature image when viewing submissions

### DIFF
--- a/client/components/forms/heavy/SignatureInput.vue
+++ b/client/components/forms/heavy/SignatureInput.vue
@@ -107,6 +107,21 @@ export default {
       handler(file) {
         this.compVal = file?.url || null
       }
+    },
+    compVal: {
+      immediate: true,
+      handler(val) {
+        // When viewing an existing submission, the API returns signature data
+        // as [{file_url: "...", file_name: "..."}]. Convert to the format
+        // expected by UploadedFile so the signature image is displayed.
+        if (this.disabled && val && Array.isArray(val) && val.length > 0 && val[0].file_url) {
+          this.file = {
+            file: { name: val[0].file_name || 'signature.png' },
+            url: val[0].file_url,
+            src: val[0].file_url
+          }
+        }
+      }
     }
   },
 


### PR DESCRIPTION
## Summary
- Fixes #1063 - Signature images now display when viewing existing submissions instead of showing an empty canvas
- The `SignatureInput` component now detects the API's array format `[{file_url, file_name}]` and converts it for the `UploadedFile` component

## Changes
- Added a `compVal` watcher with `immediate: true` in `SignatureInput.vue`
- When the field is disabled (viewing mode) and contains existing signature data in the API array format, the watcher constructs a compatible `file` object so the signature image renders

## Test plan
- [x] Code change is minimal (15 lines added) and scoped to the display-only path (guarded by `this.disabled`)
- [x] Does not affect signature input/capture flow for new form submissions
- [ ] Manual verification: view a submission with a signature field and confirm the signature image appears in the form view
- [ ] Manual verification: create a new form submission with a signature and confirm drawing/upload still works

## Limitations
- The email notification "Invalid signature" link issue mentioned in #1063 requires separate backend investigation (likely related to signed URL handling in email clients)
- Only the first signature in the array is displayed (matching the single-signature design of the component)

Closes #1063

## Bounty
This PR addresses a bug eligible for OpnForm's bounty program (via Algora).