### PR TITLE
[codex] Backport comparison demos to main

### DIFF
--- a/client/components/pages/comparisons/ComparisonPage.vue
+++ b/client/components/pages/comparisons/ComparisonPage.vue
@@ -103,15 +103,14 @@
           <h2
             class="text-4xl sm:text-5xl sm:leading-14 font-semibold tracking-[-1%] text-gray-950"
           >
-            Free Plan Comparison:
-            <br />
-            OpnForm vs {{ competitorName }}
+            {{ resolvedPlanComparisonTitleLines[0] }}
+            <br v-if="resolvedPlanComparisonTitleLines.length > 1" />
+            {{ resolvedPlanComparisonTitleLines[1] }}
           </h2>
           <p
             class="mt-4 text-base tracking-[-1.1%] font-medium leading-8 text-gray-600"
           >
-            With OpnForm, you get everything {{ competitorName }} offers — and
-            more — without limits.
+            {{ resolvedPlanComparisonSubtitle }}
           </p>
         </div>
 
@@ -133,8 +132,20 @@
                       OpnForm
                     </span>
                   </div>
-                  <div class="text-right text-sm font-medium leading-5 text-gray-700">
-                    {{ row.cells[0] }}
+                  <div class="flex justify-end text-right text-sm font-medium leading-5 text-gray-700">
+                    <UIcon
+                      v-if="isYesCell(row.cells[0])"
+                      name="i-heroicons-check"
+                      class="h-5 w-5 text-green-500"
+                    />
+                    <UIcon
+                      v-else-if="isNoCell(row.cells[0])"
+                      name="i-heroicons-x-mark"
+                      class="h-5 w-5 text-red-500"
+                    />
+                    <span v-else>
+                      {{ row.cells[0] }}
+                    </span>
                   </div>
                 </div>
                 <div class="flex items-start justify-between gap-4 px-5 py-4">
@@ -148,8 +159,20 @@
                       {{ competitorName }}
                     </span>
                   </div>
-                  <div class="text-right text-sm font-medium leading-5 text-gray-700">
-                    {{ row.cells[1] }}
+                  <div class="flex justify-end text-right text-sm font-medium leading-5 text-gray-700">
+                    <UIcon
+                      v-if="isYesCell(row.cells[1])"
+                      name="i-heroicons-check"
+                      class="h-5 w-5 text-green-500"
+                    />
+                    <UIcon
+                      v-else-if="isNoCell(row.cells[1])"
+                      name="i-heroicons-x-mark"
+                      class="h-5 w-5 text-red-500"
+                    />
+                    <span v-else>
+                      {{ row.cells[1] }}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -179,7 +202,7 @@
                     OpnForm
                     <span
                       class="ml-3 text-gray-600 text-base leading-8 tracking-[-1.1%] font-medium"
-                      >(Free)</span
+                      >({{ opnformPlanLabel }})</span
                     >
                   </div>
                 </div>
@@ -189,7 +212,21 @@
                   class="px-6 py-4 text-base leading-8 tracking-[-1.1%] font-medium text-gray-950"
                   :class="idx % 2 === 0 ? 'bg-gray-50' : 'bg-white'"
                 >
-                  {{ row.cells[0] }}
+                  <div class="flex items-center justify-start gap-2">
+                    <UIcon
+                      v-if="isYesCell(row.cells[0])"
+                      name="i-heroicons-check"
+                      class="h-6 w-6 text-green-500"
+                    />
+                    <UIcon
+                      v-else-if="isNoCell(row.cells[0])"
+                      name="i-heroicons-x-mark"
+                      class="h-6 w-6 text-red-500"
+                    />
+                    <span v-else>
+                      {{ row.cells[0] }}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -201,7 +238,7 @@
                   {{ competitorName }}
                   <span
                     class="ml-3 text-gray-600 text-base leading-8 tracking-[-1.1%] font-medium"
-                    >(Free)</span
+                    >({{ competitorPlanLabel }})</span
                   >
                 </div>
               </div>
@@ -211,7 +248,21 @@
                 class="px-6 py-4 text-base leading-8 tracking-[-1.1%] font-medium text-gray-600 rounded-r-[12px]"
                 :class="idx % 2 === 0 ? 'bg-gray-50' : 'bg-white'"
               >
-                {{ row.cells[1] }}
+                <div class="flex items-center justify-start gap-2">
+                  <UIcon
+                    v-if="isYesCell(row.cells[1])"
+                    name="i-heroicons-check"
+                    class="h-6 w-6 text-green-500"
+                  />
+                  <UIcon
+                    v-else-if="isNoCell(row.cells[1])"
+                    name="i-heroicons-x-mark"
+                    class="h-6 w-6 text-red-500"
+                  />
+                  <span v-else>
+                    {{ row.cells[1] }}
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -309,12 +360,12 @@
                   </div>
                   <div class="flex justify-end text-right text-sm font-medium leading-5 text-gray-700">
                     <UIcon
-                      v-if="row.cells[0] === 'Y'"
+                      v-if="isYesCell(row.cells[0])"
                       name="i-heroicons-check"
                       class="h-5 w-5 text-green-500"
                     />
                     <UIcon
-                      v-else-if="row.cells[0] === 'N'"
+                      v-else-if="isNoCell(row.cells[0])"
                       name="i-heroicons-x-mark"
                       class="h-5 w-5 text-red-500"
                     />
@@ -336,12 +387,12 @@
                   </div>
                   <div class="flex justify-end text-right text-sm font-medium leading-5 text-gray-700">
                     <UIcon
-                      v-if="row.cells[1] === 'Y'"
+                      v-if="isYesCell(row.cells[1])"
                       name="i-heroicons-check"
                       class="h-5 w-5 text-green-500"
                     />
                     <UIcon
-                      v-else-if="row.cells[1] === 'N'"
+                      v-else-if="isNoCell(row.cells[1])"
                       name="i-heroicons-x-mark"
                       class="h-5 w-5 text-red-500"
                     />
@@ -407,12 +458,12 @@
                   <td class="px-8 py-4 text-center border-l border-gray-200">
                     <div class="flex items-center justify-center gap-2">
                       <UIcon
-                        v-if="row.cells[0] === 'Y'"
+                        v-if="isYesCell(row.cells[0])"
                         name="i-heroicons-check"
                         class="h-6 w-6 text-green-500"
                       />
                       <UIcon
-                        v-else-if="row.cells[0] === 'N'"
+                        v-else-if="isNoCell(row.cells[0])"
                         name="i-heroicons-x-mark"
                         class="h-6 w-6 text-red-500"
                       />
@@ -428,12 +479,12 @@
                   <td class="px-8 py-4 text-center border-l border-neutral-200">
                     <div class="flex items-center justify-center gap-2">
                       <UIcon
-                        v-if="row.cells[1] === 'Y'"
+                        v-if="isYesCell(row.cells[1])"
                         name="i-heroicons-check"
                         class="h-6 w-6 text-green-500"
                       />
                       <UIcon
-                        v-else-if="row.cells[1] === 'N'"
+                        v-else-if="isNoCell(row.cells[1])"
                         name="i-heroicons-x-mark"
                         class="h-6 w-6 text-red-500"
                       />
