### PR TITLE
Fix editable submission identifiers

### DIFF
--- a/api/app/Http/Controllers/Forms/PublicFormController.php
+++ b/api/app/Http/Controllers/Forms/PublicFormController.php
@@ -18,7 +18,6 @@ use App\Service\WorkspaceHelper;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
-use Vinkla\Hashids\Facades\Hashids;
 use Illuminate\Support\Str;
 
 class PublicFormController extends Controller
@@ -194,9 +193,7 @@ class PublicFormController extends Controller
     /**
      * Processes submission identifiers to ensure consistent format
      *
-     * Handles both UUID (new format) and Hashid (legacy format) in submission_id field.
-     * For UUID: Looks up submission and converts to numeric ID if found
-     * For Hashid: Decodes to numeric ID
+     * Handles UUID submission identifiers and converts them to internal numeric IDs.
      *
      * @param Request $request
      * @param array $submissionData
@@ -235,39 +232,23 @@ class PublicFormController extends Controller
             return $canPartialSubmit && $submission?->status === FormSubmission::STATUS_PARTIAL;
         };
 
-        // Check if it's a UUID (new format)
-        if (Str::isUuid($submissionIdentifier)) {
-            $submission = $form->submissions()
-                ->where('public_id', $submissionIdentifier)
-                ->first();
-            if (!$submission) {
-                abort(404, 'Submission not found');
-            }
-            if (!$canUseResolvedSubmission($submission)) {
-                unset($submissionData['submission_id'], $submissionData['submission_hash']);
+        if (!Str::isUuid($submissionIdentifier)) {
+            abort(404, 'Submission not found');
+        }
 
-                return $submissionData;
-            }
-            $submissionData['submission_id'] = $submission->id;
-            unset($submissionData['submission_hash']);
+        $submission = $form->submissions()
+            ->where('public_id', $submissionIdentifier)
+            ->first();
+        if (!$submission) {
+            abort(404, 'Submission not found');
+        }
+        if (!$canUseResolvedSubmission($submission)) {
+            unset($submissionData['submission_id'], $submissionData['submission_hash']);
+
             return $submissionData;
         }
-
-        // Legacy Hashid support (backward compatibility)
-        unset($submissionData['submission_id'], $submissionData['submission_hash']);
-        $decodedId = Hashids::decode($submissionIdentifier);
-        if (!empty($decodedId)) {
-            $numericId = (int)($decodedId[0] ?? null);
-            if ($numericId) {
-                $submission = $form->submissions()->find($numericId);
-                if ($submission && $submission->public_id) {
-                    abort(404, 'Submission not found');
-                }
-                if ($canUseResolvedSubmission($submission)) {
-                    $submissionData['submission_id'] = $numericId;
-                }
-            }
-        }
+        $submissionData['submission_id'] = $submission->id;
+        unset($submissionData['submission_hash']);
 
         return $submissionData;
     }
@@ -282,30 +263,15 @@ class PublicFormController extends Controller
             abort(403);
         }
 
-        $submission = null;
-
-        // Try UUID lookup first (new format)
-        if (Str::isUuid($submission_id)) {
-            $submission = $form->submissions()
-                ->where('public_id', $submission_id)
-                ->first();
+        if (!Str::isUuid($submission_id)) {
+            return $this->error([
+                'message' => 'Submission not found.',
+            ], 404);
         }
 
-        // Fallback to Hashid decode (backward compatibility - strict migration)
-        if (!$submission) {
-            $decodedId = Hashids::decode($submission_id);
-            $numericId = !empty($decodedId) ? (int)($decodedId[0]) : false;
-            if ($numericId) {
-                $submission = $form->submissions()->find($numericId);
-
-                // CRITICAL: If submission has UUID, return 404 (force UUID usage)
-                if ($submission && $submission->public_id) {
-                    return $this->error([
-                        'message' => 'Submission not found.'
-                    ], 404);
-                }
-            }
-        }
+        $submission = $form->submissions()
+            ->where('public_id', $submission_id)
+            ->first();
 
         if (!$submission) {
             return $this->error([

--- a/api/app/Service/Forms/SubmissionUrlService.php
+++ b/api/app/Service/Forms/SubmissionUrlService.php
@@ -5,25 +5,32 @@ namespace App\Service\Forms;
 use App\Models\Forms\Form;
 use App\Models\Forms\FormSubmission;
 use Illuminate\Support\Str;
-use Vinkla\Hashids\Facades\Hashids;
 
 class SubmissionUrlService
 {
     /**
-     * Get the submission identifier (UUID or Hashid) for a submission.
-     * Returns UUID if available, otherwise falls back to Hashid.
+     * Get the public submission identifier for a submission.
      *
      * @param FormSubmission $submission
      * @return string
      */
     public static function getSubmissionIdentifier(FormSubmission $submission): string
     {
-        return $submission->public_id ?? Hashids::encode($submission->id);
+        if (!$submission->public_id) {
+            $publicId = Str::uuid()->toString();
+            $updated = FormSubmission::query()
+                ->whereKey($submission->id)
+                ->whereNull('public_id')
+                ->update(['public_id' => $publicId]);
+
+            $submission->public_id = $updated ? $publicId : $submission->refresh()->public_id;
+        }
+
+        return $submission->public_id;
     }
 
     /**
      * Get the submission identifier by submission ID.
-     * Fetches the submission and returns UUID if available, otherwise Hashid.
      *
      * @param Form $form
      * @param int $submissionId
@@ -34,42 +41,28 @@ class SubmissionUrlService
         $submission = $form->submissions()->find($submissionId);
 
         if (!$submission) {
-            // Fallback to Hashid if submission not found (shouldn't happen in normal flow)
-            return Hashids::encode($submissionId);
+            abort(404, 'Submission not found');
         }
 
         return self::getSubmissionIdentifier($submission);
     }
 
     /**
-     * Resolve a submission from its identifier (UUID or Hashid).
+     * Resolve a submission from its public UUID identifier.
      *
      * @param Form $form
-     * @param string $identifier UUID or Hashid
+     * @param string $identifier UUID
      * @return FormSubmission|null
      */
     public static function resolveSubmission(Form $form, string $identifier): ?FormSubmission
     {
-        // Try UUID lookup first (new format)
-        if (Str::isUuid($identifier)) {
-            return $form->submissions()
-                ->where('public_id', $identifier)
-                ->first();
+        if (!Str::isUuid($identifier)) {
+            return null;
         }
 
-        // Fallback to Hashid decode (backward compatibility)
-        $decodedId = Hashids::decode($identifier);
-        $numericId = !empty($decodedId) ? (int)($decodedId[0]) : false;
-
-        if ($numericId) {
-            $submission = $form->submissions()->find($numericId);
-
-            if ($submission && $submission->form_id === $form->id) {
-                return $submission;
-            }
-        }
-
-        return null;
+        return $form->submissions()
+            ->where('public_id', $identifier)
+            ->first();
     }
 
     /**

--- a/api/database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
+++ b/api/database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('form_submissions')
+            ->whereNull('public_id')
+            ->chunkById(1000, function ($submissions) {
+                foreach ($submissions as $submission) {
+                    DB::table('form_submissions')
+                        ->where('id', $submission->id)
+                        ->whereNull('public_id')
+                        ->update([
+                            'public_id' => Str::uuid()->toString(),
+                        ]);
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/api/tests/Feature/Forms/SubmissionIdentifierTest.php
+++ b/api/tests/Feature/Forms/SubmissionIdentifierTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Forms\FormSubmission;
+use App\Service\Forms\SubmissionUrlService;
 use Illuminate\Support\Str;
 use Vinkla\Hashids\Facades\Hashids;
 
@@ -107,16 +108,16 @@ describe('Submission UUID Identifiers', function () {
 
         $this->actingAsGuest();
         $this->postJson(route('forms.answer', $this->form), $editData)
-            ->assertSuccessful();
+            ->assertStatus(404);
 
-        expect($this->form->submissions()->count())->toBe(2);
+        expect($this->form->submissions()->count())->toBe(1);
 
         $submission->refresh();
         expect($submission->data[$nameField['id']])->toBe('ORIGINAL_DATA');
     });
 });
 
-describe('Legacy Hashid Backward Compatibility', function () {
+describe('Legacy Hashid Rejection', function () {
     beforeEach(function () {
         $this->user = $this->actingAsBusinessUser();
         $this->workspace = $this->createUserWorkspace($this->user);
@@ -125,7 +126,7 @@ describe('Legacy Hashid Backward Compatibility', function () {
         ]);
     });
 
-    it('allows fetching legacy submission without UUID using hashid', function () {
+    it('rejects fetching legacy submission without UUID using hashid', function () {
         // Create a legacy submission (without UUID)
         $submission = new FormSubmission();
         $submission->form_id = $this->form->id;
@@ -139,7 +140,7 @@ describe('Legacy Hashid Backward Compatibility', function () {
         $this->getJson(route('forms.fetchSubmission', [
             'form' => $this->form->slug,
             'submission_id' => $hashid,
-        ]))->assertSuccessful();
+        ]))->assertStatus(404);
     });
 
     it('rejects hashid access when submission has UUID', function () {
@@ -176,7 +177,7 @@ describe('Legacy Hashid Backward Compatibility', function () {
             ->assertStatus(404);
     });
 
-    it('allows hashid update for legacy submission without UUID', function () {
+    it('rejects hashid update for legacy submission without UUID', function () {
         $submission = new FormSubmission();
         $submission->form_id = $this->form->id;
         $submission->data = ['test' => 'data'];
@@ -189,7 +190,20 @@ describe('Legacy Hashid Backward Compatibility', function () {
         $editData['submission_id'] = $hashid;
 
         $this->postJson(route('forms.answer', $this->form), $editData)
-            ->assertSuccessful();
+            ->assertStatus(404);
+    });
+
+    it('generates a UUID identifier for legacy submissions when building edit links', function () {
+        $submission = new FormSubmission();
+        $submission->form_id = $this->form->id;
+        $submission->data = ['test' => 'data'];
+        $submission->public_id = null;
+        $submission->save();
+
+        $identifier = SubmissionUrlService::getSubmissionIdentifier($submission);
+
+        expect(Str::isUuid($identifier))->toBeTrue();
+        expect($submission->refresh()->public_id)->toBe($identifier);
     });
 
     it('returns 404 for invalid hashid', function () {
@@ -300,7 +314,7 @@ describe('Submission update blocked when editable submissions disabled', functio
         expect($submission->data)->toBe($originalData);
     });
 
-    it('does not update completed legacy submission when only partial submissions are enabled', function () {
+    it('rejects non-UUID submission identifier when only partial submissions are enabled', function () {
         $user = $this->actingAsBusinessUser();
         $workspace = $this->createUserWorkspace($user);
         $form = $this->createForm($user, $workspace, [
@@ -322,9 +336,9 @@ describe('Submission update blocked when editable submissions disabled', functio
         $editData['submission_id'] = $hashid;
 
         $this->postJson(route('forms.answer', $form), $editData)
-            ->assertSuccessful();
+            ->assertStatus(404);
 
-        expect($form->submissions()->count())->toBe(2);
+        expect($form->submissions()->count())->toBe(1);
         $submission->refresh();
         expect($submission->status)->toBe(FormSubmission::STATUS_COMPLETED);
         expect($submission->data)->toBe($originalData);

--- a/api/tests/Feature/Submissions/PartialSubmissionTest.php
+++ b/api/tests/Feature/Submissions/PartialSubmissionTest.php
@@ -4,7 +4,7 @@ use App\Models\Forms\FormSubmission;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
-it('can submit form partially and complete it later using submission hash', function () {
+it('can submit form partially and complete it later using submission identifier', function () {
     $user = $this->actingAsBusinessUser();
     $workspace = $this->createUserWorkspace($user);
     $form = $this->createForm($user, $workspace, [
@@ -76,7 +76,7 @@ it('can update partial submission multiple times', function () {
     expect($submission->data[array_key_first($secondData)])->toBe('Second Draft');
 });
 
-it('does not update a partial submission from a raw numeric submission id', function () {
+it('rejects a partial submission update from a raw numeric submission id', function () {
     $user = $this->actingAsBusinessUser();
     $workspace = $this->createUserWorkspace($user);
     $form = $this->createForm($user, $workspace, [
@@ -103,15 +103,15 @@ it('does not update a partial submission from a raw numeric submission id', func
     $attackData['submission_id'] = (string) $victimSubmission->id;
 
     $this->postJson(route('forms.answer', $form->slug), $attackData)
-        ->assertSuccessful();
+        ->assertStatus(404);
 
-    expect($form->submissions()->count())->toBe(2);
+    expect($form->submissions()->count())->toBe(1);
 
     $victimSubmission->refresh();
     expect($victimSubmission->data[$nameField['id']])->toBe('VICTIM_CONFIDENTIAL_DATA');
 });
 
-it('does not update a completed submission from a raw numeric submission id in a partial request', function () {
+it('rejects a completed submission update from a raw numeric submission id in a partial request', function () {
     $user = $this->actingAsBusinessUser();
     $workspace = $this->createUserWorkspace($user);
     $form = $this->createForm($user, $workspace, [
@@ -137,9 +137,9 @@ it('does not update a completed submission from a raw numeric submission id in a
     $attackData['submission_id'] = (string) $completedSubmission->id;
 
     $this->postJson(route('forms.answer', $form->slug), $attackData)
-        ->assertSuccessful();
+        ->assertStatus(404);
 
-    expect($form->submissions()->count())->toBe(2);
+    expect($form->submissions()->count())->toBe(1);
 
     $completedSubmission->refresh();
     expect($completedSubmission->status)->toBe(FormSubmission::STATUS_COMPLETED);

--- a/client/components/open/forms/OpenCompleteForm.vue
+++ b/client/components/open/forms/OpenCompleteForm.vue
@@ -168,7 +168,7 @@ const workingFormStore = useWorkingFormStore()
 const { data: user } = useAuth().user()
 const passwordForm = useForm({ password: null })
 // Removed unused hidePasswordDisabledMsg (was always false and unused)
-// submission_id can be UUID (new secure format) or Hashid (legacy format)
+// submission_id is a public UUID identifier
 const submissionId = ref(route.query.submission_id || null)
 const submittedData = ref(null)
 const showFirstSubmissionModal = ref(false)

--- a/client/lib/forms/composables/useFormInitialization.js
+++ b/client/lib/forms/composables/useFormInitialization.js
@@ -209,8 +209,7 @@ export function useFormInitialization(formConfig, form, pendingSubmission) {
 
   /**
    * Attempts to load form data from an existing submission.
-   * Supports both UUID (new format) and Hashid (legacy format) identifiers.
-   * @param {String} submissionId - UUID or Hashid of the submission to load
+   * @param {String} submissionId - UUID of the submission to load
    * @returns {Promise<Boolean>} - Whether loading was successful
    */
   const tryLoadFromSubmissionId = async (submissionId) => {
@@ -289,4 +288,4 @@ export function useFormInitialization(formConfig, form, pendingSubmission) {
     applyDefaultValues,
     resetAndFill // Export our wrapped function for use elsewhere
   }
-} 
+}

