### PR TITLE
[codex] Add public self-hosted license checkout

### DIFF
--- a/client/components/pages/pricing/MonthlyYearlySelector.vue
+++ b/client/components/pages/pricing/MonthlyYearlySelector.vue
@@ -26,7 +26,10 @@
       </button>
     </div>
 
-    <div class="absolute top-1/2 left-full ml-1.5 hidden -translate-y-1/2 sm:block">
+    <div
+      v-if="showSavingsBadge"
+      class="absolute top-1/2 left-full ml-1.5 hidden -translate-y-1/2 sm:block"
+    >
       <div
         class="inline-flex items-center whitespace-nowrap rounded-[7px] bg-purple-50 px-2 py-1 pr-2.5 text-xs font-medium text-purple-600"
       >
@@ -39,6 +42,7 @@
 <script setup>
 defineProps({
   modelValue: { type: Boolean, required: true },
+  showSavingsBadge: { type: Boolean, default: true },
 })
 const emit = defineEmits(['update:modelValue'])
 

--- a/client/pages/pricing.vue
+++ b/client/pages/pricing.vue
@@ -562,8 +562,9 @@
           <p
             class="mt-4 text-base font-normal tracking-[-1.1%] leading-7 text-gray-600"
           >
-            The self-hosted commercial licenses are the same price as hosted
-            plans.
+            Self-host the core product for free. Upgrade to a self-hosted
+            Enterprise license when you need more users, advanced identity
+            controls, branding, and support.
           </p>
         </div>
 
@@ -605,8 +606,9 @@
                     size="lg"
                     variant="outline"
                     color="neutral"
-                    label="Request a quote"
-                    @click.prevent="contactUs"
+                    label="View self-hosting docs"
+                    href="https://docs.opnform.com/deployment/docker"
+                    target="_blank"
                     class="px-4 py-2.5 rounded-[12px] text-base leading-7 tracking-[-1.1%] font-medium"
                   />
                 </div>
@@ -674,11 +676,20 @@
                 <div class="mt-6">
                   <UButton
                     size="lg"
-                    variant="outline"
-                    color="neutral"
-                    label="Request a quote"
-                    @click.prevent="contactUs"
+                    label="Buy license"
+                    :to="{ name: 'self-hosted-license' }"
                     class="px-4 py-2.5 rounded-[12px] text-base leading-7 tracking-[-1.1%] font-medium"
+                  />
+                  <p class="mt-3 text-sm leading-5 tracking-[-0.6%] font-medium text-gray-600">
+                    Self-service checkout. License key delivered by email.
+                  </p>
+                  <UButton
+                    size="sm"
+                    variant="link"
+                    color="neutral"
+                    label="Need invoice or procurement?"
+                    class="mt-1 p-0 text-sm font-medium"
+                    @click.prevent="contactUs"
                   />
                 </div>
               </div>
@@ -821,8 +832,9 @@ const communityEditionFeatures = [
   "Unlimited forms & submissions",
   "File uploads, logic, computed fields",
   "Pre-fills, URL parameters",
-  "Multi-user access allowed (all admins, no roles)",
-  "Unlimited workspaces",
+  "Up to 2 users across the instance",
+  "Core workspace management",
+  "OIDC SSO within the 2-user limit",
   "Branding required",
   "Community support",
 ]

