### PR TITLE
[codex] Fix summary date format and rating averages

### DIFF
--- a/api/app/Service/Forms/FormSummaryService.php
+++ b/api/app/Service/Forms/FormSummaryService.php
@@ -162,13 +162,21 @@ class FormSummaryService
     private function accumulateValue(array &$acc, mixed $value, array $property, int $submissionId): void
     {
         $summaryType = $this->getSummaryType($property['type'] ?? '');
-        $acc['answered']++;
 
         try {
+            if ($summaryType === 'rating') {
+                if ($this->accumulateRating($acc, $value, $property)) {
+                    $acc['answered']++;
+                }
+
+                return;
+            }
+
+            $acc['answered']++;
+
             match ($summaryType) {
                 'distribution' => $this->accumulateDistribution($acc, $value),
                 'numeric_stats' => $this->accumulateNumeric($acc, $value),
-                'rating' => $this->accumulateRating($acc, $value),
                 'boolean' => $this->accumulateBoolean($acc, $value),
                 'text_list' => $this->accumulateText($acc, $value, $submissionId),
                 'date_summary' => $this->accumulateDate($acc, $value),
@@ -211,15 +219,25 @@ class FormSummaryService
         }
     }
 
-    private function accumulateRating(array &$acc, mixed $value): void
+    private function accumulateRating(array &$acc, mixed $value, array $property): bool
     {
         $numericValue = $this->extractNumericValue($value);
 
-        if ($numericValue !== null) {
-            $rating = (int) round($numericValue);
-            $acc['values'][] = $numericValue;
-            $acc['distribution'][$rating] = ($acc['distribution'][$rating] ?? 0) + 1;
+        if ($numericValue === null) {
+            return false;
         }
+
+        $maxRating = (int) ($property['rating_max_value'] ?? 5);
+        $rating = (int) round($numericValue);
+
+        if ($rating < 1 || $rating > $maxRating) {
+            return false;
+        }
+
+        $acc['values'][] = $numericValue;
+        $acc['distribution'][$rating] = ($acc['distribution'][$rating] ?? 0) + 1;
+
+        return true;
     }
 
     private function accumulateBoolean(array &$acc, mixed $value): void

--- a/api/tests/Feature/Forms/FormSummaryTest.php
+++ b/api/tests/Feature/Forms/FormSummaryTest.php
@@ -239,6 +239,33 @@ describe('Form Summary', function () {
             ->and($ratingField['data']['distribution'][1])->toBe(1);
     });
 
+    it('excludes skipped rating values from averages and answered count', function () {
+        $ratingProperty = collect($this->form->properties)->firstWhere('name', 'Rating');
+
+        $this->form->submissions()->createMany([
+            ['data' => [$ratingProperty['id'] => 5], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [$ratingProperty['id'] => 5], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [$ratingProperty['id'] => 4], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [$ratingProperty['id'] => 3], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [$ratingProperty['id'] => 1], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [$ratingProperty['id'] => 0], 'status' => FormSubmission::STATUS_COMPLETED],
+            ['data' => [], 'status' => FormSubmission::STATUS_COMPLETED],
+        ]);
+
+        $response = $this->getJson(route('open.workspaces.form.summary', [$this->workspace, $this->form]))
+            ->assertSuccessful();
+
+        $fields = collect($response->json('fields'));
+        $ratingField = $fields->firstWhere('type', 'rating');
+
+        expect($ratingField['answered_count'])->toBe(5)
+            ->and($ratingField['total_submissions'])->toBe(7)
+            ->and($ratingField['data']['average'])->toBe(3.6)
+            ->and($ratingField['data']['count'])->toBe(5)
+            ->and($ratingField['data']['distribution'][5])->toBe(2)
+            ->and($ratingField['data']['distribution'][1])->toBe(1);
+    });
+
     it('tracks answered count per field', function () {
         $nameProperty = collect($this->form->properties)->firstWhere('name', 'Name');
         $numberProperty = collect($this->form->properties)->firstWhere('name', 'Number');

--- a/client/components/open/forms/components/FormSummary.vue
+++ b/client/components/open/forms/components/FormSummary.vue
@@ -20,6 +20,7 @@
             wrapper-class="mb-0"
             :date-range="true"
             :disable-future-dates="true"
+            :date-format="localDateFormat"
             class="!mb-0 w-full sm:w-auto"
           />
         </div>
@@ -169,6 +170,32 @@ const statusOptions = [
   { value: 'partial', name: 'Partial' },
 ]
 
+const localDateFormat = computed(() => {
+  if (!import.meta.client || typeof Intl === 'undefined') {
+    return 'dd/MM/yyyy'
+  }
+
+  const parts = new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(2026, 10, 22))
+
+  const order = parts
+    .filter((part) => ['day', 'month', 'year'].includes(part.type))
+    .map((part) => part.type)
+
+  if (order[0] === 'month') {
+    return 'MM/dd/yyyy'
+  }
+
+  if (order[0] === 'year') {
+    return 'yyyy/MM/dd'
+  }
+
+  return 'dd/MM/yyyy'
+})
+
 const dateFrom = computed(() => filterForm.date_range?.[0] || null)
 const dateTo = computed(() => filterForm.date_range?.[1] || null)
 const status = computed(() => filterForm.status || 'completed')
@@ -204,4 +231,3 @@ const limitationDescription = computed(() => {
   return `Your form has ${total} total submissions. For performance, the summary is calculated from the most recent entries.`
 })
 </script>
-


### PR DESCRIPTION
## Summary
- adapt the Summary tab date range display to the browser locale
- ignore invalid/cleared rating values like 0 when computing Summary averages and answered counts
- add coverage for skipped rating values in form summary tests

## Why
Rating inputs clear to 0, but the Summary tab was treating those cleared values as real ratings. That lowered average ratings and inflated answered counts. The Summary tab date range also always used day-first formatting, which was confusing for US users.

## Validation
- npm run lint (client) passed in the main checkout after applying the patch
- ./vendor/bin/pest tests/Feature/Forms/FormSummaryTest.php passed in the main checkout after applying the patch
- php -l api/app/Service/Forms/FormSummaryService.php passed in the clean PR worktree
- php -l api/tests/Feature/Forms/FormSummaryTest.php passed in the clean PR worktree

Note: the clean PR worktree does not include ignored dependencies (api/vendor and client/node_modules), so full Pest/lint commands were run from the dependency-ready checkout before creating this clean branch.