### PR TITLE
[codex] Fix comparison page mobile spacing

### DIFF
--- a/client/components/pages/comparisons/ComparisonPage.vue
+++ b/client/components/pages/comparisons/ComparisonPage.vue
@@ -2,7 +2,7 @@
   <div>
     <section class="bg-white">
       <div class="relative">
-        <div class="py-14 sm:py-28 px-8 lg:px-12 relative z-2">
+        <div class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 relative z-2">
           <div class="max-w-3xl mx-auto text-center">
             <div class="flex items-center justify-center gap-4">
               <div
@@ -68,7 +68,7 @@
         ></div>
       </div>
       <div class="relative">
-        <div class="pt-1 pb-14 sm:pb-24 px-8 lg:px-12 relative z-2">
+        <div class="pt-1 pb-14 sm:pb-24 px-4 sm:px-8 lg:px-12 relative z-2">
           <div class="max-w-3xl mx-auto text-center">
             <h2
               class="text-2xl leading-8 font-semibold tracking-[-0.5%] text-gray-950"
@@ -97,7 +97,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -282,7 +282,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -323,7 +323,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -504,7 +504,7 @@
       </div>
     </section>
 
-    <section v-if="displayCompetitorPrice" class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section v-if="displayCompetitorPrice" class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -591,7 +591,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -649,7 +649,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <div class="max-w-266 mx-auto">
         <div class="max-w-2xl mx-auto text-center">
           <h2
@@ -694,7 +694,7 @@
       </div>
     </section>
 
-    <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
+    <section class="py-14 sm:py-28 px-4 sm:px-8 lg:px-12 bg-white">
       <Testimonials />
     </section>
 

--- a/client/components/pages/welcome/Testimonials.vue
+++ b/client/components/pages/welcome/Testimonials.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="relative px-6 py-8 sm:px-8 sm:py-10">
+  <div class="relative px-4 py-8 sm:px-8 sm:py-10">
     <div
-      class="pointer-events-none absolute left-1/2 top-8 h-[21.75rem] w-[72rem] max-w-[145%] -translate-x-1/2 rounded-full bg-blue-100/70 blur-3xl"
+      class="pointer-events-none absolute left-1/2 top-8 h-[21.75rem] w-full max-w-full -translate-x-1/2 rounded-full bg-blue-100/70 blur-3xl sm:w-[72rem] sm:max-w-[145%]"
       aria-hidden="true"
     ></div>
 


### PR DESCRIPTION
## Summary

Fixes the mobile spacing on shared competitor comparison pages such as `/opnform-vs-youform`.

## Root cause

The comparison page used `px-8` at the base breakpoint, leaving narrow content columns on phones. The testimonials background glow also kept its wide desktop width on mobile and could increase the document scroll width, creating the white right-side margin.

## Changes

- Use smaller base mobile horizontal padding on `ComparisonPage.vue`, while preserving existing `sm` and desktop spacing.
- Constrain the testimonials glow to `w-full max-w-full` on mobile and keep the wider decorative treatment from `sm` upward.

## Validation

- `git diff --check`
- `npm run lint` in `client/`
- Local Nuxt check on `http://127.0.0.1:3107/opnform-vs-youform`
- Playwright width checks at 320, 360, 375, and 390px: all returned `overflow: 0`. At 360px, usable content width increased from about 296px on production to 323px locally.