--- a/client/pages/self-hosted/license.vue
+++ b/client/pages/self-hosted/license.vue
@@ -1,0 +1,254 @@
+<template>
+  <div>
+    <section class="bg-white">
+      <div class="relative">
+        <div class="relative z-2 mx-auto max-w-5xl px-8 py-14 text-center sm:py-24 lg:px-12">
+          <UBadge
+            color="primary"
+            variant="subtle"
+            class="mb-5"
+          >
+            Self-hosted Enterprise
+          </UBadge>
+          <h1 class="text-4xl font-semibold tracking-[-1%] text-neutral-950 sm:text-[56px] sm:leading-16">
+            Buy a self-hosted license
+          </h1>
+          <p class="mx-auto mt-4 max-w-2xl text-lg font-normal leading-7 tracking-[-1.5%] text-neutral-600 sm:text-xl sm:leading-8">
+            Unlock Enterprise features for your self-hosted OpnForm instance.
+            Checkout is handled by Stripe and your license key is delivered by email.
+          </p>
+        </div>
+        <div class="pointer-events-none absolute inset-0 h-full w-full bg-linear-to-b from-white from-20% via-blue-50 via-50% to-white to-80%" />
+      </div>
+
+      <div class="px-8 pb-16 lg:px-12">
+        <div class="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[1fr_420px]">
+          <div class="rounded-3xl border border-neutral-200 bg-white p-6 shadow-sm sm:p-8">
+            <h2 class="text-2xl font-semibold tracking-[-1%] text-neutral-950">
+              What is included
+            </h2>
+            <p class="mt-3 text-base font-medium leading-7 tracking-[-1.1%] text-neutral-600">
+              Self-hosted Enterprise is for teams that want to run OpnForm on
+              their own infrastructure while unlocking advanced workspace,
+              identity, and governance controls.
+            </p>
+
+            <div class="mt-8 grid gap-4 sm:grid-cols-2">
+              <div
+                v-for="feature in licenseFeatures"
+                :key="feature.title"
+                class="rounded-2xl border border-neutral-200 bg-neutral-50/60 p-4"
+              >
+                <Icon
+                  :name="feature.icon"
+                  class="h-5 w-5 text-blue-600"
+                />
+                <h3 class="mt-3 text-base font-semibold text-neutral-950">
+                  {{ feature.title }}
+                </h3>
+                <p class="mt-1 text-sm leading-6 text-neutral-600">
+                  {{ feature.description }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="rounded-3xl border border-blue-200 bg-white p-6 shadow-[0_18px_50px_rgba(59,130,246,0.12)] sm:p-8">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="text-2xl font-semibold tracking-[-1%] text-neutral-950">
+                  Enterprise License
+                </h2>
+                <p class="mt-2 text-sm leading-6 text-neutral-600">
+                  One license per self-hosted instance.
+                </p>
+              </div>
+              <Icon
+                name="heroicons:shield-check-20-solid"
+                class="h-7 w-7 shrink-0 text-blue-600"
+              />
+            </div>
+
+            <div class="mt-6">
+              <MonthlyYearlySelector
+                v-model="isYearly"
+                :show-savings-badge="false"
+              />
+            </div>
+
+            <div class="mt-8">
+              <p class="flex items-end gap-2">
+                <span class="text-4xl font-semibold tracking-[-1%] text-neutral-950">
+                  ${{ monthlyDisplayPrice }}
+                </span>
+                <span class="pb-1 text-base font-medium leading-7 text-neutral-600">
+                  /mo
+                </span>
+              </p>
+              <p class="mt-2 text-sm leading-6 text-neutral-500">
+                {{ billingSummary }}
+              </p>
+            </div>
+
+            <form
+              class="mt-8 space-y-4"
+              @submit.prevent="startCheckout"
+            >
+              <TextInput
+                name="billingEmail"
+                :form="checkoutForm"
+                label="Billing email"
+                native-type="email"
+                autocomplete="email"
+                placeholder="you@company.com"
+                :required="true"
+              />
+
+              <UAlert
+                v-if="errorMessage"
+                color="error"
+                variant="subtle"
+                icon="i-heroicons-exclamation-triangle"
+                :description="errorMessage"
+              />
+
+              <UButton
+                type="submit"
+                block
+                size="lg"
+                icon="i-heroicons-credit-card"
+                :loading="isLoading"
+                :disabled="!checkoutForm.billingEmail || isLoading"
+                class="h-12 rounded-2xl font-semibold"
+              >
+                Continue to Stripe
+              </UButton>
+            </form>
+
+            <div class="mt-6 rounded-2xl bg-neutral-50 p-4 text-sm leading-6 text-neutral-600">
+              Already bought a license? Open your self-hosted instance, go to
+              <strong>User Settings</strong>, then activate it from the
+              <strong>License</strong> tab.
+            </div>
+
+            <UButton
+              variant="link"
+              color="neutral"
+              class="mt-4 p-0 font-medium"
+              @click.prevent="contactUs"
+            >
+              Need invoice or procurement help?
+            </UButton>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <OpenFormFooter :show-cta="false" />
+  </div>
+</template>
+
+<script setup>
+import MonthlyYearlySelector from "~/components/pages/pricing/MonthlyYearlySelector.vue"
+
+definePageMeta({
+  layout: "default",
+  middleware: ["self-hosted"],
+})
+
+useOpnSeoMeta({
+  title: "Self-hosted Enterprise License",
+  description: "Buy a self-hosted OpnForm Enterprise license with self-service Stripe checkout.",
+})
+
+const alert = useAlert()
+const { tiers } = usePlanCatalog()
+const { getPlanPrice } = useBillingUpsell()
+
+const isYearly = ref(true)
+const isLoading = ref(false)
+const errorMessage = ref("")
+const checkoutForm = useForm({
+  billingEmail: "",
+})
+
+const yearlyPrice = computed(() => tiers.value.self_hosted?.price_yearly ?? 1999)
+const monthlyPrice = computed(() => tiers.value.self_hosted?.price_monthly ?? 199)
+const monthlyDisplayPrice = computed(() => {
+  const catalogPrice = getPlanPrice("self_hosted", isYearly.value)
+  if (catalogPrice !== null && catalogPrice !== undefined) return catalogPrice
+
+  return isYearly.value ? Math.round(yearlyPrice.value / 12) : monthlyPrice.value
+})
+const formatUsd = (amount) => new Intl.NumberFormat("en-US").format(amount)
+const billingSummary = computed(() => {
+  if (isYearly.value) {
+    return `Billed yearly at $${formatUsd(yearlyPrice.value)}/year.`
+  }
+
+  return `Billed monthly at $${formatUsd(monthlyPrice.value)}/month.`
+})
+
+const licenseFeatures = [
+  {
+    icon: "heroicons:users",
+    title: "More than 2 users",
+    description: "Add the team members your self-hosted instance needs.",
+  },
+  {
+    icon: "heroicons:shield-check",
+    title: "Enterprise SSO",
+    description: "Unlock SAML and LDAP controls for centralized access.",
+  },
+  {
+    icon: "heroicons:paint-brush",
+    title: "Branding controls",
+    description: "Remove OpnForm branding and use advanced workspace branding.",
+  },
+  {
+    icon: "heroicons:document-text",
+    title: "Audit and governance",
+    description: "Use licensed controls for compliance-oriented teams.",
+  },
+  {
+    icon: "heroicons:envelope",
+    title: "Workspace SMTP",
+    description: "Configure dedicated SMTP settings for individual workspaces.",
+  },
+  {
+    icon: "heroicons:chat-bubble-left-right",
+    title: "Priority support",
+    description: "Get help for your self-hosted Enterprise deployment.",
+  },
+]
+
+function startCheckout() {
+  if (!checkoutForm.billingEmail || isLoading.value) return
+
+  isLoading.value = true
+  errorMessage.value = ""
+  const cloudApiUrl = useRuntimeConfig().public.licenseApiEndpoint
+
+  $fetch(`${cloudApiUrl}/licenses/create`, {
+    method: "POST",
+    body: {
+      billingEmail: checkoutForm.billingEmail,
+      plan: "self_hosted",
+      period: isYearly.value ? "yearly" : "monthly",
+    },
+  }).then((response) => {
+    window.location.href = response.checkoutUrl
+  }).catch((error) => {
+    errorMessage.value = error?.data?.error
+      || error?.data?.message
+      || "Failed to start checkout. Please try again."
+    alert.error(errorMessage.value)
+  }).finally(() => {
+    isLoading.value = false
+  })
+}
+
+function contactUs() {
+  useCrisp().openAndShowChat()
+}
+</script>

--- a/client/sitemap.js
+++ b/client/sitemap.js
@@ -2,8 +2,18 @@ import templateIndustries from './data/forms/templates/industries.json'
 import templateTypes from './data/forms/templates/types.json'
 import opnformConfig from './opnform.config.js'
 
+const isSelfHostedBuild = process.env.SELF_HOSTED === 'true'
+  || process.env.NUXT_PUBLIC_SELF_HOSTED === 'true'
+  || process.env.NUXT_PUBLIC_API_BASE === '/api'
+
 export default {
-  exclude: ['/subscriptions/**', '/templates/my-templates', '/setup'],
+  exclude: [
+    '/subscriptions/**',
+    '/templates/my-templates',
+    '/setup',
+    '/self-hosted/checkout/**',
+    ...(isSelfHostedBuild ? ['/self-hosted/license'] : []),
+  ],
   sources: [`${process.env.NUXT_PUBLIC_API_BASE}sitemap-urls`],
   cacheMaxAgeSeconds: 60 * 60 * 2, // 2 hours
   xslColumns: [
@@ -16,9 +26,22 @@ export default {
     return [
       ...getTemplateIndustriesUrls(),
       ...getTemplateTypesUrls(),
+      ...getCloudMarketingUrls(),
       ...(await getIntegrationsPages().catch(() => [])),
     ]
   }
+}
+
+function getCloudMarketingUrls () {
+  if (isSelfHostedBuild) return []
+
+  return [
+    {
+      url: '/self-hosted/license',
+      changefreq: 'monthly',
+      priority: 0.7
+    }
+  ]
 }
 
 function getTemplateTypesUrls () {


### PR DESCRIPTION
## Summary

Adds a public self-service checkout page for self-hosted Enterprise licenses and updates the pricing page copy/CTAs so the self-hosted license is no longer presented as a quote-only flow.

## What changed

- Added `/self-hosted/license` as a cloud-facing public purchase page.
- The new page collects a billing email, supports monthly/yearly selection, and redirects to Stripe through the existing `/licenses/create` cloud license endpoint.
- Updated the pricing page self-hosted section:
  - Community points users to self-hosting docs.
  - Enterprise points users to the new self-service license page.
  - Community wording now reflects the 2-user self-hosted limit.
- Added a `showSavingsBadge` prop to the pricing period selector so the savings badge can be hidden in narrow card layouts.
- Updated sitemap behavior so `/self-hosted/license` is included for cloud marketing builds and checkout result pages are excluded.

## Why

The public pricing page showed “Request a quote” for self-hosted Enterprise even though license purchase is self-service. This made the licensing path look sales-led and created mismatch with the in-app self-hosted purchase flow.

## Validation

- `cd client && npm run lint`
- Manually verified locally:
  - `/pricing` shows the new self-hosted CTAs and corrected Community copy.
  - `/self-hosted/license` renders the purchase page, monthly/yearly selector, email field, yearly price, and hidden savings badge in the card layout.
  - Checkout button remains disabled until a billing email is entered.

## Notes

This PR intentionally excludes unrelated local FormSummary/API changes that were present in the working tree.