### PR TITLE
Avoid deploy-time submission public ID backfill

### DIFF
--- a/api/database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
+++ b/api/database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 return new class () extends Migration {
     /**
@@ -10,18 +8,8 @@ return new class () extends Migration {
      */
     public function up(): void
     {
-        DB::table('form_submissions')
-            ->whereNull('public_id')
-            ->chunkById(1000, function ($submissions) {
-                foreach ($submissions as $submission) {
-                    DB::table('form_submissions')
-                        ->where('id', $submission->id)
-                        ->whereNull('public_id')
-                        ->update([
-                            'public_id' => Str::uuid()->toString(),
-                        ]);
-                }
-            });
+        // Keep deployment migrations lightweight. Legacy submissions receive a
+        // public_id lazily when an edit/share URL is generated.
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the production-wide form_submissions.public_id row-by-row backfill from the deploy-time migration
- rely on existing lazy public_id generation when edit/share URLs are generated

## Root cause
The production deploy failed in Vapor while running deployment hooks. The failing hook is php artisan migrate --force; the visible Vapor error was App\\Jobs\\RunDeploymentHooks has been attempted too many times.

The last successful main deploy was ed1b5e2f on 2026-06-21 16:56 UTC. The failed run was 9193d28d on 2026-06-22 09:06 UTC. The relevant backend change between them was PR #1173, which added a row-by-row backfill over form_submissions.

## Validation
- php -l api/database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
- ./vendor/bin/pint --test database/migrations/2026_06_20_000000_backfill_public_id_on_form_submissions_table.php
- ./vendor/bin/pest --filter=SubmissionIdentifierTest (passes with existing warning output: 18 warnings, 69 assertions)