### PR TITLE
[codex] Gate self-hosted licensed features

### DIFF
--- a/api/app/Http/Controllers/WorkspaceController.php
+++ b/api/app/Http/Controllers/WorkspaceController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Workspace\CustomCodeSettingsRequest;
 use App\Http\Requests\Workspace\EmailSettingsRequest;
 use App\Http\Resources\WorkspaceResource;
 use App\Models\Workspace;
+use App\Service\Billing\Feature;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -65,7 +66,7 @@ class WorkspaceController extends Controller
     public function saveCustomCodeSettings(CustomCodeSettingsRequest $request)
     {
         $this->authorize('adminAction', $request->workspace);
-        $request->workspace->requireFeature('branding.advanced');
+        $request->workspace->requireFeature(Feature::CUSTOM_CODE);
 
         $validated = $request->validated();
         $request->workspace->update([

--- a/api/app/Http/Resources/FormResource.php
+++ b/api/app/Http/Resources/FormResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Http\Middleware\Form\ProtectedForm;
+use App\Service\Branding\BrandingPolicy;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User as UserModel;
@@ -48,7 +49,7 @@ class FormResource extends JsonResource
             }
         }
 
-        return array_merge(parent::toArray($request), $ownerData, [
+        $data = array_merge(parent::toArray($request), $ownerData, [
             'settings' => $this->settings ?? new \stdClass(),
             'plan_tier' => $this->workspace->plan_tier ?? 'free',
             'is_trialing' => $this->workspaceIsTrialing(),
@@ -69,6 +70,10 @@ class FormResource extends JsonResource
             'translations' => $this->translations ?? new \stdClass(),
             'computed_variables' => $this->computed_variables ?? [],
         ]);
+
+        $data['no_branding'] = app(BrandingPolicy::class)->canRemoveFormBranding($this->resource);
+
+        return $data;
     }
 
     public function setCleanings(array $cleanings)
@@ -97,7 +102,7 @@ class FormResource extends JsonResource
             'has_password' => $this->has_password,
             'width' => 'centered',
             'layout_rtl' => $this->layout_rtl,
-            'no_branding' => $this->no_branding,
+            'no_branding' => app(BrandingPolicy::class)->canRemoveFormBranding($this->resource),
             'properties' => [],
             'logo_picture' => $this->logo_picture,
             'seo_meta' => $this->seo_meta,

--- a/api/app/Http/Resources/WorkspaceResource.php
+++ b/api/app/Http/Resources/WorkspaceResource.php
@@ -39,7 +39,7 @@ class WorkspaceResource extends JsonResource
             return [
                 'id' => $this->resource->id,
                 'max_file_size' => $this->resource->max_file_size / 1000000,
-                'settings' => $this->resource->hasFeature('branding.advanced') ? [
+                'settings' => $this->resource->hasFeature('custom_code') ? [
                     'custom_code' => $settings['custom_code'] ?? null,
                     'custom_css' => $settings['custom_css'] ?? null,
                 ] : [],

--- a/api/app/Notifications/Forms/FormEmailNotification.php
+++ b/api/app/Notifications/Forms/FormEmailNotification.php
@@ -6,6 +6,7 @@ use App\Events\Forms\FormSubmitted;
 use App\Models\Forms\FormSubmission;
 use App\Models\PdfTemplate;
 use App\Open\MentionParser;
+use App\Service\Branding\BrandingPolicy;
 use App\Service\Billing\Feature;
 use App\Service\Forms\FormSubmissionFormatter;
 use App\Service\Forms\SubmissionUrlService;
@@ -302,7 +303,7 @@ class FormEmailNotification extends Notification
             'fields' => $this->formatSubmissionData(),
             'form' => $form,
             'integrationData' => $this->integrationData,
-            'noBranding' => $form->no_branding,
+            'noBranding' => app(BrandingPolicy::class)->canRemoveFormBranding($form),
             'submission_id' => $this->getEncodedSubmissionId(),
             'emailAppearance' => $emailAppearance,
         ];

--- a/api/app/Service/Billing/Feature.php
+++ b/api/app/Service/Billing/Feature.php
@@ -16,6 +16,7 @@ final class Feature
     public const FILE_UPLOAD_ALLOWED_TYPES = 'file_upload.allowed_types';
     public const EDITABLE_SUBMISSIONS = 'editable_submissions';
     public const BRANDING_ADVANCED = 'branding.advanced';
+    public const CUSTOM_CODE = 'custom_code';
     public const FORM_VERSIONING = 'form_versioning';
     public const ENABLE_IP_TRACKING = 'enable_ip_tracking';
     public const PARTIAL_SUBMISSIONS = 'partial_submissions';
@@ -37,6 +38,7 @@ final class Feature
             self::FILE_UPLOAD_ALLOWED_TYPES,
             self::EDITABLE_SUBMISSIONS,
             self::BRANDING_ADVANCED,
+            self::CUSTOM_CODE,
             self::FORM_VERSIONING,
             self::ENABLE_IP_TRACKING,
             self::PARTIAL_SUBMISSIONS,

--- a/api/app/Service/Billing/PlanAccessService.php
+++ b/api/app/Service/Billing/PlanAccessService.php
@@ -65,6 +65,15 @@ class PlanAccessService
 
     public function hasFormFeature(Workspace $workspace, string $feature): bool
     {
+        if ($feature === 'no_branding') {
+            $overrideFeatures = $this->planOverrideResolver->getEffectiveOverrides($workspace)['features'] ?? [];
+            if (in_array($feature, $overrideFeatures, true)) {
+                return true;
+            }
+
+            return $this->hasFeature($workspace, Feature::BRANDING_REMOVAL);
+        }
+
         $featureMap = config('plans.form_features', []);
         $overrideFeatures = $this->planOverrideResolver->getEffectiveOverrides($workspace)['features'] ?? [];
 

--- a/api/app/Service/Branding/BrandingPolicy.php
+++ b/api/app/Service/Branding/BrandingPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Service\Branding;
+
+use App\Models\Forms\Form;
+use App\Service\Billing\Feature;
+
+class BrandingPolicy
+{
+    public function canRemoveBranding(Form $form, bool $requested): bool
+    {
+        return $requested && ($form->workspace?->hasFeature(Feature::BRANDING_REMOVAL) ?? false);
+    }
+
+    public function canRemoveFormBranding(Form $form): bool
+    {
+        return $this->canRemoveBranding($form, (bool) $form->no_branding);
+    }
+}

--- a/api/app/Service/Forms/FormCleaner.php
+++ b/api/app/Service/Forms/FormCleaner.php
@@ -29,7 +29,7 @@ class FormCleaner
 
     private array $cleaningMessages = [
         // For form
-        'no_branding' => 'OpenForm branding is not hidden.',
+        'no_branding' => 'OpnForm branding is not hidden.',
         'database_fields_update' => 'Form submission will only create new records (no updates).',
         'editable_submissions' => 'Users will not be able to edit their submissions.',
         'custom_code' => 'Custom code was disabled',
@@ -111,6 +111,7 @@ class FormCleaner
     public function processForm(Request $request, Form $form): FormCleaner
     {
         $data = (new FormResource($form))->toArray($request);
+        $data['no_branding'] = (bool) $form->no_branding;
 
         // Determine if custom code is allowed in this response context
         $allowOnSelfHosted = config('app.self_hosted', true) && (bool) config('opnform.custom_code.enable_self_hosted', false);

--- a/api/app/Service/Pdf/PdfGeneratorService.php
+++ b/api/app/Service/Pdf/PdfGeneratorService.php
@@ -6,7 +6,7 @@ use App\Exceptions\PdfNotSupportedException;
 use App\Models\Forms\Form;
 use App\Models\Forms\FormSubmission;
 use App\Models\PdfTemplate;
-use App\Service\Billing\Feature;
+use App\Service\Branding\BrandingPolicy;
 use App\Service\Forms\FormSubmissionFormatter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -37,8 +37,7 @@ class PdfGeneratorService
         $submissionData = $this->getFormattedSubmissionData($form, $submission);
 
         // Check if branding should be added
-        $hasBrandingRemoval = $form->workspace?->hasFeature(Feature::BRANDING_REMOVAL) ?? false;
-        $addBranding = !($template->remove_branding && $hasBrandingRemoval);
+        $addBranding = !app(BrandingPolicy::class)->canRemoveBranding($form, (bool) $template->remove_branding);
 
         // Generate the PDF
         $pdfContent = $this->generatePdfContent($template, $zoneMappings, $submissionData, $addBranding);

--- a/api/config/plans.php
+++ b/api/config/plans.php
@@ -58,6 +58,7 @@ return [
 
         // Business
         'branding.advanced' => 'business',  // CSS, fonts, favicons
+        'custom_code' => 'business',
         'custom_domain.wildcard' => 'business',
         'multi_user.roles' => 'business',
         'integrations.hubspot' => 'business',
@@ -153,6 +154,6 @@ return [
         'custom_smtp' => ['custom_smtp'],
         'audit_logs' => ['audit_logs', 'compliance_features'],
         'external_storage' => ['external_storage'],
-        'custom_code' => ['custom_code', 'custom_css', 'branding.advanced'],
+        'custom_code' => ['custom_code', 'custom_css'],
     ],
 ];

--- a/api/tests/Feature/Forms/FormTest.php
+++ b/api/tests/Feature/Forms/FormTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Support\Facades\Cache;
 
 it('can create a contact form', function () {
     $user = $this->actingAsUser();
@@ -88,6 +89,21 @@ it('can fetch a form', function () {
             'id' => $form->id,
             'title' => $form->title
         ]);
+});
+
+it('returns effective no_branding for form owners on self-hosted', function () {
+    config()->set('app.self_hosted', true);
+    Cache::flush();
+
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'no_branding' => true,
+    ]);
+
+    $formData = (new \App\Http\Resources\FormResource($form))->toArray(request());
+
+    expect($formData['no_branding'])->toBeFalse();
 });
 
 it('does not leak workspace details on public form fetch', function () {

--- a/api/tests/Feature/SelfHosted/WorkspaceProFeaturesTest.php
+++ b/api/tests/Feature/SelfHosted/WorkspaceProFeaturesTest.php
@@ -126,6 +126,17 @@ describe('custom code and CSS settings', function () {
         $response->assertStatus(403);
     });
 
+    it('blocks custom code with whitelabel license only', function () {
+        activateLicenseWithFeatures(['whitelabel' => true]);
+
+        $response = $this->putJson(
+            route('open.workspaces.save-custom-code-settings', ['workspace' => $this->workspace]),
+            ['custom_code' => '<script>console.log("hello")</script>'],
+        );
+
+        $response->assertStatus(403);
+    });
+
     it('allows custom code with license having custom_code feature', function () {
         activateLicenseWithFeatures(['custom_code' => true]);
 

--- a/api/tests/Unit/Service/FormCleanerTest.php
+++ b/api/tests/Unit/Service/FormCleanerTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Service\Forms\FormCleaner;
+use App\Service\License\LicenseCheckResult;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 
 uses(\Tests\TestCase::class);
 
@@ -151,6 +153,52 @@ describe('FormCleaner tier-based cleaning', function () {
         // Pro features should remain for pro tier
         expect($data['no_branding'])->toBeTrue();
         expect($data['redirect_url'])->toBe('https://example.com/thanks');
+    });
+
+    it('cleans no_branding on self-hosted without whitelabel license', function () {
+        config()->set('app.self_hosted', true);
+        Cache::flush();
+
+        $user = $this->actingAsUser();
+        $workspace = $this->createUserWorkspace($user);
+
+        $form = $this->createForm($user, $workspace, [
+            'no_branding' => true,
+        ]);
+
+        $request = Request::create('/', 'GET');
+        $cleaner = (new FormCleaner())->processForm($request, $form);
+        $cleaner->performCleaning($workspace);
+        $data = $cleaner->getData();
+
+        expect($data['no_branding'])->toBeFalse();
+    });
+
+    it('keeps no_branding on self-hosted with whitelabel license', function () {
+        config()->set('app.self_hosted', true);
+        $this->storeSelfHostedLicense([
+            'license_key' => 'lic_whitelabel12345',
+        ]);
+
+        Cache::put('self_hosted_license_check', new LicenseCheckResult(
+            status: 'active',
+            features: ['whitelabel' => true],
+            lastChecked: now(),
+        ), 86400);
+
+        $user = $this->actingAsUser();
+        $workspace = $this->createUserWorkspace($user);
+
+        $form = $this->createForm($user, $workspace, [
+            'no_branding' => true,
+        ]);
+
+        $request = Request::create('/', 'GET');
+        $cleaner = (new FormCleaner())->processForm($request, $form);
+        $cleaner->performCleaning($workspace);
+        $data = $cleaner->getData();
+
+        expect($data['no_branding'])->toBeTrue();
     });
 
     it('cleans business features from pro tier workspace', function () {
@@ -310,7 +358,7 @@ describe('FormCleaner tier-based cleaning', function () {
 
         $cleanings = $cleaner->getPerformedCleanings();
         expect($cleanings)->toHaveKey('form');
-        expect($cleanings['form']->toArray())->toContain('OpenForm branding is not hidden.');
+        expect($cleanings['form']->toArray())->toContain('OpnForm branding is not hidden.');
         expect($cleanings['form']->toArray())->toContain('Redirect Url was disabled');
         expect($cleanings['form']->toArray())->toContain('Partial submissions were disabled');
         expect($cleanings['form']->toArray())->toContain('IP tracking was disabled');

--- a/api/tests/Unit/Service/PlanAccessServiceTest.php
+++ b/api/tests/Unit/Service/PlanAccessServiceTest.php
@@ -3,6 +3,8 @@
 use App\Exceptions\FeatureAccessDeniedException;
 use App\Service\Billing\Feature;
 use App\Service\Billing\PlanAccessService;
+use App\Service\License\LicenseCheckResult;
+use Illuminate\Support\Facades\Cache;
 
 uses(\Tests\TestCase::class);
 
@@ -46,6 +48,55 @@ it('does not leak paid workspace or form features into a free workspace payload'
     expect($features)->toBe([]);
     expect($this->service->hasFeature($workspace, Feature::BRANDING_REMOVAL))->toBeFalse();
     expect($this->service->hasFormFeature($workspace, 'redirect_url'))->toBeFalse();
+});
+
+it('requires self-hosted whitelabel for branding removal and no_branding', function () {
+    config()->set('app.self_hosted', true);
+    Cache::flush();
+
+    $user = $this->createUser();
+    $workspace = $this->createUserWorkspace($user);
+
+    expect($this->service->hasFeature($workspace, Feature::BRANDING_REMOVAL))->toBeFalse();
+    expect($this->service->hasFormFeature($workspace, 'no_branding'))->toBeFalse();
+});
+
+it('does not grant custom code with self-hosted whitelabel only', function () {
+    config()->set('app.self_hosted', true);
+    $this->storeSelfHostedLicense([
+        'license_key' => 'lic_whitelabel12345',
+    ]);
+
+    Cache::put('self_hosted_license_check', new LicenseCheckResult(
+        status: 'active',
+        features: ['whitelabel' => true],
+        lastChecked: now(),
+    ), 86400);
+
+    $user = $this->createUser();
+    $workspace = $this->createUserWorkspace($user);
+
+    expect($this->service->hasFeature($workspace, Feature::CUSTOM_CODE))->toBeFalse();
+    expect($this->service->hasFeature($workspace, Feature::BRANDING_ADVANCED))->toBeTrue();
+});
+
+it('grants branding removal and no_branding with self-hosted whitelabel', function () {
+    config()->set('app.self_hosted', true);
+    $this->storeSelfHostedLicense([
+        'license_key' => 'lic_whitelabel12345',
+    ]);
+
+    Cache::put('self_hosted_license_check', new LicenseCheckResult(
+        status: 'active',
+        features: ['whitelabel' => true],
+        lastChecked: now(),
+    ), 86400);
+
+    $user = $this->createUser();
+    $workspace = $this->createUserWorkspace($user);
+
+    expect($this->service->hasFeature($workspace, Feature::BRANDING_REMOVAL))->toBeTrue();
+    expect($this->service->hasFormFeature($workspace, 'no_branding'))->toBeTrue();
 });
 
 it('throws a feature exception when access is denied', function () {

--- a/client/components/open/forms/components/form-components/FormCustomization.vue
+++ b/client/components/open/forms/components/form-components/FormCustomization.vue
@@ -256,7 +256,6 @@ const showGoogleFontPicker = ref(false)
 const { $i18n } = useNuxtApp()
 
 const isPro = computed(() => {
-  if (!useFeatureFlag('billing.enabled')) return true
   return hasFeature('branding.removal')
 })
 

--- a/client/components/workspaces/settings/CustomCode.vue
+++ b/client/components/workspaces/settings/CustomCode.vue
@@ -3,17 +3,7 @@
     <div class="flex flex-col flex-wrap items-start justify-between gap-4 sm:flex-row sm:items-center">
       <div class="flex-1">
         <h3 class="text-lg font-medium text-neutral-900">
-          Custom Code <PlanTag required-tier="business"
-            class="mb-2 block"
-            upgrade-modal-title="Upgrade to Unlock Custom Code Capabilities"
-            upgrade-modal-description="On the Free plan, you can explore custom code features within the workspace settings. Upgrade your plan to implement custom scripts, styles, and advanced tracking in all your workspace forms. Elevate your forms' functionality and design with unlimited customization options."
-          />
-          <PlanTag
-            v-if="isSelfHosted"
-            required-tier="self_hosted"
-            class="mb-2 block"
-            upgrade-modal-title="Upgrade to Unlock Custom Code"
-          />
+          Custom Code
         </h3>
         <p class="mt-1 text-sm text-neutral-500">
           The code will be injected in the <b>head</b> section of all forms in this workspace. Workspace code is applied first, then form-specific code (if any).
@@ -39,15 +29,15 @@
     </div>
 
     <UAlert
-      v-if="!isSelfHosted && !canAccessAdvancedBranding"
-      icon="i-heroicons-user-group-20-solid"
+      v-if="!canAccessCustomCode"
+      icon="i-heroicons-lock-closed"
       class="mb-4"
       color="warning"
       variant="subtle"
-      title="Business plan required"
-      description="Please upgrade your plan to unlock workspace-level custom code."
+      :title="upgradeCalloutTitle"
+      :description="upgradeCalloutDescription"
       :actions="[{
-        label: 'Try Business plan',
+        label: upgradeCalloutActionLabel,
         color: 'warning',
         variant: 'solid',
         onClick: () => openUpgradeModal()
@@ -76,17 +66,7 @@
             <div class="flex flex-col flex-wrap items-start justify-between gap-4 sm:flex-row sm:items-center">
               <div>
                 <h3 class="text-lg font-medium text-neutral-900">
-                  Custom CSS <PlanTag
-                    class="mb-2 block"
-                    upgrade-modal-title="Upgrade to Unlock Custom CSS"
-                    upgrade-modal-description="On the Free plan, you can explore custom CSS within the workspace settings. Upgrade to apply custom styles to all your workspace forms."
-                  />
-                  <PlanTag
-                    v-if="isSelfHosted"
-                    required-tier="self_hosted"
-                    class="mb-2 block"
-                    upgrade-modal-title="Upgrade to Unlock Custom CSS"
-                  />
+                  Custom CSS
                 </h3>
                 <p class="mt-1 text-sm text-neutral-500">
                   The CSS will be injected in the <b>head</b> of all forms in this workspace.
@@ -106,7 +86,7 @@
               name="custom_css"
               class="mt-4"
               :form="customCodeForm"
-              :disabled="!canAccessAdvancedBranding"
+              :disabled="!canAccessCustomCode"
               help="CSS only. Example: body { background: #f8fafc }"
               label="Custom CSS"
               placeholder="body { background: #f8fafc }"
@@ -118,7 +98,7 @@
           <UButton
             type="submit"
             :loading="customCodeForm.busy"
-            :disabled="!canAccessAdvancedBranding"
+            :disabled="!canAccessCustomCode"
             color="primary"
           >
             Save Changes
@@ -130,21 +110,36 @@
 </template>
 
 <script setup>
-import PlanTag from "~/components/app/PlanTag.vue"
-
 const alert = useAlert()
 const crisp = useCrisp()
 const { current: workspace } = useCurrentWorkspace()
 const { invalidateAll } = useWorkspaces()
 const { hasFeature } = usePlanFeatures()
-const canAccessAdvancedBranding = computed(() => hasFeature('branding.advanced'))
+const canAccessCustomCode = computed(() => hasFeature('custom_code'))
 const isSelfHosted = computed(() => useFeatureFlag('self_hosted'))
 const { openSubscriptionModal } = useAppModals()
+
+const upgradeCalloutTitle = computed(() => {
+  return isSelfHosted.value ? 'Enterprise license required' : 'Business plan required'
+})
+
+const upgradeCalloutDescription = computed(() => {
+  if (isSelfHosted.value) {
+    return 'Workspace-level custom code and CSS require an Enterprise self-hosted license. Purchase or activate a license to inject scripts and styles across all forms in this workspace.'
+  }
+
+  return 'Workspace-level custom code and CSS require a Business plan. Upgrade to inject scripts, styles, analytics snippets, and advanced tracking across all forms in this workspace.'
+})
+
+const upgradeCalloutActionLabel = computed(() => {
+  return isSelfHosted.value ? 'Purchase license' : 'Upgrade to Business'
+})
 
 const openUpgradeModal = () => {
   openSubscriptionModal({
     plan: isSelfHosted.value ? 'self_hosted' : 'business',
-    modal_title: 'Upgrade to use workspace level custom code'
+    modal_title: isSelfHosted.value ? 'Enterprise license required for custom code' : 'Upgrade to use workspace-level custom code',
+    modal_description: upgradeCalloutDescription.value
   })
 }
 
@@ -160,7 +155,7 @@ const hasCustomDomain = computed(() => {
 const allowSelfHosted = computed(() => !!useFeatureFlag('custom_code.enable_self_hosted', false))
 
 const canUseCustomCode = computed(() => {
-  if (!canAccessAdvancedBranding.value) return false
+  if (!canAccessCustomCode.value) return false
   return hasCustomDomain.value || (isSelfHosted.value && allowSelfHosted.value)
 })
 
@@ -175,7 +170,7 @@ const customCodeHelp = computed(() => {
 })
 
 const saveChanges = () => {
-  if (!canAccessAdvancedBranding.value) return
+  if (!canAccessCustomCode.value) return
 
   customCodeForm
     .put(`/open/workspaces/${workspace.value.id}/custom-code-settings`, {

--- a/client/components/workspaces/settings/InviteUser.vue
+++ b/client/components/workspaces/settings/InviteUser.vue
@@ -96,6 +96,7 @@ const hasActiveLicense = computed(() => {
 })
 const crisp = useCrisp()
 const { openSubscriptionModal } = useAppModals()
+const { handleLicenseError } = useLicenseUpgradeModal()
 const { currentId: workspaceId } = useCurrentWorkspace()
 const alert = useAlert()
 const { hasFeature } = usePlanFeatures()
@@ -142,6 +143,15 @@ const addUser = () => {
     emit('user-added')
     closeModal()
   }).catch((error) => {
+    const handled = handleLicenseError(error, {
+      title: 'Enterprise license required for more users',
+      description: 'Your self-hosted instance includes up to 2 users without an Enterprise license. Purchase or activate an Enterprise self-hosted license to invite more workspace members.'
+    })
+    if (handled) {
+      closeModal()
+      return
+    }
+
     alert.error(error?.data?.message || "There was an error adding user")
   })
 }

--- a/client/components/workspaces/settings/Modal.vue
+++ b/client/components/workspaces/settings/Modal.vue
@@ -23,7 +23,7 @@
     </SettingsModalPage>
 
     <SettingsModalPage
-      v-if="workspace && workspace.is_admin"
+      v-if="showDomainsSettings"
       id="domains"
       label="Domains"
       icon="i-heroicons-globe-alt"
@@ -77,6 +77,9 @@ const props = defineProps({
 })
 
 const { current: workspace } = useCurrentWorkspace()
+const showDomainsSettings = computed(() => {
+  return !!workspace.value && workspace.value.is_admin && !useFeatureFlag('self_hosted')
+})
 
 // Modal state is now derived from the presence of an active tab
 const isOpen = computed({

--- a/client/components/workspaces/settings/sso/Oidc.vue
+++ b/client/components/workspaces/settings/sso/Oidc.vue
@@ -98,6 +98,7 @@ import OidcConnectionModal from './OidcConnectionModal.vue'
 const { current: workspace } = useCurrentWorkspace()
 const alert = useAlert()
 const { openSubscriptionModal } = useAppModals()
+const { handleLicenseError } = useLicenseUpgradeModal()
 
 const workspaceId = computed(() => workspace.value?.id)
 
@@ -160,6 +161,14 @@ const openUpgradeModal = () => {
   })
 }
 
+const openSsoLicenseModal = (error) => {
+  return handleLicenseError(error, {
+    includeUnauthorized: true,
+    title: 'Enterprise license required for SSO',
+    description: 'Your self-hosted license does not include SSO. Purchase or activate an Enterprise self-hosted license to create and manage OIDC connections.'
+  })
+}
+
 const showCreateModal = ref(false)
 const editingConnection = ref(null)
 
@@ -196,6 +205,7 @@ const saveConnection = () => {
       })
       .catch((error) => {
         // Form handles validation errors automatically
+        if (openSsoLicenseModal(error)) return
         if (error.response?.status !== 422) {
           alert.error(error.response?._data?.message ?? 'Failed to update connection')
         }
@@ -210,6 +220,7 @@ const saveConnection = () => {
       })
       .catch((error) => {
         // Form handles validation errors automatically
+        if (openSsoLicenseModal(error)) return
         if (error.response?.status !== 422) {
           alert.error(error.response?._data?.message ?? 'Failed to create connection')
         }
@@ -247,6 +258,7 @@ const deleteConnection = (connection) => {
           alert.success('OIDC connection deleted successfully')
         })
         .catch((error) => {
+          if (openSsoLicenseModal(error)) return
           alert.error(error.response?._data?.message ?? 'Failed to delete connection')
         })
     }

--- a/client/components/workspaces/settings/sso/Saml.vue
+++ b/client/components/workspaces/settings/sso/Saml.vue
@@ -2,18 +2,16 @@
   <div class="space-y-4">
     <div class="flex flex-col flex-wrap items-start justify-between gap-4 sm:flex-row sm:items-center">
       <div>
-        <h3 class="text-lg font-medium text-neutral-900">SAML Settings</h3>
+        <div class="flex items-center gap-2">
+          <h3 class="text-lg font-medium text-neutral-900">SAML Settings</h3>
+          <UBadge color="neutral" variant="subtle">
+            Not available yet
+          </UBadge>
+        </div>
         <p class="mt-1 text-sm text-neutral-500">
-          Configure SAML single sign-on for your workspace.
+          SAML single sign-on is not available yet. Use OIDC for workspace SSO.
         </p>
       </div>
-
-      <UButton
-        v-if="canManageConnections"
-        label="Add Connection"
-        icon="i-heroicons-plus"
-        @click="openContactChat"
-      />
     </div>
 
     <!-- Empty State -->
@@ -26,26 +24,8 @@
         No SAML connections yet
       </h4>
       <p class="text-neutral-500 mb-6 max-w-md mx-auto">
-        Configure your first SAML connection to enable single sign-on for your workspace.
+        SAML setup is not implemented in this version of OpnForm.
       </p>
-      <UButton
-        v-if="canManageConnections"
-        label="Add Your First Connection"
-        icon="i-heroicons-plus"
-        @click="openContactChat"
-      />
     </div>
   </div>
 </template>
-
-<script setup>
-const { current: workspace } = useCurrentWorkspace()
-const { openAndShowChat } = useCrisp()
-
-const canManageConnections = computed(() => !!workspace.value && workspace.value.is_admin)
-
-const openContactChat = () => {
-  const message = "Hi! I'd like to set up SAML SSO for my workspace. Can you help me configure it?"
-  openAndShowChat(message)
-}
-</script>

--- a/client/composables/useLicenseUpgradeModal.js
+++ b/client/composables/useLicenseUpgradeModal.js
@@ -1,0 +1,42 @@
+export function useLicenseUpgradeModal() {
+  const { openSubscriptionModal } = useAppModals()
+
+  const getErrorStatus = (error) => {
+    return error?.response?.status || error?.status || error?.statusCode
+  }
+
+  const getErrorMessage = (error) => {
+    return error?.response?._data?.message
+      || error?.response?.data?.message
+      || error?.data?.message
+      || error?.message
+      || ''
+  }
+
+  const isLicenseError = (error, options = {}) => {
+    const message = getErrorMessage(error)
+    if (getErrorStatus(error) !== 403) return false
+
+    return message.includes('self-hosted license')
+      || message.includes('Enterprise license is required')
+      || (options.includeUnauthorized && message === 'This action is unauthorized.')
+  }
+
+  const handleLicenseError = (error, options = {}) => {
+    if (!isLicenseError(error, options)) return false
+
+    openSubscriptionModal({
+      plan: 'self_hosted',
+      modal_title: options.title || 'Enterprise self-hosted license required',
+      modal_description: options.description || getErrorMessage(error)
+    })
+
+    return true
+  }
+
+  return {
+    getErrorMessage,
+    handleLicenseError,
+    isLicenseError
+  }
+}

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -149,6 +149,9 @@ export default defineNuxtConfig({
           },
       ],
       clientBundle: {
+          icons: [
+              'ix:mandatory',
+          ],
           includeCustomCollections: true,
           scan: {
               globInclude: ['**/*.vue', '**/*.json'],

--- a/docs/api-reference/forms/update-form.mdx
+++ b/docs/api-reference/forms/update-form.mdx
@@ -46,7 +46,7 @@ These fields must always be included:
 | dark_mode              | string  | Dark mode setting                                                    |
 | color                  | string  | Primary color (hex format)                                           |
 | uppercase_labels       | boolean | Whether labels should be uppercase                                   |
-| no_branding            | boolean | Hide OpenForm branding                                               |
+| no_branding            | boolean | Hide OpnForm branding                                                |
 | transparent_background | boolean | Use transparent background                                           |
 | properties             | array   | Array of form fields/blocks — **must never be empty**, or existing properties will be lost |
 | …other fields          | mixed   | All other fields from Create Form (description, logo_picture, etc.)  |


### PR DESCRIPTION
## Summary
- Enforce branding removal/no-branding through a shared self-hosted branding policy across forms, emails, PDFs, cleaners, and API resources.
- Improve self-hosted license UX by opening the subscription modal for restricted SSO and member-limit errors, replacing self-hosted plan tags on custom code with a clear upgrade callout, and hiding custom domains in self-hosted.
- Mark SAML as not implemented yet, force bundle the required-field icon, and update docs/tests for no_branding behavior.

## Validation
- `npm run lint` in `client/`
- `./vendor/bin/pest --filter='PlanAccessServiceTest|FormCleanerTest'` in `api/`
- `docker-compose -p opnform_latest_local -f docker-compose.yml -f docker-compose.override.yml build api ui`
- `docker-compose -p opnform_latest_local -f docker-compose.yml -f docker-compose.override.yml up -d --force-recreate api api-worker api-scheduler ui ingress`
- Docker services healthy and `http://127.0.0.1:8088` returned 200

## Notes
- Left the local `docker-compose.yml` port change unstaged because it was only used for local testing on port 8088.