### PR TITLE
[codex] Ignore stale matrix rows

### DIFF
--- a/api/app/Http/Requests/AnswerFormRequest.php
+++ b/api/app/Http/Requests/AnswerFormRequest.php
@@ -309,6 +309,13 @@ class AnswerFormRequest extends FormRequest
             if ($property['type'] === 'rich_text' && $receivedValue) {
                 $mergeData[$property['id']] = Purify::clean($receivedValue);
             }
+
+            if ($property['type'] === 'matrix' && is_array($receivedValue)) {
+                $mergeData[$property['id']] = array_intersect_key(
+                    $receivedValue,
+                    array_flip($property['rows'] ?? [])
+                );
+            }
         });
 
         $this->merge($mergeData);

--- a/api/app/Rules/MatrixValidationRule.php
+++ b/api/app/Rules/MatrixValidationRule.php
@@ -52,10 +52,5 @@ class MatrixValidationRule implements ValidationRule
             }
         }
 
-        // Check for extra rows that shouldn't be there
-        $extraRows = array_diff(array_keys($value), $rows);
-        foreach ($extraRows as $extraRow) {
-            $fail("Unexpected row '{$extraRow}' in the matrix.");
-        }
     }
 }

--- a/api/tests/Feature/Forms/MatrixInputTest.php
+++ b/api/tests/Feature/Forms/MatrixInputTest.php
@@ -37,6 +37,48 @@ it('can submit form with valid matrix input', function () {
         ]);
 });
 
+it('silently ignores matrix rows that no longer exist', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $matrixProperty = [
+        'id' => 'matrix_field',
+        'name' => 'Matrix Question',
+        'type' => 'matrix',
+        'rows' => ['Row 2', 'Row 3'],
+        'columns' => ['Column A', 'Column B', 'Column C'],
+        'required' => true
+    ];
+
+    $form->properties = array_merge($form->properties, [$matrixProperty]);
+    $form->update();
+
+    $submissionData = [
+        'matrix_field' => [
+            'Row 1' => 'Column A',
+            'Row 2' => 'Column B',
+            'Row 3' => 'Column C'
+        ]
+    ];
+
+    $formData = $this->generateFormSubmissionData($form, $submissionData);
+
+    $this->postJson(route('forms.answer', $form->slug), $formData)
+        ->assertSuccessful()
+        ->assertJson([
+            'type' => 'success',
+            'message' => 'Form submission saved.',
+        ]);
+
+    $submission = $form->submissions()->latest()->first();
+
+    expect($submission->data['matrix_field'])->toBe([
+        'Row 2' => 'Column B',
+        'Row 3' => 'Column C'
+    ]);
+});
+
 it('cannot submit form with invalid matrix input', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);


### PR DESCRIPTION
## Summary

This PR makes matrix submissions tolerant of stale row keys sent by the browser. If a submitted matrix payload includes rows that no longer exist in the form definition, those rows are filtered out before validation and storage.

## Why

A live form submission could fail with `Unexpected row 'Row 1' in the matrix.` when the client submitted an old matrix row that had since been removed from the form. The intended behavior is to accept the submission and silently ignore rows that the current matrix field no longer defines.

## Details

- Filters matrix request values to the current field rows during `AnswerFormRequest::prepareForValidation()`.
- Removes the validation failure for extra matrix rows.
- Keeps invalid column values strict, so submissions still cannot store matrix answers the current field cannot represent.
- Adds a feature regression test that verifies stale rows are ignored and not persisted.

## Validation

- `vendor/bin/pest tests/Feature/Forms/MatrixInputTest.php`