### PR TITLE
[codex] Fix negative logic on unanswered fields

### DIFF
--- a/api/app/Service/Forms/FormLogicConditionChecker.php
+++ b/api/app/Service/Forms/FormLogicConditionChecker.php
@@ -354,6 +354,23 @@ class FormLogicConditionChecker
             is_numeric($fieldValue);
     }
 
+    private function hasAnswerValue($fieldValue): bool
+    {
+        if ($fieldValue === null) {
+            return false;
+        }
+
+        if (is_string($fieldValue)) {
+            return $fieldValue !== '';
+        }
+
+        if (is_array($fieldValue)) {
+            return count($fieldValue) > 0;
+        }
+
+        return true;
+    }
+
     private function checkGreaterThan($condition, $fieldValue): bool
     {
         if (!$this->areValidNumbers($condition, $fieldValue)) {
@@ -692,11 +709,11 @@ class FormLogicConditionChecker
             case 'equals':
                 return $this->checkEquals($propertyCondition, $value);
             case 'does_not_equal':
-                return !$this->checkEquals($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkEquals($propertyCondition, $value);
             case 'contains':
                 return $this->checkContains($propertyCondition, $value);
             case 'does_not_contain':
-                return !$this->checkContains($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkContains($propertyCondition, $value);
             case 'starts_with':
                 return $this->checkStartsWith($propertyCondition, $value);
             case 'ends_with':
@@ -728,6 +745,9 @@ class FormLogicConditionChecker
                 }
             case 'does_not_match_regex':
                 try {
+                    if (!$this->hasAnswerValue($value)) {
+                        return false;
+                    }
                     if (!is_string($propertyCondition['value']) || !is_string($value)) {
                         return true;
                     }
@@ -750,7 +770,7 @@ class FormLogicConditionChecker
             case 'equals':
                 return $this->checkEquals($propertyCondition, $value);
             case 'does_not_equal':
-                return !$this->checkEquals($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkEquals($propertyCondition, $value);
             case 'greater_than':
                 return $this->checkGreaterThan($propertyCondition, $value);
             case 'less_than':
@@ -812,7 +832,7 @@ class FormLogicConditionChecker
             case 'equals':
                 return $this->checkEquals($propertyCondition, $value);
             case 'does_not_equal':
-                return !$this->checkEquals($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkEquals($propertyCondition, $value);
             case 'is_empty':
                 return $this->checkIsEmpty($propertyCondition, $value);
             case 'is_not_empty':
@@ -876,7 +896,7 @@ class FormLogicConditionChecker
             case 'contains':
                 return $this->checkListContains($propertyCondition, $value);
             case 'does_not_contain':
-                return !$this->checkListContains($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkListContains($propertyCondition, $value);
             case 'is_empty':
                 return $this->checkIsEmpty($propertyCondition, $value);
             case 'is_not_empty':
@@ -908,11 +928,11 @@ class FormLogicConditionChecker
             case 'equals':
                 return $this->checkMatrixEquals($propertyCondition, $value);
             case 'does_not_equal':
-                return !$this->checkMatrixEquals($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkMatrixEquals($propertyCondition, $value);
             case 'contains':
                 return $this->checkMatrixContains($propertyCondition, $value);
             case 'does_not_contain':
-                return !$this->checkMatrixContains($propertyCondition, $value);
+                return $this->hasAnswerValue($value) && !$this->checkMatrixContains($propertyCondition, $value);
             case 'exists_in_submissions':
                 return $this->checkExistsInSubmissions($propertyCondition, $value);
             case 'does_not_exist_in_submissions':

--- a/api/tests/Unit/Service/Forms/FormLogicConditionCheckerTest.php
+++ b/api/tests/Unit/Service/Forms/FormLogicConditionCheckerTest.php
@@ -335,6 +335,48 @@ describe('FormLogicConditionChecker', function () {
         });
     });
 
+    describe('unanswered negative value comparisons', function () {
+        $condition = fn (string $type, string $operator, mixed $value, string $fieldId = 'field') => [
+            'value' => [
+                'property_meta' => [
+                    'id' => $fieldId,
+                    'type' => $type,
+                ],
+                'operator' => $operator,
+                'value' => $value,
+            ],
+        ];
+
+        it('does not satisfy negative value comparisons when the referenced field is unanswered', function (string $type, string $operator, mixed $value) use ($condition) {
+            expect(FormLogicConditionChecker::conditionsMet($condition($type, $operator, $value), []))
+                ->toBeFalse();
+        })->with([
+            'text does_not_equal' => ['text', 'does_not_equal', 'blocked'],
+            'text does_not_contain' => ['text', 'does_not_contain', 'blocked'],
+            'text does_not_match_regex' => ['text', 'does_not_match_regex', '^blocked$'],
+            'text content_length_does_not_equal' => ['text', 'content_length_does_not_equal', 7],
+            'number does_not_equal' => ['number', 'does_not_equal', 42],
+            'select does_not_equal' => ['select', 'does_not_equal', 'blocked'],
+            'multi_select does_not_contain' => ['multi_select', 'does_not_contain', 'blocked'],
+            'matrix does_not_equal' => ['matrix', 'does_not_equal', ['row1' => 'blocked']],
+            'matrix does_not_contain' => ['matrix', 'does_not_contain', ['row1' => 'blocked']],
+        ]);
+
+        it('does not satisfy a mixed positive and negative AND group before every referenced field is answered', function () use ($condition) {
+            $conditions = [
+                'operatorIdentifier' => 'and',
+                'children' => [
+                    $condition('text', 'equals', 'yes', 'answered_field'),
+                    $condition('text', 'does_not_equal', 'blocked', 'unanswered_field'),
+                ],
+            ];
+
+            expect(FormLogicConditionChecker::conditionsMet($conditions, [
+                'answered_field' => 'yes',
+            ]))->toBeFalse();
+        });
+    });
+
     describe('date conditions', function () {
         it('handles date comparison operators correctly', function () {
             $condition = [
@@ -477,9 +519,9 @@ describe('FormLogicConditionChecker', function () {
             $formData = ['matrix_field' => ['row2' => 'col2']];
             expect(FormLogicConditionChecker::conditionsMet($condition, $formData))->toBeTrue();
 
-            // User has no data for matrix field
+            // User has no data for matrix field, so value comparisons should not match yet
             $formData = ['matrix_field' => []];
-            expect(FormLogicConditionChecker::conditionsMet($condition, $formData))->toBeTrue();
+            expect(FormLogicConditionChecker::conditionsMet($condition, $formData))->toBeFalse();
         });
 
         it('handles missing rows in field value for contains operator', function () {

--- a/client/lib/forms/FormLogicConditionChecker.js
+++ b/client/lib/forms/FormLogicConditionChecker.js
@@ -147,9 +147,11 @@ function computedConditionMet(propertyCondition, value) {
           safeParseFloat(value) !== null &&
           parseFloat(propertyCondition.value) === parseFloat(value)
       case "does_not_equal":
-        return safeParseFloat(propertyCondition.value) === null ||
+        return hasAnswerValue(value) && (
+          safeParseFloat(propertyCondition.value) === null ||
           safeParseFloat(value) === null ||
           parseFloat(propertyCondition.value) !== parseFloat(value)
+        )
       default:
         return numberConditionMet(propertyCondition, value)
     }
@@ -170,6 +172,14 @@ function areValidNumbers(condition, fieldValue) {
   const conditionValue = safeParseFloat(condition.value)
   const parsedFieldValue = safeParseFloat(fieldValue)
   return conditionValue !== null && parsedFieldValue !== null
+}
+
+function hasAnswerValue(fieldValue) {
+  if (fieldValue === undefined || fieldValue === null) return false
+  if (typeof fieldValue === 'string') return fieldValue.length > 0
+  if (Array.isArray(fieldValue)) return fieldValue.length > 0
+  if (typeof fieldValue === 'object') return Object.keys(fieldValue).length > 0
+  return true
 }
 
 function checkEquals(condition, fieldValue) {
@@ -409,11 +419,11 @@ function textConditionMet(propertyCondition, value) {
     case "equals":
       return checkEquals(propertyCondition, value)
     case "does_not_equal":
-      return !checkEquals(propertyCondition, value)
+      return hasAnswerValue(value) && !checkEquals(propertyCondition, value)
     case "contains":
       return checkContains(propertyCondition, value)
     case "does_not_contain":
-      return !checkContains(propertyCondition, value)
+      return hasAnswerValue(value) && !checkContains(propertyCondition, value)
     case "starts_with":
       return checkStartsWith(propertyCondition, value)
     case "ends_with":
@@ -444,6 +454,7 @@ function textConditionMet(propertyCondition, value) {
       }
     case 'does_not_match_regex':
       try {
+        if (!hasAnswerValue(value)) return false
         if (typeof propertyCondition.value !== 'string' || typeof value !== 'string') return true
         const regex2 = new RegExp(propertyCondition.value)
         return !regex2.test(value)
@@ -459,7 +470,7 @@ function numberConditionMet(propertyCondition, value) {
     case "equals":
       return checkEquals(propertyCondition, value)
     case "does_not_equal":
-      return !checkEquals(propertyCondition, value)
+      return hasAnswerValue(value) && !checkEquals(propertyCondition, value)
     case "greater_than":
       return checkGreaterThan(propertyCondition, value)
     case "less_than":
@@ -508,7 +519,7 @@ function selectConditionMet(propertyCondition, value) {
     case "equals":
       return checkEquals(propertyCondition, value)
     case "does_not_equal":
-      return !checkEquals(propertyCondition, value)
+      return hasAnswerValue(value) && !checkEquals(propertyCondition, value)
     case "is_empty":
       return checkIsEmpty(propertyCondition, value)
     case "is_not_empty":
@@ -560,7 +571,7 @@ function multiSelectConditionMet(propertyCondition, value) {
     case "contains":
       return checkListContains(propertyCondition, value)
     case "does_not_contain":
-      return !checkListContains(propertyCondition, value)
+      return hasAnswerValue(value) && !checkListContains(propertyCondition, value)
     case "is_empty":
       return checkIsEmpty(propertyCondition, value)
     case "is_not_empty":
@@ -584,11 +595,11 @@ function matrixConditionMet(propertyCondition, value) {
     case "equals":
       return checkObjectEquals(propertyCondition, value)
     case "does_not_equal":
-      return !checkObjectEquals(propertyCondition, value)
+      return hasAnswerValue(value) && !checkObjectEquals(propertyCondition, value)
     case "contains":
      return checkMatrixContains(propertyCondition, value)
     case "does_not_contain":
-     return !checkMatrixContains(propertyCondition, value)
+     return hasAnswerValue(value) && !checkMatrixContains(propertyCondition, value)
   }
   return false
 }

--- a/client/test/unit/FormLogicConditionChecker.test.ts
+++ b/client/test/unit/FormLogicConditionChecker.test.ts
@@ -57,6 +57,47 @@ describe('FormLogicConditionChecker computed variables', () => {
   })
 })
 
+describe('FormLogicConditionChecker unanswered negative value comparisons', () => {
+  const condition = (type: string, operator: string, value: unknown, fieldId = 'field') => ({
+    value: {
+      operator,
+      value,
+      property_meta: {
+        id: fieldId,
+        type
+      }
+    }
+  })
+
+  it.each([
+    ['text does_not_equal', condition('text', 'does_not_equal', 'blocked')],
+    ['text does_not_contain', condition('text', 'does_not_contain', 'blocked')],
+    ['text does_not_match_regex', condition('text', 'does_not_match_regex', '^blocked$')],
+    ['text content_length_does_not_equal', condition('text', 'content_length_does_not_equal', 7)],
+    ['number does_not_equal', condition('number', 'does_not_equal', 42)],
+    ['select does_not_equal', condition('select', 'does_not_equal', 'blocked')],
+    ['multi_select does_not_contain', condition('multi_select', 'does_not_contain', 'blocked')],
+    ['matrix does_not_equal', condition('matrix', 'does_not_equal', { row1: 'blocked' })],
+    ['matrix does_not_contain', condition('matrix', 'does_not_contain', { row1: 'blocked' })]
+  ])('does not satisfy %s when the referenced field is unanswered', (_name, conditions) => {
+    expect(conditionsMet(conditions, {})).toBe(false)
+  })
+
+  it('does not satisfy a mixed positive and negative AND group before every referenced field is answered', () => {
+    const conditions = {
+      operatorIdentifier: 'and',
+      children: [
+        condition('text', 'equals', 'yes', 'answered_field'),
+        condition('text', 'does_not_equal', 'blocked', 'unanswered_field')
+      ]
+    }
+
+    expect(conditionsMet(conditions, {
+      answered_field: 'yes'
+    })).toBe(false)
+  })
+})
+
 describe('FormLogicConditionChecker mention values', () => {
   const mentionHtml = (fieldId: string, fieldName: string, fallback = '') => {
     return `<span mention="true" mention-field-id="${fieldId}" mention-field-name="${fieldName}" mention-fallback="${fallback}">@${fieldName}</span>`


### PR DESCRIPTION
## Summary

Fixes form logic negative value comparisons so unanswered fields no longer satisfy `does_not_equal`, `does_not_contain`, `does_not_match_regex`, or equivalent select/multi-select/matrix comparisons.

Refs #1169.

## Root cause

The frontend and backend condition checkers implemented negative value operators as bare inverses of their positive checks. When a referenced field had not been answered yet, the positive check returned false, so the negative check returned true and could prematurely satisfy mixed AND groups.

## Changes

- Add an answered-value guard before negative value comparisons in the Nuxt form logic checker.
- Mirror the same guard in the Laravel form logic checker.
- Add frontend and backend regression tests for unanswered negative operators and mixed positive/negative AND groups.
- Update the existing backend matrix-empty expectation so empty matrix values do not match value comparisons before an answer exists.

## Validation

- `npm run test -- --run test/unit/FormLogicConditionChecker.test.ts`
- `npm run lint`
- `php vendor/bin/pest tests/Unit/Service/Forms/FormLogicConditionCheckerTest.php`
- `php vendor/bin/pint --test app/Service/Forms/FormLogicConditionChecker.php tests/Unit/Service/Forms/FormLogicConditionCheckerTest.php`

Note: backend Pest run passes with existing warning/deprecation output unrelated to this change.