@@ -686,6 +737,22 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  opnformPlanLabel: {
+    type: String,
+    default: "Free",
+  },
+  competitorPlanLabel: {
+    type: String,
+    default: "Free",
+  },
+  planComparisonTitle: {
+    type: String,
+    default: null,
+  },
+  planComparisonSubtitle: {
+    type: String,
+    default: null,
+  },
   featureSectionSubtitle: {
     type: String,
     default:
@@ -706,13 +773,29 @@ const props = defineProps({
   getCompetitorPrice: {
     type: Function,
     default: null,
-  }
+  },
 })
 
 const { isAuthenticated: authenticated } = useIsAuthenticated()
 
 const switchSectionTitle = computed(
   () => `Why Users Switch from ${props.competitorName} to OpnForm`,
+)
+
+const resolvedPlanComparisonTitle = computed(
+  () =>
+    props.planComparisonTitle ??
+    `Free Plan Comparison:\nOpnForm vs ${props.competitorName}`,
+)
+
+const resolvedPlanComparisonTitleLines = computed(() =>
+  resolvedPlanComparisonTitle.value.split("\n"),
+)
+
+const resolvedPlanComparisonSubtitle = computed(
+  () =>
+    props.planComparisonSubtitle ??
+    `With OpnForm, you get everything ${props.competitorName} offers — and more — without limits.`,
 )
 
 const resolvedHeroSecondaryCtaLabel = computed(
@@ -780,6 +863,14 @@ const privacyFeatures = [
 const displayCompetitorPrice = computed(() => {
   return (props.getCompetitorPrice) ? true : false
 })
+
+function isYesCell(value) {
+  return value === "Y" || value === true
+}
+
+function isNoCell(value) {
+  return value === "N" || value === false
+}
 
 const submissionOptions = [
   100, 250, 500, 1000, 2500, 5000, 7500, 10000, 15000, 20000, 25000,

--- a/client/components/pages/welcome/LiveDemoForm.vue
+++ b/client/components/pages/welcome/LiveDemoForm.vue
@@ -4,10 +4,11 @@
     class="live-demo-form relative flex min-h-[460px] flex-col overflow-hidden bg-white sm:min-h-[620px]"
     :style="formStyle"
   >
-    <OpenFormFocused
+    <component
+      :is="formComponent"
       v-if="isFormReady"
       :form-manager="formManager"
-      class="grow"
+      class="grow overflow-y-auto"
       @submit="handleSubmit"
     >
       <template #after-submit>
@@ -52,7 +53,7 @@
           </div>
         </div>
       </template>
-    </OpenFormFocused>
+    </component>
   </div>
 </template>
 
@@ -60,6 +61,7 @@
 import { tailwindcssPaletteGenerator } from "~/lib/colors.js"
 import { useFormManager } from "~/lib/forms/composables/useFormManager"
 import { FormMode } from "~/lib/forms/FormModeStrategy.js"
+import OpenForm from "~/components/open/forms/OpenForm.vue"
 import OpenFormFocused from "~/components/open/forms/OpenFormFocused.vue"
 
 const props = defineProps({
@@ -80,6 +82,9 @@ const props = defineProps({
 const scenario = computed(() => props.scenario)
 const primaryCtaTo = computed(() => props.primaryCtaTo)
 const secondaryCtaTo = computed(() => props.secondaryCtaTo)
+const formComponent = computed(() =>
+  props.scenario.form.presentation_style === "focused" ? OpenFormFocused : OpenForm,
+)
 
 provide("formTheme", computed(() => props.scenario.form.theme || "default"))
 provide("formSize", computed(() => props.scenario.form.size || "lg"))
@@ -153,6 +158,10 @@ function restartDemo() {
 
 .live-demo-form :deep(.nf-text .text-block h2) {
   line-height: 1.22;
+}
+
+.live-demo-form :deep(.nf-text .text-block p:first-child strong) {
+  color: var(--form-color, #2563eb);
 }
 
 .live-demo-form :deep(.nf-text .text-block p) {

--- a/client/composables/useOpnSeoMeta.js
+++ b/client/composables/useOpnSeoMeta.js
@@ -1,30 +1,134 @@
 import { useSubdomainRedirect } from '~/composables/useSubdomainRedirect'
 
+const nonIndexablePathPatterns = [
+  /^\/admin(?:\/|$)/,
+  /^\/forms\/create(?:\/|$)/,
+  /^\/forms\/[^/]+\/(?:edit|pdf-editor|show)(?:\/|$)/,
+  /^\/home(?:\/|$)/,
+  /^\/login(?:\/|$)/,
+  /^\/password(?:\/|$)/,
+  /^\/redirect(?:\/|$)/,
+  /^\/register(?:\/|$)/,
+  /^\/self-hosted\/checkout(?:\/|$)/,
+  /^\/setup(?:\/|$)/,
+  /^\/subscriptions(?:\/|$)/,
+  /^\/templates\/my-templates(?:\/|$)/,
+]
+
 export const useOpnSeoMeta = (meta, alwaysEnabled = false) => {
   const { shouldRedirect } = useSubdomainRedirect()
+  const route = useRoute()
+  const canonicalBaseUrl = resolveCanonicalBaseUrl()
 
   if (!alwaysEnabled && shouldRedirect()) {
     return
   }
 
-  return useSeoMeta({
-    ...(meta.title
-      ? {
-          ogTitle: meta.title,
-          twitterTitle: meta.title,
-        }
-      : {}),
-    ...(meta.description
-      ? {
-          ogDescription: meta.description,
-          twitterDescription: meta.description,
-        }
-      : {}),
-    ...(meta.ogImage
-      ? {
-          twitterImage: meta.ogImage,
-        }
-      : {}),
-    ...meta,
+  const seoMeta = { ...meta }
+  delete seoMeta.canonical
+
+  useHead(() => {
+    const canonicalUrl = resolveCanonicalUrl(meta.canonical, route, canonicalBaseUrl)
+
+    return {
+      link: canonicalUrl
+        ? [
+            {
+              key: 'canonical',
+              rel: 'canonical',
+              href: canonicalUrl,
+            },
+          ]
+        : [],
+    }
   })
+
+  return useSeoMeta({
+    ...(seoMeta.title
+      ? {
+          ogTitle: seoMeta.title,
+          twitterTitle: seoMeta.title,
+        }
+      : {}),
+    ...(seoMeta.description
+      ? {
+          ogDescription: seoMeta.description,
+          twitterDescription: seoMeta.description,
+        }
+      : {}),
+    ...(seoMeta.ogImage
+      ? {
+          twitterImage: seoMeta.ogImage,
+        }
+      : {}),
+    ...seoMeta,
+    robots: () => resolveRobots(seoMeta.robots, route),
+  })
+}
+
+function resolveRobots (robots, route) {
+  const resolvedRobots = resolveMetaValue(robots)
+  if (resolvedRobots) {
+    return resolvedRobots
+  }
+
+  return isNonIndexablePath(route.path) ? 'noindex, nofollow' : null
+}
+
+function resolveCanonicalUrl (canonical, route, canonicalBaseUrl) {
+  const resolvedCanonical = resolveMetaValue(canonical)
+  if (resolvedCanonical === false) {
+    return null
+  }
+
+  if (typeof resolvedCanonical === 'string' && resolvedCanonical) {
+    return normalizeCanonicalUrl(resolvedCanonical, canonicalBaseUrl)
+  }
+
+  return joinCanonicalUrl(canonicalBaseUrl, route.path)
+}
+
+function resolveCanonicalBaseUrl () {
+  const configuredAppUrl = useRuntimeConfig().public.appUrl
+  if (configuredAppUrl && configuredAppUrl !== '/') {
+    return configuredAppUrl
+  }
+
+  if (import.meta.server) {
+    const event = useRequestEvent()
+    const forwardedHost = event?.node.req.headers['x-forwarded-host']
+    const host = forwardedHost || event?.node.req.headers.host
+    const protocol = event?.node.req.headers['x-forwarded-proto'] || 'https'
+
+    return host ? `${protocol}://${host}` : ''
+  }
+
+  return import.meta.client ? window.location.origin : ''
+}
+
+function normalizeCanonicalUrl (url, canonicalBaseUrl) {
+  if (/^https?:\/\//.test(url)) {
+    return url
+  }
+
+  return joinCanonicalUrl(canonicalBaseUrl, url)
+}
+
+function joinCanonicalUrl (baseUrl, path) {
+  if (!baseUrl) {
+    return null
+  }
+
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  const normalizedPath = path === '/' ? '/' : `/${path.replace(/^\/+|\/+$/g, '')}`
+
+  return `${normalizedBaseUrl}${normalizedPath}`
+}
+
+function isNonIndexablePath (path) {
+  return nonIndexablePathPatterns.some((pattern) => pattern.test(path))
+}
+
+function resolveMetaValue (value) {
+  return typeof value === 'function' ? value() : value
 }

--- a/client/data/live-demo-scenarios.js
+++ b/client/data/live-demo-scenarios.js
@@ -10,19 +10,19 @@ const LIVE_DEMO_MEDIA = {
   switch: "/img/live-demo/variants/logic-big-soft-blobs-v2.webp",
 }
 
-const scenarioGroups = {
-  typeform: ["typeform"],
-  googleForms: ["google forms", "googleforms"],
-  workflow: ["fillout", "jotform", "123formbuilder", "123 formbuilder", "form.io", "formio"],
-  simpleSwitch: ["tally", "youform", "heyform", "formbricks"],
-}
-
 function option(name, extra = {}) {
   return {
     id: name,
     name,
     ...extra,
   }
+}
+
+function competitorSlug(competitorName) {
+  return (competitorName || "current-tool")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
 }
 
 function withSlideMedia(field, media, layout = "right-split", extra = {}) {
@@ -159,6 +159,32 @@ function selectField(id, name, options, extra = {}) {
   }
 }
 
+function multiSelectField(id, name, options, extra = {}) {
+  return {
+    id,
+    type: "multi_select",
+    name,
+    required: true,
+    hidden: false,
+    placeholder: "Choose all that apply",
+    multi_select: {
+      options: options.map((item) => (typeof item === "string" ? option(item) : option(item.name, item))),
+    },
+    ...extra,
+  }
+}
+
+function checkboxField(id, name, extra = {}) {
+  return {
+    id,
+    type: "checkbox",
+    name,
+    required: false,
+    hidden: false,
+    ...extra,
+  }
+}
+
 function ratingField(id, name, extra = {}) {
   return {
     id,
@@ -167,6 +193,34 @@ function ratingField(id, name, extra = {}) {
     required: true,
     hidden: false,
     rating_max_value: 5,
+    ...extra,
+  }
+}
+
+function scaleField(id, name, extra = {}) {
+  return {
+    id,
+    type: "scale",
+    name,
+    required: true,
+    hidden: false,
+    scale_min_value: 1,
+    scale_max_value: 5,
+    scale_step_value: 1,
+    ...extra,
+  }
+}
+
+function sliderField(id, name, extra = {}) {
+  return {
+    id,
+    type: "slider",
+    name,
+    required: true,
+    hidden: false,
+    slider_min_value: 0,
+    slider_max_value: 100,
+    slider_step_value: 5,
     ...extra,
   }
 }
@@ -180,6 +234,45 @@ function textField(id, name, extra = {}) {
     hidden: false,
     placeholder: "Type your answer...",
     ...extra,
+  }
+}
+
+function pageBreak(id, extra = {}) {
+  return {
+    id,
+    type: "nf-page-break",
+    name: "Page Break",
+    required: false,
+    hidden: false,
+    next_btn_text: "Continue",
+    previous_btn_text: "Back",
+    ...extra,
+  }
+}
+
+function focusedSlides(properties, mediaSequence = ["intro", "fields", "select", "logic", "routing", "scale", "summary"]) {
+  return properties
+    .filter((field) => field.type !== "nf-page-break")
+    .map((field, index) => {
+      const focusedField = { ...field }
+      delete focusedField.width
+
+      if (focusedField.image) {
+        return focusedField
+      }
+
+      const media = mediaSequence[index % mediaSequence.length]
+      const layout = index % 2 === 0 ? "right-split" : "left-split"
+      return withSlideMedia(focusedField, media, layout)
+    })
+}
+
+function computedVariable(id, name, formula, resultType = "number") {
+  return {
+    id,
+    name,
+    formula,
+    result_type: resultType,
   }
 }
 
@@ -315,145 +408,874 @@ function buildHomeScenario() {
   })
 }
 
-function buildComparisonScenario(competitorName, importSource) {
+function buildMigrationFields(prefix, competitorName, importSource, media = "switch") {
   const hasImport = !!importSource
-  const importOption = "Yes, I would import it"
-  const importOptions = hasImport
-    ? [importOption, "No, I would start fresh", "I am just comparing"]
-    : ["No, I would start fresh", "I am just comparing", "Maybe later"]
+  const importOption = `Yes, import my ${competitorName} form`
+  const importFieldId = `${prefix}_import`
+  const fields = [
+    withSlideMedia(
+      selectField(importFieldId, "Would you bring an existing form with you?", hasImport
+        ? [importOption, "No, I would rebuild it", "I am just comparing"]
+        : ["No, I would rebuild it", "I am just comparing", "Maybe later"], {
+          help: hasImport
+            ? "Choose import to reveal a conditional URL field."
+            : "This keeps the demo focused on the switching workflow.",
+        }),
+      media,
+      "left-split",
+    ),
+  ]
 
+  if (hasImport) {
+    fields.push(
+      withSlideMedia(
+        urlField(`${prefix}_import_url`, `Paste a ${competitorName} form URL`, {
+          hidden: true,
+          placeholder: `https://${competitorSlug(competitorName).replaceAll("-", "")}.com/...`,
+          logic: showWhen(importFieldId, "select", "equals", importOption),
+          help: "This field appears only because you chose to import an existing form.",
+        }),
+        media,
+        "right-split",
+      ),
+    )
+  }
+
+  return { fields, hasImport, importOption, importFieldId }
+}
+
+function comparisonForm(key, competitorName, overrides = {}) {
+  return baseForm(`comparison-${key}`, {
+    title: `${competitorName} comparison demo`,
+    submit_button_text: "Submit demo response",
+    settings: {
+      auto_next: false,
+      navigation_arrows: false,
+    },
+    ...overrides,
+  })
+}
+
+function comparisonScenario(key, competitorName, importSource, overrides) {
+  return baseScenario(`comparison-${key}`, {
+    urlLabel: `opnform.com/vs-${competitorSlug(competitorName)}`,
+    secondaryCtaLabel: importSource ? `Import your ${competitorName} form` : null,
+    successTitle: "Demo response submitted.",
+    ...overrides,
+  })
+}
+
+function buildTypeformScenario(importSource) {
+  const competitorName = "Typeform"
+  const migration = buildMigrationFields("typeform", competitorName, importSource || "typeform")
+  const scoreFormula = `ROUND(({typeform_experience} + COUNT({typeform_controls}) + IF({${migration.importFieldId}} = "${migration.importOption}", 2, 0)) * 10)`
+  const properties = [
+    introSlide(
+      "typeform_intro",
+      '<span class="text-blue-500">Build a Typeform-style form in OpnForm.</span>',
+      "Answer a few plain questions. You will see the same one-question-at-a-time feel, plus routing and unlimited responses.",
+      "right-split",
+      "intro",
+    ),
+    withSlideMedia(
+      textField("typeform_name", "Who is filling this out?", {
+        prefill: "Jamie from Acme",
+        help: "A clean conversational opener keeps the Typeform feel.",
+      }),
+      "fields",
+      "left-split",
+    ),
+    withSlideMedia(
+      selectField("typeform_use_case", "What are you collecting?", [
+        "Inbound leads",
+        "Applications",
+        "Product feedback",
+        "Event registrations",
+      ], {
+        prefill: "Inbound leads",
+        help: "Single-choice qualification works well in focused mode.",
+      }),
+      "select",
+      "right-split",
+    ),
+    withSlideMedia(
+      ratingField("typeform_experience", "How polished should the form feel?", {
+        prefill: 5,
+        help: "A simple rating field.",
+      }),
+      "scale",
+      "left-split",
+    ),
+    withSlideMedia(
+      multiSelectField("typeform_controls", "What should happen after someone submits?", [
+        "Unlimited responses",
+        "Ask follow-up questions",
+        "Custom domain",
+        "Send data to a webhook",
+        "Export responses",
+      ], {
+        prefill: ["Unlimited responses", "Ask follow-up questions", "Send data to a webhook"],
+        min_selection: 1,
+        max_selection: 4,
+        help: "Pick the actions you would actually use.",
+      }),
+      "select",
+      "right-split",
+    ),
+    ...migration.fields,
+    withSlideMedia(
+      emailField("typeform_email", "Where should the qualified lead go?", {
+        hidden: true,
+        prefill: "sales@example.com",
+        logic: showWhen("typeform_use_case", "select", "equals", "Inbound leads"),
+        help: "Conditional routing appears because inbound leads were selected.",
+      }),
+      "routing",
+      "left-split",
+    ),
+    withSlideMedia(
+      textBlock(
+        "typeform_summary",
+        `<p><strong>Your demo form</strong></p><h2><span class="text-blue-500">A Typeform-style form, built in OpnForm.</span></h2><p>${mention("typeform_name", "Name", "Jamie")} wants to collect ${mention("typeform_use_case", "Use case", "inbound leads")} and then ${mention("typeform_controls", "Follow-up actions", "send responses to a webhook")}.</p>`,
+      ),
+      "summary",
+      "right-split",
+    ),
+  ]
+
+  const form = comparisonForm("typeform", competitorName, {
+    properties,
+    computed_variables: [
+      computedVariable("cv_typeform_fit", "Fit score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("typeform", competitorName, importSource || "typeform", {
+    title: "Try a Typeform-style flow in OpnForm.",
+    description: "A simple one-question-at-a-time form with choices, routing, and a personalized ending.",
+    highlights: ["Focused mode", "Plain questions", "Personalized ending"],
+    successBody: "That was a Typeform-style experience, but with OpnForm's routing and unlimited responses behind it.",
+    form,
+  })
+}
+
+function buildGoogleFormsScenario(importSource) {
+  const competitorName = "Google Forms"
+  const migration = buildMigrationFields("google_forms", competitorName, importSource || "google_forms")
+  const scoreFormula = `ROUND(({google_forms_depth} + COUNT({google_forms_outputs}) + IF({google_forms_access} = "Branded public form", 2, 0)) * 10)`
+  const properties = [
+    textBlock(
+      "google_forms_intro",
+      "<p><strong>Live demo</strong></p><h2>Make a Google Forms-style request form feel polished.</h2><p>Answer a few simple questions. OpnForm turns them into a clean form with follow-up actions.</p>",
+    ),
+    textField("google_forms_name", "Request owner", {
+      width: "1/2",
+      prefill: "Maya Chen",
+    }),
+    emailField("google_forms_email", "Team email", {
+      width: "1/2",
+      prefill: "maya@example.com",
+    }),
+    selectField("google_forms_access", "Who needs to fill it out?", [
+      "Internal team only",
+      "Branded public form",
+      "Customers and partners",
+    ], {
+      prefill: "Branded public form",
+    }),
+    pageBreak("google_forms_break_1", { next_btn_text: "Design workflow" }),
+    multiSelectField("google_forms_outputs", "What should happen after someone submits?", [
+      "Notify the right team",
+      "Send data to a webhook",
+      "Embed on a website",
+      "Export responses",
+      "Use a custom domain",
+    ], {
+      prefill: ["Notify the right team", "Embed on a website", "Export responses"],
+      min_selection: 1,
+    }),
+    scaleField("google_forms_depth", "How important is this form for your team?", {
+      prefill: 4,
+      help: "A simple 1-5 scale field.",
+    }),
+    textField("google_forms_brand_note", "What should feel more polished than a Google Form?", {
+      multi_lines: true,
+      prefill: "The form should match our site and route high-priority requests automatically.",
+      hidden: true,
+      logic: showWhen("google_forms_access", "select", "equals", "Branded public form"),
+    }),
+    ...migration.fields,
+    pageBreak("google_forms_break_2", { next_btn_text: "Review form" }),
+    textBlock(
+      "google_forms_summary",
+      `<p><strong>Your demo form</strong></p><h2><span class="text-blue-500">A cleaner request form than a basic Google Form.</span></h2><p>${mention("google_forms_name", "Request owner", "Maya")} needs a ${mention("google_forms_access", "Audience", "branded public form")} that can ${mention("google_forms_outputs", "Follow-up actions", "notify the team and export responses")}.</p>`,
+    ),
+  ]
+
+  const form = comparisonForm("google-forms", competitorName, {
+    show_progress_bar: true,
+    properties: focusedSlides(properties),
+    computed_variables: [
+      computedVariable("cv_google_forms_workflow", "Workflow score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("google-forms", competitorName, importSource || "google_forms", {
+    title: "Try a branded workflow beyond a basic Google Form.",
+    description: "A simple request form with clear choices, follow-up actions, and a personalized ending.",
+    highlights: ["Focused mode", "Clear choices", "Personalized ending"],
+    successBody: "That was a Google Forms-style request upgraded into a branded OpnForm form.",
+    form,
+  })
+}
+
+function buildTallyScenario(importSource) {
+  const competitorName = "Tally"
+  const migration = buildMigrationFields("tally", competitorName, importSource || "tally")
+  const scoreFormula = `ROUND(({tally_control} + COUNT({tally_needs}) + IF({tally_self_host} = TRUE, 2, 0)) * 10)`
+  const properties = [
+    introSlide(
+      "tally_intro",
+      '<span class="text-blue-500">Build a simple Tally-style form in OpnForm.</span>',
+      "Keep the form short. Add unlimited responses, embeds, and exports when the project grows.",
+      "right-split",
+      "intro",
+    ),
+    withSlideMedia(
+      textField("tally_project", "What are you building?", {
+        prefill: "A waitlist for our new product",
+      }),
+      "fields",
+      "left-split",
+    ),
+    withSlideMedia(
+      multiSelectField("tally_needs", "What needs to stay simple?", [
+        "Fast form creation",
+        "Clean embeds",
+        "Unlimited responses",
+        "Custom domain",
+        "Exportable data",
+      ], {
+        prefill: ["Fast form creation", "Clean embeds", "Unlimited responses"],
+        min_selection: 1,
+      }),
+      "select",
+      "right-split",
+    ),
+    withSlideMedia(
+      scaleField("tally_control", "How important is it to keep this form flexible?", {
+        prefill: 5,
+      }),
+      "scale",
+      "left-split",
+    ),
+    withSlideMedia(
+      checkboxField("tally_self_host", "I want the option to self-host later", {
+        prefill: true,
+        help: "A yes/no field can reveal different follow-up steps.",
+      }),
+      "routing",
+      "right-split",
+    ),
+    ...migration.fields,
+    withSlideMedia(
+      textBlock(
+        "tally_summary",
+        `<p><strong>Your demo form</strong></p><h2><span class="text-blue-500">A simple form with room to grow.</span></h2><p>${mention("tally_project", "Project", "A waitlist")} needs ${mention("tally_needs", "Needs", "fast creation, embeds, and unlimited responses")}.</p>`,
+      ),
+      "summary",
+      "right-split",
+    ),
+  ]
+
+  const form = comparisonForm("tally", competitorName, {
+    properties,
+    computed_variables: [
+      computedVariable("cv_tally_control", "Control score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("tally", competitorName, importSource || "tally", {
+    title: "Try a simple form with infrastructure control built in.",
+    description: "A short focused form for people who want speed now and more options later.",
+    highlights: ["Focused mode", "Simple choices", "Personalized ending"],
+    successBody: "That was a simple Tally-style flow with OpnForm controls ready when the project grows.",
+    form,
+  })
+}
+
+function buildJotformScenario(importSource) {
+  const competitorName = "Jotform"
+  const scoreFormula = "ROUND(({jotform_volume} * 0.5) + ({jotform_importance} * 8) + (COUNT({jotform_workflows}) * 4))"
+  const properties = [
+    textBlock(
+      "jotform_intro",
+      "<p><strong>Live demo</strong></p><h2>Build a scalable intake form without turning it into a maze.</h2><p>This focused flow shows the kind of client or operations intake teams often compare with Jotform.</p>",
+    ),
+    textField("jotform_company", "Company or client name", {
+      width: "1/2",
+      prefill: "Northstar Studio",
+    }),
+    emailField("jotform_contact", "Contact email", {
+      width: "1/2",
+      prefill: "ops@example.com",
+    }),
+    multiSelectField("jotform_workflows", "Which intake steps do you need?", [
+      "File upload",
+      "Approval routing",
+      "Conditional questions",
+      "Payment later",
+      "CRM handoff",
+    ], {
+      prefill: ["Approval routing", "Conditional questions", "CRM handoff"],
+      min_selection: 1,
+    }),
+    pageBreak("jotform_break_1", { next_btn_text: "Estimate volume" }),
+    sliderField("jotform_volume", "Expected monthly submissions", {
+      prefill: 70,
+      slider_step_value: 10,
+      help: "This slider contributes to the scale score.",
+    }),
+    scaleField("jotform_importance", "How painful are form limits as volume grows?", {
+      prefill: 5,
+    }),
+    textField("jotform_high_volume_note", "What breaks first when volume grows?", {
+      multi_lines: true,
+      prefill: "Manual routing and plan limits become the bottleneck.",
+      hidden: true,
+      logic: showWhen("jotform_volume", "slider", "greater_than_or_equal_to", 60),
+    }),
+    pageBreak("jotform_break_2", { next_btn_text: "Review score" }),
+    textBlock(
+      "jotform_summary",
+      `<p><strong>Scale score</strong></p><h2>${mention("cv_jotform_scale", "Scale score", "94")}/100</h2><p>${mention("jotform_company", "Company", "Northstar Studio")} expects ${mention("jotform_volume", "Monthly submissions", "70")} submissions and needs ${mention("jotform_workflows", "Workflow steps", "routing and CRM handoff")}.</p>`,
+    ),
+  ]
+
+  const form = comparisonForm("jotform", competitorName, {
+    show_progress_bar: true,
+    properties: focusedSlides(properties),
+    computed_variables: [
+      computedVariable("cv_jotform_scale", "Scale score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("jotform", competitorName, importSource, {
+    title: "Try a scalable intake form.",
+    description: "A focused client intake with multi-select workflow needs, sliders, conditional follow-up, and a scale score.",
+    highlights: ["Focused mode", "Slider input", "Scale score"],
+    successBody: "That was a Jotform-style intake workflow rebuilt around OpnForm's scaling story.",
+    form,
+  })
+}
+
+function buildFilloutScenario(importSource) {
+  const competitorName = "Fillout"
+  const scoreFormula = `ROUND(({fillout_data_control} * 12) + (COUNT({fillout_destinations}) * 5) + IF({fillout_control_priority} = "Keep response data easy to export", 20, 0))`
+  const properties = [
+    textBlock(
+      "fillout_intro",
+      "<p><strong>Live demo</strong></p><h2>Build a lead form that sends people to the right next step.</h2><p>This demo shows a simple workflow with routing, exports, webhooks, and open-source flexibility.</p>",
+    ),
+    selectField("fillout_control_priority", "What would you want more control over?", [
+      "Keep response data easy to export",
+      "Move submissions to my tools",
+      "Launch fast embeds first",
+    ], {
+      prefill: "Keep response data easy to export",
+    }),
+    multiSelectField("fillout_destinations", "Where should submissions go?", [
+      "Email notification",
+      "Webhook",
+      "CRM",
+      "Spreadsheet export",
+      "Internal dashboard",
+    ], {
+      prefill: ["Email notification", "Webhook", "Spreadsheet export"],
+      min_selection: 1,
+    }),
+    pageBreak("fillout_break_1", { next_btn_text: "Add control needs" }),
+    scaleField("fillout_data_control", "How important are easy export and routing?", {
+      prefill: 5,
+      help: "This shapes the recommendation shown at the end.",
+    }),
+    checkboxField("fillout_open_source", "I want an open-source fallback if this workflow grows", {
+      prefill: true,
+    }),
+    textField("fillout_control_note", "What should your team be able to change without rebuilding the form?", {
+      multi_lines: true,
+      prefill: "We want to adjust routing, exports, and copy without touching the rest of the workflow.",
+      hidden: true,
+      logic: showWhen("fillout_open_source", "checkbox", "is_checked"),
+    }),
+    pageBreak("fillout_break_2", { next_btn_text: "Review setup" }),
+    textBlock(
+      "fillout_summary",
+      `<p><strong>Recommended setup</strong></p><h2><span class="text-blue-500">Use routing, webhooks, and exports.</span></h2><p>You chose ${mention("fillout_control_priority", "Control priority", "easy export")} and ${mention("fillout_destinations", "Destinations", "webhook and exports")}. OpnForm can collect the lead, send it to the right place, and keep the data easy to export.</p>`,
+    ),
+  ]
+
+  const form = comparisonForm("fillout", competitorName, {
+    show_progress_bar: true,
+    properties: focusedSlides(properties),
+    computed_variables: [
+      computedVariable("cv_fillout_workflow_match", "Workflow match", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("fillout", competitorName, importSource, {
+    title: "Try a simple lead routing workflow.",
+    description: "A focused workflow form showing data destinations, export needs, conditional notes, and a concrete recommended setup.",
+    highlights: ["Focused mode", "Webhook routing", "Workflow match"],
+    successBody: "That was a simple lead workflow using OpnForm's routing, exports, and open-source flexibility.",
+    form,
+  })
+}
+
+function buildHeyformScenario(importSource) {
+  const competitorName = "HeyForm"
+  const scoreFormula = `ROUND(({heyform_conversation} + COUNT({heyform_needs}) + IF({heyform_followup} = "Trigger a workflow", 2, 0)) * 10)`
+  const properties = [
+    introSlide(
+      "heyform_intro",
+      '<span class="text-blue-500">Conversational forms with workflow depth.</span>',
+      "Try a friendly one-question-at-a-time form that adds routing, multi-select needs, and a readiness score.",
+      "right-split",
+      "intro",
+    ),
+    withSlideMedia(
+      selectField("heyform_goal", "What should this conversational form do?", [
+        "Collect leads",
+        "Run a survey",
+        "Qualify applicants",
+        "Handle support requests",
+      ], {
+        prefill: "Qualify applicants",
+      }),
+      "select",
+      "left-split",
+    ),
+    withSlideMedia(
+      ratingField("heyform_conversation", "How much does conversational UX matter?", {
+        prefill: 4,
+      }),
+      "scale",
+      "right-split",
+    ),
+    withSlideMedia(
+      multiSelectField("heyform_needs", "What should happen behind the form?", [
+        "Conditional questions",
+        "Email routing",
+        "Webhook",
+        "Custom branding",
+        "Unlimited submissions",
+      ], {
+        prefill: ["Conditional questions", "Email routing", "Unlimited submissions"],
+        min_selection: 1,
+      }),
+      "select",
+      "left-split",
+    ),
+    withSlideMedia(
+      selectField("heyform_followup", "What should happen to qualified responses?", [
+        "Trigger a workflow",
+        "Just store the response",
+        "Review manually",
+      ], {
+        prefill: "Trigger a workflow",
+      }),
+      "routing",
+      "right-split",
+    ),
+    withSlideMedia(
+      emailField("heyform_route_to", "Workflow owner email", {
+        hidden: true,
+        prefill: "hiring@example.com",
+        logic: showWhen("heyform_followup", "select", "equals", "Trigger a workflow"),
+      }),
+      "routing",
+      "left-split",
+    ),
+    withSlideMedia(
+      textBlock(
+        "heyform_summary",
+        `<p><strong>Readiness score</strong></p><h2><span class="text-blue-500">${mention("cv_heyform_readiness", "Readiness score", "90")}/100</span></h2><p>This ${mention("heyform_goal", "Goal", "applicant qualification")} form needs ${mention("heyform_needs", "Needs", "logic and routing")}.</p>`,
+      ),
+      "summary",
+      "right-split",
+    ),
+  ]
+
+  const form = comparisonForm("heyform", competitorName, {
+    properties,
+    computed_variables: [
+      computedVariable("cv_heyform_readiness", "Readiness score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("heyform", competitorName, importSource, {
+    title: "Try a conversational form with workflow depth.",
+    description: "A focused HeyForm-style flow with routing logic, multi-select workflow needs, and a readiness score.",
+    highlights: ["Focused mode", "Email routing", "Readiness score"],
+    successBody: "That was a HeyForm-style conversational flow with OpnForm workflow depth built in.",
+    form,
+  })
+}
+
+function buildYouformScenario(importSource) {
+  const competitorName = "Youform"
+  const scoreFormula = `ROUND(({youform_growth} + COUNT({youform_needs}) + IF({youform_limit} = "I need more control", 2, 0)) * 10)`
+  const properties = [
+    introSlide(
+      "youform_intro",
+      '<span class="text-blue-500">Simple form first, platform later.</span>',
+      "Try a lightweight form that starts simple and checks when a team needs more control, routing, and ownership.",
+      "right-split",
+      "intro",
+    ),
+    withSlideMedia(
+      textField("youform_project", "What is the form for?", {
+        prefill: "Newsletter sponsorship requests",
+      }),
+      "fields",
+      "left-split",
+    ),
+    withSlideMedia(
+      multiSelectField("youform_needs", "What do you need beyond a simple form?", [
+        "Unlimited responses",
+        "Conditional logic",
+        "Custom branding",
+        "Embeds",
+        "Exports",
+      ], {
+        prefill: ["Unlimited responses", "Conditional logic", "Embeds"],
+        min_selection: 1,
+      }),
+      "select",
+      "right-split",
+    ),
+    withSlideMedia(
+      scaleField("youform_growth", "How likely is this form to become a repeat workflow?", {
+        prefill: 4,
+      }),
+      "scale",
+      "left-split",
+    ),
+    withSlideMedia(
+      selectField("youform_limit", "What would make you switch from a simple-only tool?", [
+        "I need more control",
+        "I need more styling",
+        "I need more integrations",
+      ], {
+        prefill: "I need more control",
+      }),
+      "switch",
+      "right-split",
+    ),
+    withSlideMedia(
+      textBlock(
+        "youform_summary",
+        `<p><strong>Platform score</strong></p><h2><span class="text-blue-500">${mention("cv_youform_platform", "Platform score", "90")}/100</span></h2><p>${mention("youform_project", "Project", "Sponsorship requests")} needs ${mention("youform_needs", "Needs", "logic, embeds, and unlimited responses")}.</p>`,
+      ),
+      "summary",
+      "right-split",
+    ),
+  ]
+
+  const form = comparisonForm("youform", competitorName, {
+    properties,
+    computed_variables: [
+      computedVariable("cv_youform_platform", "Platform score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("youform", competitorName, importSource, {
+    title: "Try a simple form that can become a platform.",
+    description: "A focused lightweight form that shows when OpnForm's logic, embeds, and ownership become useful.",
+    highlights: ["Focused mode", "Multi-select", "Platform score"],
+    successBody: "That was a Youform-style simple flow with OpnForm's path to richer workflows.",
+    form,
+  })
+}
+
+function buildFormbricksScenario(importSource) {
+  const competitorName = "Formbricks"
+  const scoreFormula = `ROUND(({formbricks_need} + COUNT({formbricks_use_cases}) + IF({formbricks_scope} = "I need full forms too", 2, 0)) * 10)`
+  const properties = [
+    introSlide(
+      "formbricks_intro",
+      '<span class="text-blue-500">From feedback survey to full form workflow.</span>',
+      "Formbricks is strong for feedback. This OpnForm demo shows what happens when the job expands into applications, registrations, and lead capture.",
+      "right-split",
+      "intro",
+    ),
+    withSlideMedia(
+      selectField("formbricks_scope", "Are you collecting feedback only, or full form submissions?", [
+        "Feedback only",
+        "I need full forms too",
+        "Not sure yet",
+      ], {
+        prefill: "I need full forms too",
+      }),
+      "select",
+      "left-split",
+    ),
+    withSlideMedia(
+      multiSelectField("formbricks_use_cases", "Which form use cases are on the roadmap?", [
+        "Lead capture",
+        "Applications",
+        "Registrations",
+        "Customer intake",
+        "Embedded website forms",
+      ], {
+        prefill: ["Lead capture", "Applications", "Embedded website forms"],
+        min_selection: 1,
+      }),
+      "select",
+      "right-split",
+    ),
+    withSlideMedia(
+      scaleField("formbricks_need", "How important is a general-purpose form builder?", {
+        prefill: 5,
+      }),
+      "scale",
+      "left-split",
+    ),
+    withSlideMedia(
+      emailField("formbricks_owner", "Who owns non-survey responses?", {
+        hidden: true,
+        prefill: "growth@example.com",
+        logic: showWhen("formbricks_scope", "select", "equals", "I need full forms too"),
+      }),
+      "routing",
+      "right-split",
+    ),
+    withSlideMedia(
+      textBlock(
+        "formbricks_summary",
+        `<p><strong>Workflow score</strong></p><h2><span class="text-blue-500">${mention("cv_formbricks_workflow", "Workflow score", "100")}/100</span></h2><p>You selected ${mention("formbricks_use_cases", "Use cases", "lead capture and applications")}, so this is more than an in-app survey.</p>`,
+      ),
+      "summary",
+      "right-split",
+    ),
+  ]
+
+  const form = comparisonForm("formbricks", competitorName, {
+    properties,
+    computed_variables: [
+      computedVariable("cv_formbricks_workflow", "Workflow score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("formbricks", competitorName, importSource, {
+    title: "Try a general-purpose form, not just a survey.",
+    description: "A focused flow that contrasts feedback collection with broader OpnForm use cases and routing.",
+    highlights: ["Focused mode", "Use-case branching", "Workflow score"],
+    successBody: "That was an OpnForm workflow tailored to someone comparing Formbricks for more than surveys.",
+    form,
+  })
+}
+
+function buildFormioScenario(importSource) {
+  const competitorName = "Form.io"
+  const scoreFormula = `ROUND(({formio_dev_load} * 10) + (COUNT({formio_needs}) * 6) + IF({formio_backend} = "No, I want hosted forms first", 20, 0))`
+  const properties = [
+    textBlock(
+      "formio_intro",
+      "<p><strong>Live demo</strong></p><h2>Production intake without provisioning a form backend.</h2><p>This focused flow shows a developer-friendly request workflow without making the respondent feel like they are filling an API schema.</p>",
+    ),
+    textField("formio_project", "Project name", {
+      width: "1/2",
+      prefill: "Partner onboarding portal",
+    }),
+    selectField("formio_backend", "Do you want to maintain form backend infrastructure?", [
+      "No, I want hosted forms first",
+      "Yes, we have a backend team",
+      "Maybe for enterprise cases",
+    ], {
+      width: "1/2",
+      prefill: "No, I want hosted forms first",
+    }),
+    multiSelectField("formio_needs", "Which developer workflows still matter?", [
+      "Webhooks",
+      "API access",
+      "Self-hosting option",
+      "Custom domains",
+      "Exports",
+    ], {
+      prefill: ["Webhooks", "API access", "Self-hosting option"],
+      min_selection: 1,
+    }),
+    pageBreak("formio_break_1", { next_btn_text: "Estimate effort" }),
+    scaleField("formio_dev_load", "How much engineering effort should the form builder save?", {
+      prefill: 5,
+    }),
+    checkboxField("formio_business_owner", "A non-technical teammate should edit this form", {
+      prefill: true,
+    }),
+    textField("formio_handoff_note", "What should the non-technical owner be able to change?", {
+      multi_lines: true,
+      prefill: "They should edit fields, copy, and routing without asking engineering.",
+      hidden: true,
+      logic: showWhen("formio_business_owner", "checkbox", "is_checked"),
+    }),
+    pageBreak("formio_break_2", { next_btn_text: "Review developer workflow" }),
+    textBlock(
+      "formio_summary",
+      `<p><strong>Developer workflow score</strong></p><h2>${mention("cv_formio_dev_workflow", "Developer workflow score", "88")}/100</h2><p>${mention("formio_project", "Project", "Partner onboarding")} needs ${mention("formio_needs", "Developer workflows", "webhooks and API access")} while avoiding unnecessary backend maintenance.</p>`,
+    ),
+  ]
+
+  const form = comparisonForm("formio", competitorName, {
+    show_progress_bar: true,
+    properties: focusedSlides(properties),
+    computed_variables: [
+      computedVariable("cv_formio_dev_workflow", "Developer workflow score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("formio", competitorName, importSource, {
+    title: "Try a focused production form without provisioning a form backend.",
+    description: "A focused Form.io comparison flow for teams who want developer workflows without starting from infrastructure.",
+    highlights: ["Focused mode", "Developer workflow", "Computed score"],
+    successBody: "That was a Form.io-style production intake reframed around OpnForm's no-backend setup.",
+    form,
+  })
+}
+
+function build123FormBuilderScenario(importSource) {
+  const competitorName = "123FormBuilder"
+  const scoreFormula = "ROUND(({builder_volume} * 0.5) + ({builder_complexity} * 8) + (COUNT({builder_needs}) * 5))"
+  const properties = [
+    textBlock(
+      "builder_intro",
+      "<p><strong>Live demo</strong></p><h2>A client request form without starter-plan ceilings.</h2><p>This focused demo keeps the familiar request-form questions, then adds logic and a growth score.</p>",
+    ),
+    textField("builder_client", "Client or team name", {
+      width: "1/2",
+      prefill: "Atlas Events",
+    }),
+    emailField("builder_email", "Contact email", {
+      width: "1/2",
+      prefill: "events@example.com",
+    }),
+    multiSelectField("builder_needs", "What does the request form need?", [
+      "More fields",
+      "More submissions",
+      "Conditional logic",
+      "File uploads",
+      "Embeds",
+    ], {
+      prefill: ["More fields", "More submissions", "Conditional logic"],
+      min_selection: 1,
+    }),
+    pageBreak("builder_break_1", { next_btn_text: "Add volume" }),
+    sliderField("builder_volume", "Expected monthly responses", {
+      prefill: 80,
+      slider_step_value: 10,
+    }),
+    scaleField("builder_complexity", "How complex will this form become?", {
+      prefill: 4,
+    }),
+    textField("builder_limit_note", "Which limit would block this form first?", {
+      multi_lines: true,
+      prefill: "Field count and response volume would block us before the workflow is mature.",
+      hidden: true,
+      logic: showWhen("builder_needs", "multi_select", "contains", "More fields"),
+    }),
+    pageBreak("builder_break_2", { next_btn_text: "Review growth fit" }),
+    textBlock(
+      "builder_summary",
+      `<p><strong>Growth score</strong></p><h2>${mention("cv_123_growth", "Growth score", "87")}/100</h2><p>${mention("builder_client", "Client", "Atlas Events")} expects ${mention("builder_volume", "Monthly responses", "80")} responses and needs ${mention("builder_needs", "Needs", "more fields and logic")}.</p>`,
+    ),
+  ]
+
+  const form = comparisonForm("123formbuilder", competitorName, {
+    show_progress_bar: true,
+    properties: focusedSlides(properties),
+    computed_variables: [
+      computedVariable("cv_123_growth", "Growth score", scoreFormula),
+    ],
+  })
+
+  return comparisonScenario("123formbuilder", competitorName, importSource, {
+    title: "Try a focused client request form without starter-plan ceilings.",
+    description: "A focused request form with multi-select needs, response-volume slider, conditional fields, and a growth score.",
+    highlights: ["Focused mode", "Conditional field", "Growth score"],
+    successBody: "That was a 123FormBuilder-style request form showing why OpnForm fits growing workflows.",
+    form,
+  })
+}
+
+function buildComparisonScenario(competitorName, importSource) {
+  const safeName = competitorName || "your current tool"
+  const migration = buildMigrationFields("cmp", safeName, importSource)
+  const scoreFormula = `ROUND(({cmp_satisfaction} + COUNT({cmp_needs}) + IF({${migration.importFieldId}} = "${migration.importOption}", 2, 0)) * 10)`
   const properties = [
     introSlide(
       "cmp_intro",
-      `Try the ${competitorName} demo.`,
-      `A short live form for people comparing ${competitorName} with OpnForm.`,
+      '<span class="text-blue-500">Try the OpnForm switching workflow.</span>',
+      `A short live form for people comparing ${safeName} with OpnForm.`,
       "right-split",
       "switch",
     ),
     withSlideMedia(
       textField("cmp_name", "What should we call you?", {
         prefill: "Jamie Lee",
-        placeholder: "Jamie Lee",
-        help: "A prefilled text field keeps the demo moving while showing editable answers.",
       }),
       "fields",
       "left-split",
     ),
     withSlideMedia(
-      ratingField("cmp_satisfaction", `How satisfied are you with ${competitorName} today?`, {
-        help: "A rating makes the comparison concrete without adding friction.",
+      ratingField("cmp_satisfaction", `How satisfied are you with ${safeName} today?`, {
+        prefill: 3,
       }),
       "scale",
       "right-split",
     ),
     withSlideMedia(
-      selectField("cmp_reason", "What is the main reason you are comparing tools?", [
-        "Response limits",
-        "Price as traffic grows",
-        "Branding restrictions",
-        "Need more control over data",
-        "Need better automations",
+      multiSelectField("cmp_needs", "What are you comparing for?", [
+        "More responses",
+        "Better branding",
+        "More control",
+        "Automations",
+        "Open-source flexibility",
       ], {
-        help: "This mirrors the main objection a visitor brings to a comparison page.",
+        prefill: ["More responses", "More control", "Automations"],
+        min_selection: 1,
       }),
       "select",
       "left-split",
     ),
-    withSlideMedia(
-      textField("cmp_note", `What should still feel good after leaving ${competitorName}?`, {
-        multi_lines: true,
-        prefill: "I want a clean form experience, but with fewer limits as responses grow.",
-        placeholder: "Write a short note...",
-        help: "This shows how comparison pages can collect qualitative switching context.",
-      }),
-      "summary",
-      "right-split",
-    ),
-    withSlideMedia(
-      selectField("cmp_import", "Would you bring an existing form with you?", importOptions, {
-        help: hasImport
-          ? "Choose import to see a conditional URL field."
-          : "This keeps the demo focused on the switch decision.",
-      }),
-      "switch",
-      "left-split",
-    ),
-  ]
-
-  if (hasImport) {
-    properties.push(
-      withSlideMedia(
-        urlField("cmp_import_url", `Paste a ${competitorName} form URL`, {
-          hidden: true,
-          placeholder: `https://${competitorName.toLowerCase().replace(/[^a-z0-9]+/g, "")}.com/...`,
-          logic: showWhen("cmp_import", "select", "equals", importOption),
-          help: "This field appears only because you chose to import an existing form.",
-        }),
-        "switch",
-        "right-split",
-      ),
-    )
-  }
-
-  properties.push(
+    ...migration.fields,
     withSlideMedia(
       textBlock(
         "cmp_summary",
-        `<p><strong>Demo complete</strong></p><h2><span class="text-blue-500">Thanks, ${mention("cmp_name", "Name", "Jamie")}.</span></h2><p>You rated ${competitorName} ${mention("cmp_satisfaction", "Satisfaction", "3")}/5 and said your main reason to compare is ${mention("cmp_reason", "Reason", "response limits")}.</p><p>Your note: ${mention("cmp_note", "Switch note", "you want a cleaner form experience with fewer limits")}</p>`,
+        `<p><strong>Switch score</strong></p><h2><span class="text-blue-500">${mention("cv_cmp_switch", "Switch score", "80")}/100</span></h2><p>${mention("cmp_name", "Name", "Jamie")} is comparing for ${mention("cmp_needs", "Needs", "more control and automations")}.</p>`,
       ),
       "summary",
-      "left-split",
+      "right-split",
     ),
-  )
+  ]
 
-  const form = baseForm("comparison", {
-    title: `${competitorName} comparison survey`,
-    submit_button_text: "Submit demo response",
+  const form = comparisonForm(competitorSlug(safeName), safeName, {
     properties,
+    computed_variables: [
+      computedVariable("cv_cmp_switch", "Switch score", scoreFormula),
+    ],
   })
 
-  return baseScenario("comparison", {
-    title: `Try the ${competitorName} demo.`,
-    description: `Answer a short live form for people comparing ${competitorName} with OpnForm.`,
-    urlLabel: `opnform.com/vs-${competitorName.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
-    highlights: ["Prefilled text", "Star rating", "Conditional import"],
-    secondaryCtaLabel: hasImport ? `Import your ${competitorName} form` : null,
-    successTitle: "Demo response submitted.",
-    successBody: `That was a real OpnForm-style survey tailored to someone comparing ${competitorName}.`,
+  return comparisonScenario(competitorSlug(safeName), safeName, importSource, {
+    title: "Try a switching workflow in OpnForm.",
+    description: `Answer a short live form for people comparing ${safeName} with OpnForm.`,
+    highlights: ["Focused mode", "Conditional import", "Switch score"],
+    successBody: `That was an OpnForm switching workflow tailored to someone comparing ${safeName}.`,
     form,
   })
 }
 
-function buildTypeformScenario(importSource) {
-  return buildComparisonScenario("Typeform", importSource || "typeform")
-}
-
-function buildGoogleFormsScenario(importSource) {
-  return buildComparisonScenario("Google Forms", importSource || "google_forms")
-}
-
-function buildWorkflowScenario(competitorName, importSource) {
-  return buildComparisonScenario(competitorName, importSource)
-}
-
-function buildSimpleSwitchScenario(competitorName, importSource) {
-  return buildComparisonScenario(competitorName, importSource)
-}
-
 function normalizeCompetitorName(competitorName) {
   return (competitorName || "").toLowerCase().trim()
-}
-
-function getComparisonGroup(competitorName) {
-  const normalized = normalizeCompetitorName(competitorName)
-
-  for (const [group, names] of Object.entries(scenarioGroups)) {
-    if (names.includes(normalized)) {
-      return group
-    }
-  }
-
-  return "comparison"
 }
 
 export function getLiveDemoScenario({
@@ -465,23 +1287,32 @@ export function getLiveDemoScenario({
     return buildHomeScenario()
   }
 
-  const group = getComparisonGroup(competitorName)
-
-  if (group === "typeform") {
-    return buildTypeformScenario(importSource)
+  switch (normalizeCompetitorName(competitorName)) {
+    case "typeform":
+      return buildTypeformScenario(importSource)
+    case "google forms":
+    case "googleforms":
+      return buildGoogleFormsScenario(importSource)
+    case "tally":
+      return buildTallyScenario(importSource)
+    case "jotform":
+    case "jot form":
+      return buildJotformScenario(importSource)
+    case "fillout":
+      return buildFilloutScenario(importSource)
+    case "heyform":
+      return buildHeyformScenario(importSource)
+    case "youform":
+      return buildYouformScenario(importSource)
+    case "formbricks":
+      return buildFormbricksScenario(importSource)
+    case "form.io":
+    case "formio":
+      return buildFormioScenario(importSource)
+    case "123formbuilder":
+    case "123 formbuilder":
+      return build123FormBuilderScenario(importSource)
+    default:
+      return buildComparisonScenario(competitorName, importSource)
   }
-
-  if (group === "googleForms") {
-    return buildGoogleFormsScenario(importSource)
-  }
-
-  if (group === "workflow") {
-    return buildWorkflowScenario(competitorName, importSource)
-  }
-
-  if (group === "simpleSwitch") {
-    return buildSimpleSwitchScenario(competitorName, importSource)
-  }
-
-  return buildComparisonScenario(competitorName, importSource)
 }

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -4,7 +4,8 @@ import sitemap from "./sitemap"
 
 const isUnitTestMode = !!process.env.VITEST
 const isE2EMode = process.env.E2E === '1'
-const isDevtoolsEnabled = !isE2EMode && process.env.NODE_ENV !== 'production'
+const isDevtoolsEnabled =
+  process.env.NUXT_DEVTOOLS === '1' && !isE2EMode && process.env.NODE_ENV !== 'production'
 
 export default defineNuxtConfig({
   loglevel: process.env.NUXT_LOG_LEVEL || 'info',

--- a/client/package.json
+++ b/client/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
     "build:e2e": "E2E=1 NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
-    "dev": "export NODE_TLS_REJECT_UNAUTHORIZED=0; nuxt dev",
-    "docker-dev": "export NODE_TLS_REJECT_UNAUTHORIZED=0; nuxt dev --host 0.0.0.0",
+    "dev": "export NODE_TLS_REJECT_UNAUTHORIZED=0; node --import ./scripts/node-localstorage-polyfill.mjs ./node_modules/nuxt/bin/nuxt.mjs dev",
+    "docker-dev": "export NODE_TLS_REJECT_UNAUTHORIZED=0; node --import ./scripts/node-localstorage-polyfill.mjs ./node_modules/nuxt/bin/nuxt.mjs dev --host 0.0.0.0",
     "generate": "export NODE_TLS_REJECT_UNAUTHORIZED=0; nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/client/pages/opnform-vs-123formbuilder.vue
+++ b/client/pages/opnform-vs-123formbuilder.vue
@@ -3,6 +3,7 @@
     competitor-name="123FormBuilder"
     competitor-icon="opnform:123formbuilder"
     :hero-title="'OpnForm — The Open-Source 123FormBuilder Alternative'"
+    competitor-plan-label="Basic"
     :free-plan-comparison="freePlanComparison"
     :switch-reasons="switchReasons"
     :feature-comparison="featureComparison"
@@ -35,7 +36,7 @@ const freePlanComparison = [
     cells: ["Unlimited submissions", "Limited (100/month)"],
   },
   {
-    label: "Forms Allowed",
+    label: "Forms allowed",
     cells: ["Unlimited forms", "Limited (5 forms)"],
   },
   {
@@ -51,17 +52,25 @@ const freePlanComparison = [
     cells: ["Included", "Included"],
   },
   {
-    label: "File Uploads",
-    cells: ["Free basic quota", "Not Included"],
+    label: "File uploads",
+    cells: ["Included", "Paid plan"],
   },
   {
     label: "Custom CSS",
-    cells: ["No direct custom CSS", "CSS editor"],
+    cells: ["Business+", "Included"],
   },
   {
     label: "API access",
-    cells: ["Free", "100 calls/day"],
-  }
+    cells: ["Included", "100 calls/day"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
+  },
 ]
 
 const switchReasons = [
@@ -132,7 +141,7 @@ const featureComparison = [
   },
   {
     label: "Integrations",
-    cells: ["Basic free; advanced paid", "Limited"],
+    cells: ["Basic included; advanced paid", "Limited"],
   },
   {
     label: "Analytics dashboard",

--- a/client/pages/opnform-vs-fillout.vue
+++ b/client/pages/opnform-vs-fillout.vue
@@ -32,19 +32,19 @@ useOpnSeoMeta({
 
 const freePlanComparison = [
   {
-    label: "Monthly Responses",
+    label: "Monthly responses",
     cells: ["Unlimited submissions per month", "1,000 / month"],
   },
   {
-    label: "Forms Allowed",
+    label: "Forms allowed",
     cells: ["Unlimited forms", "Unlimited forms"],
   },
   {
-    label: "Branding Removal",
-    cells: ["Not available on free", "Not available"],
+    label: "Branding removal",
+    cells: ["Pro+", "Starter+"],
   },
   {
-    label: "Conditional Logic",
+    label: "Conditional logic",
     cells: ["Included", "Included"],
   },
   {
@@ -52,20 +52,24 @@ const freePlanComparison = [
     cells: ["Included", "Included"],
   },
   {
-    label: "File Uploads",
-    cells: ["Free basic quota", "Included"],
+    label: "File uploads",
+    cells: ["Included", "Included"],
   },
   {
     label: "Custom CSS",
-    cells: ["No direct custom CSS", "Pro+"],
-  },
-  {
-    label: "Self-hosting Option",
-    cells: ["Available", "No self-hosting"],
+    cells: ["Business+", "Pro+"],
   },
   {
     label: "API access",
-    cells: ["Free", "Included"],
+    cells: ["Included", "Included"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
   },
 ]
 
@@ -129,7 +133,7 @@ const featureComparison = [
   },
   {
     label: "Integrations",
-    cells: ["Basic free; advanced paid", "50+ included"],
+    cells: ["Basic included; advanced paid", "50+ included"],
   },
   {
     label: "Analytics dashboard",
@@ -145,7 +149,7 @@ const featureComparison = [
   },
   {
     label: "API access",
-    cells: ["Free", "Y"],
+    cells: ["Included", "Y"],
   },
   {
     label: "GDPR compliance",

--- a/client/pages/opnform-vs-formbricks.vue
+++ b/client/pages/opnform-vs-formbricks.vue
@@ -4,6 +4,7 @@
     competitor-icon="i-simple-icons-formbricks"
     competitor-icon-class="text-[#00CABA]"
     :hero-title="'OpnForm — The Open-Source Formbricks Alternative'"
+    competitor-plan-label="Hobby"
     :free-plan-comparison="freePlanComparison"
     :switch-reasons="switchReasons"
     :feature-comparison="featureComparison"
@@ -34,16 +35,16 @@ useOpnSeoMeta({
 
 const freePlanComparison = [
   {
-    label: "Monthly Responses",
+    label: "Monthly responses",
     cells: ["Unlimited", "250/month on Cloud Hobby"],
   },
   {
     label: "Unlimited forms / surveys",
-    cells: ["Yes", "Yes"],
+    cells: ["Y", "Y"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Limited"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Custom CSS / styling",
@@ -51,15 +52,19 @@ const freePlanComparison = [
   },
   {
     label: "Native integrations",
-    cells: ["Basic", "Pro cloud / self-host"],
-  },
-  {
-    label: "Self-hosting",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Pro cloud / self-host"],
   },
   {
     label: "API access",
-    cells: ["Free", "Scale cloud / self-host"],
+    cells: ["Included", "Self-host / paid cloud"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "Y"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "Y"],
   },
 ]
 
@@ -107,7 +112,7 @@ const featureComparison = [
   },
   {
     label: "Developer extensibility (API + webhooks)",
-    cells: ["Free API + webhooks", "Cloud tiers / self-host"],
+    cells: ["Included API + webhooks", "Cloud tiers / self-host"],
   },
   {
     label: "Custom domains for forms",
@@ -119,7 +124,7 @@ const featureComparison = [
   },
   {
     label: "Native ecosystem integrations",
-    cells: ["Basic free; advanced paid", "Pro cloud / self-host"],
+    cells: ["Basic included; advanced paid", "Pro cloud / self-host"],
   },
   {
     label: "Advanced analytics & dashboards",

--- a/client/pages/opnform-vs-formio.vue
+++ b/client/pages/opnform-vs-formio.vue
@@ -3,6 +3,9 @@
     competitor-name="Form.io"
     competitor-icon="opnform:formio"
     :hero-title="'OpnForm — The Open-Source Form.io Alternative'"
+    competitor-plan-label="Self-hosted"
+    :plan-comparison-title="'Hosted vs Self-hosted Setup:\nOpnForm vs Form.io'"
+    plan-comparison-subtitle="Compare OpnForm's hosted free plan with Form.io's developer-oriented self-hosted setup."
     :free-plan-comparison="freePlanComparison"
     :switch-reasons="switchReasons"
     :feature-comparison="featureComparison"
@@ -51,7 +54,7 @@ const freePlanComparison = [
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Included with file storage setup"],
+    cells: ["Included", "Requires file storage setup"],
   },
   {
     label: "Drag-and-drop builder",
@@ -59,11 +62,23 @@ const freePlanComparison = [
   },
   {
     label: "No code required",
-    cells: ["Yes", "Low-code / developer-oriented"],
+    cells: ["Y", "Low-code / developer-oriented"],
   },
   {
     label: "Hosted experience without infra",
-    cells: ["Yes", "Must self-host"],
+    cells: ["Y", "N"],
+  },
+  {
+    label: "API access",
+    cells: ["Included", "Included"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "Y"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "Y"],
   },
 ]
 
@@ -115,11 +130,11 @@ const featureComparison = [
   },
   {
     label: "Developer workflows (API + webhooks)",
-    cells: ["Free API + webhooks", "Y"],
+    cells: ["Included API + webhooks", "Y"],
   },
   {
     label: "Native integrations ecosystem",
-    cells: ["Basic free; advanced paid", "Must build integrations"],
+    cells: ["Basic included; advanced paid", "Must build integrations"],
   },
   {
     label: "Full control of styling without code",

--- a/client/pages/opnform-vs-googleforms.vue
+++ b/client/pages/opnform-vs-googleforms.vue
@@ -34,31 +34,31 @@ useOpnSeoMeta({
 const freePlanComparison = [
   {
     label: "Unlimited submissions",
-    cells: ["Yes", "Yes"],
+    cells: ["Y", "Y"],
   },
   {
     label: "Unlimited forms",
-    cells: ["Yes", "Yes"],
+    cells: ["Y", "Y"],
   },
   {
     label: "Conditional logic",
-    cells: ["Yes", "Yes (basic logic jumps)"],
+    cells: ["Included", "Basic logic jumps"],
   },
   {
     label: "Multi-page forms",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Yes (requires Google account)"],
+    cells: ["Included", "Requires Google account"],
   },
   {
     label: "Custom branding",
-    cells: ["No", "No"],
+    cells: ["Pro+", "Limited themes"],
   },
   {
     label: "Custom CSS",
-    cells: ["No", "No"],
+    cells: ["Business+", "N"],
   },
   {
     label: "Analytics dashboard",
@@ -66,7 +66,19 @@ const freePlanComparison = [
   },
   {
     label: "Integrations",
-    cells: ["Via integrations", "Google ecosystem + Apps Script"],
+    cells: ["Basic included; advanced paid", "Google ecosystem + Apps Script"],
+  },
+  {
+    label: "API access",
+    cells: ["Included", "Forms API"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
   },
 ]
 
@@ -114,7 +126,7 @@ const featureComparison = [
   },
   {
     label: "API + webhooks",
-    cells: ["Free API + webhooks", "API + Apps Script"],
+    cells: ["Included API + webhooks", "API + Apps Script"],
   },
   {
     label: "Custom domains",
@@ -134,7 +146,7 @@ const featureComparison = [
   },
   {
     label: "Ecosystem integrations",
-    cells: ["Basic free; advanced paid", "Google ecosystem"],
+    cells: ["Basic included; advanced paid", "Google ecosystem"],
   },
 ]
 </script>

--- a/client/pages/opnform-vs-heyform.vue
+++ b/client/pages/opnform-vs-heyform.vue
@@ -3,6 +3,9 @@
     competitor-name="HeyForm"
     competitor-icon="opnform:heyform"
     :hero-title="'OpnForm — The Open-Source HeyForm Alternative'"
+    competitor-plan-label="Basic"
+    :plan-comparison-title="'Entry Plan Comparison:\nOpnForm Free vs HeyForm Basic'"
+    plan-comparison-subtitle="Compare OpnForm's free plan with HeyForm's entry cloud plan."
     :free-plan-comparison="freePlanComparison"
     :switch-reasons="switchReasons"
     :feature-comparison="featureComparison"
@@ -44,27 +47,39 @@ const freePlanComparison = [
   },
   {
     label: "Conditional logic",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Yes, capped by storage"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Multi-page / conversational forms",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Drag-and-drop builder",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Embedded forms",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "No code required",
-    cells: ["Yes", "Yes"],
+    cells: ["Y", "Y"],
+  },
+  {
+    label: "Custom CSS",
+    cells: ["Business+", "Premium+"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "Y"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "Y"],
   },
 ]
 
@@ -116,7 +131,7 @@ const featureComparison = [
   },
   {
     label: "Developer workflows (API + webhooks)",
-    cells: ["Free API + webhooks", "Integrations listed"],
+    cells: ["Included API + webhooks", "Integrations listed"],
   },
   {
     label: "AI-powered form generation",

--- a/client/pages/opnform-vs-jotform.vue
+++ b/client/pages/opnform-vs-jotform.vue
@@ -3,6 +3,7 @@
     competitor-name="JotForm"
     competitor-icon="opnform:jotform"
     :hero-title="'OpnForm — The Open-Source JotForm Alternative'"
+    competitor-plan-label="Starter"
     :free-plan-comparison="freePlanComparison"
     :switch-reasons="switchReasons"
     :feature-comparison="featureComparison"
@@ -35,37 +36,45 @@ const freePlanComparison = [
     cells: ["Unlimited submissions", "Limited (100/month)"],
   },
   {
-    label: "Active forms",
+    label: "Forms allowed",
     cells: ["Unlimited forms", "Limited (5 forms)"],
   },
   {
     label: "Form views",
-    cells: ["Unlimited", "Limited (1000/month)"],
+    cells: ["Unlimited", "Limited (10,000/month)"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Included"],
+    cells: ["Included", "Included"],
   },
   {
-    label: "Conditional Logic",
+    label: "Conditional logic",
     cells: ["Included", "Included"],
   },
   {
     label: "Custom CSS",
-    cells: ["Business+", "Not available"],
+    cells: ["Business+", "Not listed"],
   },
   {
     label: "API access",
-    cells: ["Free", "Basic"],
+    cells: ["Included", "Basic"],
   },
   {
     label: "Webhooks",
-    cells: ["Free", "Available"],
+    cells: ["Included", "Available"],
   },
   {
     label: "Storage space",
     cells: ["Depends on plan", "Limited"],
-  }
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
+  },
 ]
 
 const switchReasons = [
@@ -120,7 +129,7 @@ const featureComparison = [
   },
   {
     label: "Developer extensibility",
-    cells: ["Free API + webhooks", "Moderate"],
+    cells: ["Included API + webhooks", "Moderate"],
   },
   {
     label: "Custom domains for forms",

--- a/client/pages/opnform-vs-tally.vue
+++ b/client/pages/opnform-vs-tally.vue
@@ -44,27 +44,35 @@ const freePlanComparison = [
   },
   {
     label: "Branding removal",
-    cells: ["No", "No"],
+    cells: ["Pro+", "Pro"],
   },
   {
     label: "Conditional logic",
-    cells: ["Yes", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Custom CSS",
-    cells: ["No", "No"],
+    cells: ["Business+", "Pro"],
   },
   {
     label: "Native integrations",
-    cells: ["Basic", "Basic"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Webhooks",
-    cells: ["Free", "Free"],
+    cells: ["Included", "Included"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
   },
 ]
 
@@ -112,7 +120,7 @@ const featureComparison = [
   },
   {
     label: "Full API access",
-    cells: ["Free API + webhooks", "Available"],
+    cells: ["Included API + webhooks", "Available"],
   },
   {
     label: "Custom domains for forms",
@@ -124,11 +132,11 @@ const featureComparison = [
   },
   {
     label: "Native integrations ecosystem",
-    cells: ["Basic free; advanced paid", "Zapier, Make, webhooks"],
+    cells: ["Basic included; advanced paid", "Zapier, Make, webhooks"],
   },
   {
     label: "Developer-first workflows",
-    cells: ["Free API + webhooks", "API + webhooks"],
+    cells: ["Included API + webhooks", "API + webhooks"],
   },
   {
     label: "Flexible form use cases",

--- a/client/pages/opnform-vs-typeform.vue
+++ b/client/pages/opnform-vs-typeform.vue
@@ -45,15 +45,15 @@ const freePlanComparison = [
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Paid"],
+    cells: ["Included", "Paid plan"],
   },
   {
     label: "Conditional logic",
-    cells: ["Yes", "Included"],
+    cells: ["Included", "Included"],
   },
   {
     label: "Custom branding",
-    cells: ["No", "Typeform branding"],
+    cells: ["Pro+", "Paid plan"],
   },
   {
     label: "Custom CSS / styling",
@@ -61,15 +61,23 @@ const freePlanComparison = [
   },
   {
     label: "Native integrations",
-    cells: ["Basic", "Some integrations"],
+    cells: ["Included", "Some integrations"],
   },
   {
     label: "API access",
-    cells: ["Basic", "Developer tools included"],
+    cells: ["Included", "Developer tools included"],
   },
   {
     label: "Webhooks",
-    cells: ["Free", "Available via API"],
+    cells: ["Included", "Available"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
   },
 ]
 
@@ -129,11 +137,11 @@ const featureComparison = [
   },
   {
     label: "Developer extensibility (API + webhooks)",
-    cells: ["Free API + webhooks", "APIs + webhooks"],
+    cells: ["Included API + webhooks", "APIs + webhooks"],
   },
   {
     label: "Native integrations ecosystem",
-    cells: ["Basic free; advanced paid", "Many apps"],
+    cells: ["Basic included; advanced paid", "Many apps"],
   },
   {
     label: "Advanced logic & branching",

--- a/client/pages/opnform-vs-youform.vue
+++ b/client/pages/opnform-vs-youform.vue
@@ -43,15 +43,15 @@ const freePlanComparison = [
   },
   {
     label: "Conditional logic",
-    cells: ["Basic", "Yes"],
+    cells: ["Included", "Included"],
   },
   {
     label: "File uploads",
-    cells: ["Free basic quota", "Free up to 10MB"],
+    cells: ["Included", "Included up to 10MB"],
   },
   {
     label: "Custom branding",
-    cells: ["No", "No"],
+    cells: ["Pro+", "Pro"],
   },
   {
     label: "Custom CSS / styling",
@@ -59,15 +59,23 @@ const freePlanComparison = [
   },
   {
     label: "Native integrations",
-    cells: ["Basic", "Basic"],
+    cells: ["Included", "Included"],
   },
   {
     label: "API access",
-    cells: ["Basic", "Not listed"],
+    cells: ["Included", "Not listed"],
   },
   {
     label: "Webhooks",
-    cells: ["Free", "Free"],
+    cells: ["Included", "Included"],
+  },
+  {
+    label: "Open source",
+    cells: ["Y", "N"],
+  },
+  {
+    label: "Self-hosting option",
+    cells: ["Y", "N"],
   },
 ]
 
@@ -123,11 +131,11 @@ const featureComparison = [
   },
   {
     label: "Developer extensibility (API + webhooks)",
-    cells: ["Free API + webhooks", "Webhooks; API not listed"],
+    cells: ["Included API + webhooks", "Webhooks; API not listed"],
   },
   {
     label: "Native integration ecosystem",
-    cells: ["Basic free; advanced paid", "Selected integrations"],
+    cells: ["Basic included; advanced paid", "Selected integrations"],
   },
   {
     label: "Advanced logic & branching",

--- a/client/plugins/01.vue-query.ts
+++ b/client/plugins/01.vue-query.ts
@@ -14,7 +14,7 @@ import { useState } from '#app'
 export default defineNuxtPlugin((nuxt) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query')
   const shouldEnableVueQueryDevtools =
-    process.env.NODE_ENV === 'development' && process.env.E2E !== '1'
+    import.meta.client && process.env.NODE_ENV === 'development' && process.env.E2E !== '1'
 
   // Modify your Vue Query global settings here
   const queryClient = new QueryClient({

--- a/client/scripts/node-localstorage-polyfill.mjs
+++ b/client/scripts/node-localstorage-polyfill.mjs
@@ -1,0 +1,43 @@
+class MemoryStorage {
+  #store = new Map()
+
+  get length() {
+    return this.#store.size
+  }
+
+  clear() {
+    this.#store.clear()
+  }
+
+  getItem(key) {
+    const value = this.#store.get(String(key))
+    return value === undefined ? null : value
+  }
+
+  key(index) {
+    return Array.from(this.#store.keys())[index] ?? null
+  }
+
+  removeItem(key) {
+    this.#store.delete(String(key))
+  }
+
+  setItem(key, value) {
+    this.#store.set(String(key), String(value))
+  }
+}
+
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+const hasUsableLocalStorage =
+  localStorageDescriptor &&
+  "value" in localStorageDescriptor &&
+  typeof localStorageDescriptor.value?.getItem === "function"
+
+if (!hasUsableLocalStorage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    enumerable: true,
+    value: new MemoryStorage(),
+    writable: true,
+  })
+}


### PR DESCRIPTION
## Summary

- Backport the comparison page live-demo and table improvements from #1163 to `main`.
- Tailor the comparison live demos per competitor with focused-mode scenarios and clearer OpnForm-centered copy.
- Normalize comparison table labels for included features, paid-plan features, open source, and self-hosting.
- Include the local Nuxt dev startup fix from #1163: SSR-safe `localStorage` polyfill plus opt-in Nuxt DevTools via `NUXT_DEVTOOLS=1`.

## Why

#1163 was merged into `main-v2`, but production is still serving the old comparison copy from `main`. The live JotForm page still shows `Try the JotForm demo.` and old table labels such as `Free basic quota`, so the same improvements need to land on `main`.

## Validation

- Verified live `https://opnform.com/opnform-vs-jotform` still serves the old copy before this backport.
- `npm run lint` in `client/` on the backport branch.
- Source check on the backport branch confirms the old JotForm demo title and old table copy are removed.

Note: local Nuxt render in the temporary backport worktree hit Vite's 403 guard because `node_modules` was symlinked from the main checkout for validation; this is a worktree setup artifact, not an app error.