--- a/client/lib/forms/composables/useFormSubmission.js
+++ b/client/lib/forms/composables/useFormSubmission.js
@@ -30,7 +30,6 @@ export function useFormSubmission(formConfig, form) {
     }
     
     // Add submission ID if provided (for editable submissions)
-    // Supports both UUID (new secure format) and Hashid (legacy format)
     if (options.submissionId) {
       metadata.submission_id = options.submissionId
     }
@@ -44,8 +43,8 @@ export function useFormSubmission(formConfig, form) {
    * @param {Object} options.formModeStrategy - The strategy object.
    * @param {Number} [options.completionTime] - Form completion time in seconds.
    * @param {String} [options.captchaToken] - Captcha verification token.
-   * @param {String} [options.submissionHash] - Hash for partial submissions.
-   * @param {String} [options.submissionId] - UUID or Hashid for editable submissions.
+   * @param {String} [options.submissionHash] - UUID identifier for partial submissions.
+   * @param {String} [options.submissionId] - UUID identifier for editable submissions.
    * @returns {Promise<Object>} The response data from the submission endpoint.
    * @throws {Error} If submission fails.
    */
@@ -91,4 +90,4 @@ export function useFormSubmission(formConfig, form) {
   return {
     submit,
   }
-} 
+}


### PR DESCRIPTION
## What

