### PR TITLE
[codex] Truncate long form titles

### DIFF
--- a/api/app/Http/Requests/UserFormRequest.php
+++ b/api/app/Http/Requests/UserFormRequest.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Http\Request;
 use App\Rules\CssOnlyRule;
+use Illuminate\Support\Str;
 use Stevebauman\Purify\Facades\Purify;
 
 /**
@@ -33,6 +34,10 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
     protected function prepareForValidation()
     {
         $data = $this->all();
+
+        if (isset($data['title']) && is_string($data['title'])) {
+            $data['title'] = Str::substr(trim($data['title']), 0, 255);
+        }
 
         if (isset($data['properties']) && is_array($data['properties'])) {
             $data['properties'] = array_map(function ($property) {
@@ -157,7 +162,7 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
 
         return [
             // Form Info
-            'title' => 'required|string|max:60',
+            'title' => 'required|string|max:255',
             'description' => 'nullable|string|max:2000',
             'tags' => 'nullable|array',
             'visibility' => ['required', Rule::in(Form::VISIBILITY)],
@@ -259,6 +264,8 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
     {
         // Note: Property-specific messages are now handled by FormPropertiesRule
         // for better performance (single-pass validation)
-        return [];
+        return [
+            'title.max' => 'Form name must be 255 characters or fewer.',
+        ];
     }
 }

--- a/api/app/Service/FormImport/Importers/FilloutImporter.php
+++ b/api/app/Service/FormImport/Importers/FilloutImporter.php
@@ -55,7 +55,7 @@ class FilloutImporter extends AbstractImporter
             throw new FormImportException('Could not find form data in the page structure.');
         }
 
-        $title = $this->sanitizeText($pageProps['flow']['name'] ?? 'Imported Fillout Form', 60);
+        $title = $this->sanitizeText($pageProps['flow']['name'] ?? 'Imported Fillout Form', 255);
 
         $template = $pageProps['flowSnapshot']['template'] ?? [];
         $stepsMap = $this->asMap($template['steps'] ?? []);

--- a/api/app/Service/FormImport/Importers/GoogleFormsImporter.php
+++ b/api/app/Service/FormImport/Importers/GoogleFormsImporter.php
@@ -122,7 +122,7 @@ class GoogleFormsImporter extends AbstractImporter
 
     private function parseFormData(array $data): array
     {
-        $title = $this->sanitizeText($data['info']['title'] ?? $data['info']['documentTitle'] ?? 'Imported Google Form', 60);
+        $title = $this->sanitizeText($data['info']['title'] ?? $data['info']['documentTitle'] ?? 'Imported Google Form', 255);
         $description = $this->sanitizeText($data['info']['description'] ?? '', 8000);
         $items = $data['items'] ?? [];
 

--- a/api/app/Service/FormImport/Importers/TallyImporter.php
+++ b/api/app/Service/FormImport/Importers/TallyImporter.php
@@ -90,7 +90,7 @@ class TallyImporter extends AbstractImporter
             throw new FormImportException('Could not find Tally form blocks in the page data.');
         }
 
-        $title = $this->sanitizeText($pageProps['name'] ?? $pageProps['title'] ?? 'Imported Tally Form', 60);
+        $title = $this->sanitizeText($pageProps['name'] ?? $pageProps['title'] ?? 'Imported Tally Form', 255);
         ['properties' => $properties, 'settings' => $settings] = $this->mapBlocks($blocks);
 
         return [

--- a/api/app/Service/FormImport/Importers/TypeformImporter.php
+++ b/api/app/Service/FormImport/Importers/TypeformImporter.php
@@ -48,7 +48,7 @@ class TypeformImporter extends AbstractImporter
         $html = $this->fetchHtml($url);
         $formData = $this->extractFormData($html);
 
-        $title = $this->sanitizeText($formData['title'] ?? 'Imported Typeform', 60);
+        $title = $this->sanitizeText($formData['title'] ?? 'Imported Typeform', 255);
         $properties = [];
         if ($welcome = $this->renderWelcomeScreen($formData['welcome_screens'] ?? [])) {
             $properties[] = $welcome;

--- a/api/tests/Feature/Forms/FormTest.php
+++ b/api/tests/Feature/Forms/FormTest.php
@@ -146,6 +146,24 @@ it('can update a form', function () {
     ]);
 });
 
+it('truncates form titles longer than the database limit when updating a form', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $formData = (new \App\Http\Resources\FormResource($form))->toArray(request());
+    $formData['title'] = str_repeat('a', 300);
+
+    $this->putJson(route('open.forms.update', $form->id), $formData)
+        ->assertSuccessful()
+        ->assertJsonPath('form.title', str_repeat('a', 255));
+
+    $this->assertDatabaseHas('forms', [
+        'id' => $form->id,
+        'title' => str_repeat('a', 255),
+    ]);
+});
+
 it('backfills missing select option ids when creating a form', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);

--- a/client/components/app/EditableTag.vue
+++ b/client/components/app/EditableTag.vue
@@ -27,6 +27,7 @@
         v-model="content"
         class="absolute inset-0 focus:outline-hidden bg-white rounded-sm transition-colors px-2"
         :class="[{ 'bg-blue-50': editing }, contentClass]"
+        :maxlength="maxLength"
         @blur="editing = false"
         @keyup.enter="editing = false"
         @input="handleInput"
@@ -43,6 +44,7 @@ const props = defineProps({
   textAlign: { type: String, default: "left" },
   contentClass: { type: String, default: "" },
   element: { type: String, default: 'div' }, // New prop for element type
+  maxLength: { type: Number, default: null },
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/client/components/open/forms/components/FormEditorNavbar.vue
+++ b/client/components/open/forms/components/FormEditorNavbar.vue
@@ -46,6 +46,7 @@
         id="form-editor-title"
         v-model="form.title"
         element="h3"
+        :max-length="255"
         class="font-medium py-1 text-md w-48 text-neutral-500 truncate form-editor-title"
       />
       <UBadge

--- a/client/components/open/forms/components/form-components/FormErrorModal.vue
+++ b/client/components/open/forms/components/form-components/FormErrorModal.vue
@@ -14,12 +14,15 @@
           class="text-red-800 mb-3"
           v-text="validationErrorResponse.message"
         />
-        <ul class="list-disc list-inside text-red-700 space-y-1">
+        <ul
+          v-if="validationErrors.length > 0"
+          class="list-disc list-inside text-red-700 space-y-1"
+        >
           <li
-            v-for="(err, key) in validationErrorResponse.errors"
+            v-for="(err, key) in validationErrors"
             :key="key"
           >
-            {{ Array.isArray(err) ? err[0] : err }}
+            {{ err }}
           </li>
         </ul>
       </div>
@@ -46,6 +49,18 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close'])
+
+const validationErrors = computed(() => {
+  if (!props.validationErrorResponse?.errors) {
+    return []
+  }
+
+  const errors = Object.values(props.validationErrorResponse.errors).map((err) => {
+    return Array.isArray(err) ? err[0] : err
+  })
+
+  return errors.filter((err) => err !== props.validationErrorResponse.message)
+})
 
 // Modal state
 const isOpen = computed({

--- a/client/components/open/forms/components/form-components/FormInformation.vue
+++ b/client/components/open/forms/components/form-components/FormInformation.vue
@@ -16,6 +16,8 @@
         class="mt-4 max-w-xs"
         label="Form Name"
         placeholder="My form"
+        :max-char-limit="255"
+        :show-char-limit="true"
       />
       <select-input
         name="tags"


### PR DESCRIPTION
## Summary

This PR removes the rough 60-character form title limit and aligns form titles with the database-backed 255-character limit.

## What changed

- Form title validation now allows up to 255 characters.
- Titles longer than 255 characters are trimmed and truncated before validation so users are not blocked by a confusing 422 error.
- The editor title input and Settings > General form name field now use the 255-character limit.
- Form imports from Typeform, Fillout, Google Forms, and Tally now preserve titles up to 255 characters.
- The save error modal no longer repeats the same validation message twice.
- Added a regression test covering automatic truncation on form update.

## Why

A customer hit the previous 60-character limit and saw a duplicated validation error. The 60-character cap was a UX constraint, while the database can store 255 characters. Truncating at the storage boundary avoids unnecessary friction while keeping persistence safe.

## Validation

- `./vendor/bin/pest --filter="truncates form titles longer than the database limit when updating a form"`
- `npm run lint`