### PR TITLE
Enhance BlockTypeIcon component and refactor useTableState logic

### DIFF
--- a/client/components/open/forms/components/BlockTypeIcon.vue
+++ b/client/components/open/forms/components/BlockTypeIcon.vue
@@ -13,6 +13,19 @@
 <script setup>
 import blocksTypes from '~/data/blocks_types.json'
 
+const extraBlocksTypes = {
+  status: {
+    icon: 'i-heroicons-clipboard-document-check-20-solid',
+    bg_class: 'bg-gray-100',
+    text_class: 'text-gray-900',
+  },
+  ip_address: {
+    icon: 'i-heroicons-globe-alt',
+    bg_class: 'bg-gray-100',
+    text_class: 'text-gray-900',
+  },
+}
+
 const props = defineProps({
   type: {
     type: String,
@@ -28,7 +41,8 @@ const props = defineProps({
   }
 })
 
-const bgClass = computed(() => props.bgClass || blocksTypes[props.type]?.bg_class || '')
-const textClass = computed(() => props.textClass || blocksTypes[props.type]?.text_class || '')
-const icon = computed(() => blocksTypes[props.type]?.icon || '')
+const blockType = computed(() => blocksTypes[props.type] || extraBlocksTypes[props.type])
+const bgClass = computed(() => props.bgClass || blockType.value?.bg_class || '')
+const textClass = computed(() => props.textClass || blockType.value?.text_class || '')
+const icon = computed(() => blockType.value?.icon || '')
 </script>

--- a/client/composables/components/tables/useTableState.js
+++ b/client/composables/components/tables/useTableState.js
@@ -1,4 +1,4 @@
-import { computed, toValue } from 'vue'
+import { computed } from 'vue'
 import { useTableColumnPreferences } from './useTableColumnPreferences'
 import debounce from 'debounce'
 
@@ -24,9 +24,7 @@ export function useTableState(form, withActions = false) {
   )
 
   const { getColumnPreference, setColumnPreference } = columnPreferences
-  const isProForm = computed(() => {
-    return Boolean(toValue(form)?.is_pro)
-  })
+  const { hasFeature } = usePlanFeatures()
 
   /* -------------------------------------------------------------------------- */
   /*                               Column config                               */
@@ -88,7 +86,7 @@ export function useTableState(form, withActions = false) {
          })
        }
 
-       if (isProForm.value && (form.value?.enable_partial_submissions ?? false)) {
+       if (hasFeature('enable_partial_submissions') && (form.value?.enable_partial_submissions ?? false)) {
          if (!baseColumns.find(property => property.id === 'status')) {
            baseColumns.push({
             id: 'status',
@@ -104,7 +102,7 @@ export function useTableState(form, withActions = false) {
          }
        }
 
-       if (isProForm.value && (form.value?.enable_ip_tracking ?? false)) {
+       if (hasFeature('enable_ip_tracking') && (form.value?.enable_ip_tracking ?? false)) {
          if (!baseColumns.find(property => property.id === 'ip_address')) {
            baseColumns.push({
             id: 'ip_address',


### PR DESCRIPTION
- Added support for additional block types in BlockTypeIcon.vue, allowing for 'status' and 'ip_address' types with corresponding icons and styles.
- Refactored useTableState.js to replace the isProForm computed property with a feature check using hasFeature, improving clarity and maintainability of the code.