- Backfill `form_submissions.public_id` for legacy submissions that still have a null public identifier.
- Stop resolving editable submission identifiers through legacy Hashids fallbacks.
- Keep editable submission links UUID-only and lazily assign a UUID when building a link for a legacy submission.
- Update backend tests to assert that raw ids / Hashids are rejected for fetch, edit, and partial submissions.
- Update frontend comments/JSDoc to describe submission identifiers as UUIDs.

## Why

Editable submission links previously accepted predictable Hashids derived from sequential database ids when `public_id` was null. That made legacy editable submissions guessable. The intended compatibility layer became the vulnerable surface, so this PR removes that fallback and migrates old rows forward to UUID identifiers.

This intentionally invalidates old Hashid-based edit links. Existing UUID-based links remain valid, and legacy rows receive UUIDs through the backfill migration.

## Checks

- `git diff --check`
- `php -l` on touched PHP files
- `./vendor/bin/pint --test ...`
- `npm run lint` in `client/`
- Targeted Pest: `./vendor/bin/pest tests/Feature/Forms/SubmissionIdentifierTest.php tests/Feature/Submissions/PartialSubmissionTest.php tests/Feature/Forms/FormUpdateTest.php tests/Feature/Forms/FormSubmissionProcessorTest.php tests/Feature/Integrations/Pdf/PdfGenerateTest.php` -> 63 passed
- Full Pest: `php -d memory_limit=1G ./vendor/bin/pest --compact` -> 1692 passed, 3 skipped, 1 warning, 2 deprecated