### PR TITLE
[codex] Add structured data schemas

### DIFF
--- a/client/components/pages/comparisons/ComparisonPage.vue
+++ b/client/components/pages/comparisons/ComparisonPage.vue
@@ -643,6 +643,14 @@
       </div>
     </section>
 
+    <FaqSection
+      :title="`${competitorName} Alternative FAQ`"
+      :description="`Clear answers for teams comparing ${competitorName} and OpnForm.`"
+      :faqs="resolvedComparisonFaqs"
+      :show-contact="false"
+      id-prefix="comparison-faq-answer"
+    />
+
     <section class="py-14 sm:py-28 px-8 lg:px-12 bg-white">
       <Testimonials />
     </section>
@@ -703,6 +711,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  comparisonFaqs: {
+    type: Array,
+    default: null,
+  },
   getCompetitorPrice: {
     type: Function,
     default: null,
@@ -710,10 +722,60 @@ const props = defineProps({
 })
 
 const { isAuthenticated: authenticated } = useIsAuthenticated()
+const route = useRoute()
 
 const switchSectionTitle = computed(
   () => `Why Users Switch from ${props.competitorName} to OpnForm`,
 )
+
+const defaultComparisonFaqs = computed(() => [
+  {
+    question: "Is OpnForm open source?",
+    answer:
+      "Yes. OpnForm is an open-source form builder. You can use the managed cloud service or self-host the core product when you need more control.",
+  },
+  {
+    question: "Can I self-host OpnForm?",
+    answer:
+      "Yes. OpnForm can be self-hosted. The Community self-hosted edition includes the core product, while self-hosted Enterprise unlocks advanced team, identity, and governance features.",
+  },
+  {
+    question: `Is OpnForm a good alternative to ${props.competitorName}?`,
+    answer:
+      `OpnForm is a good alternative to ${props.competitorName} if you want unlimited submissions, open-source transparency, API/webhooks, and deployment control. ${props.competitorName} may still be a better fit if your team relies on its specific ecosystem or templates.`,
+  },
+  {
+    question: `Can I migrate forms from ${props.competitorName} to OpnForm?`,
+    answer:
+      `You can recreate forms in OpnForm using templates, imports when available, or the form builder. Some ${props.competitorName}-specific logic or integrations may need to be configured manually.`,
+  },
+  {
+    question: "Does OpnForm include unlimited submissions?",
+    answer:
+      "Yes. OpnForm includes unlimited submissions on all plans, including the Free plan.",
+  },
+])
+
+const resolvedComparisonFaqs = computed(() =>
+  props.comparisonFaqs && props.comparisonFaqs.length > 0
+    ? props.comparisonFaqs
+    : defaultComparisonFaqs.value,
+)
+
+const comparisonSchema = computed(() => buildSchemaGraph([
+  buildWebPageSchema({
+    name: props.heroTitle,
+    description: `Compare OpnForm and ${props.competitorName} for pricing, features, integrations, privacy, and open-source deployment control.`,
+    path: route.path,
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: props.heroTitle, path: route.path },
+  ]),
+  buildFaqSchema(resolvedComparisonFaqs.value),
+]))
+
+useJsonLd("comparison-schema", comparisonSchema)
 
 const resolvedHeroSecondaryCtaLabel = computed(
   () =>

--- a/client/composables/useJsonLd.js
+++ b/client/composables/useJsonLd.js
@@ -1,0 +1,29 @@
+import { toValue } from "vue"
+
+export function serializeJsonLd(schema) {
+  return JSON.stringify(schema)
+    .replace(/</g, "\\u003C")
+    .replace(/>/g, "\\u003E")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+}
+
+export function useJsonLd(key, schema) {
+  return useHead(() => {
+    const value = toValue(schema)
+    const schemas = (Array.isArray(value) ? value : [value]).filter(Boolean)
+
+    if (schemas.length === 0) {
+      return {}
+    }
+
+    return {
+      script: schemas.map((item, index) => ({
+        key: schemas.length === 1 ? key : `${key}-${index}`,
+        type: "application/ld+json",
+        textContent: serializeJsonLd(item),
+      })),
+    }
+  })
+}

--- a/client/composables/useOpnSchema.js
+++ b/client/composables/useOpnSchema.js
@@ -1,0 +1,266 @@
+const DEFAULT_SITE_URL = "https://opnform.com"
+const ORGANIZATION_ID = "/#organization"
+const WEBSITE_ID = "/#website"
+const SOFTWARE_ID = "/#software"
+
+function getBaseUrl() {
+  return DEFAULT_SITE_URL
+}
+
+export function resolveSchemaUrl(path = "/") {
+  if (!path) return `${getBaseUrl()}/`
+  if (path.startsWith("http")) return path
+
+  const normalizedPath = `/${path.replace(/^\/+/, "")}`
+  return normalizedPath === "/" ? `${getBaseUrl()}/` : `${getBaseUrl()}${normalizedPath}`
+}
+
+function schemaId(path) {
+  if (path.startsWith("http")) return path
+  return resolveSchemaUrl(path)
+}
+
+export function stripSchemaText(value) {
+  if (value === null || value === undefined) return ""
+
+  return String(value)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&#x27;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+export function buildSchemaGraph(nodes) {
+  const graph = nodes.filter(Boolean)
+
+  if (graph.length === 0) return null
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": graph,
+  }
+}
+
+export function buildOrganizationSchema() {
+  return {
+    "@type": "Organization",
+    "@id": schemaId(ORGANIZATION_ID),
+    name: "OpnForm",
+    url: resolveSchemaUrl("/"),
+    logo: resolveSchemaUrl("/img/logo.svg"),
+    sameAs: [
+      "https://github.com/OpnForm/OpnForm",
+      "https://twitter.com/OpnForm",
+    ],
+  }
+}
+
+export function buildWebsiteSchema() {
+  return {
+    "@type": "WebSite",
+    "@id": schemaId(WEBSITE_ID),
+    name: "OpnForm",
+    url: resolveSchemaUrl("/"),
+    publisher: {
+      "@id": schemaId(ORGANIZATION_ID),
+    },
+  }
+}
+
+export function buildSoftwareApplicationSchema(overrides = {}) {
+  return {
+    "@type": "SoftwareApplication",
+    "@id": schemaId(SOFTWARE_ID),
+    name: "OpnForm",
+    url: resolveSchemaUrl("/"),
+    description:
+      "OpnForm is an open-source form builder for creating online forms, collecting unlimited submissions, and automating data collection workflows.",
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    provider: {
+      "@id": schemaId(ORGANIZATION_ID),
+    },
+    offers: {
+      "@type": "Offer",
+      name: "Free plan",
+      price: "0",
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
+      url: resolveSchemaUrl("/pricing"),
+    },
+    ...overrides,
+  }
+}
+
+export function buildWebPageSchema({ name, description, path = "/", url } = {}) {
+  const pageUrl = url || resolveSchemaUrl(path)
+
+  return {
+    "@type": "WebPage",
+    "@id": `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: stripSchemaText(name),
+    description: stripSchemaText(description),
+    isPartOf: {
+      "@id": schemaId(WEBSITE_ID),
+    },
+    about: {
+      "@id": schemaId(SOFTWARE_ID),
+    },
+  }
+}
+
+export function buildCollectionPageSchema({ name, description, path = "/", url } = {}) {
+  const pageUrl = url || resolveSchemaUrl(path)
+
+  return {
+    "@type": "CollectionPage",
+    "@id": `${pageUrl}#webpage`,
+    url: pageUrl,
+    name: stripSchemaText(name),
+    description: stripSchemaText(description),
+    isPartOf: {
+      "@id": schemaId(WEBSITE_ID),
+    },
+    about: {
+      "@id": schemaId(SOFTWARE_ID),
+    },
+  }
+}
+
+export function buildCreativeWorkSchema({ name, description, path = "/", url, image } = {}) {
+  const pageUrl = url || resolveSchemaUrl(path)
+  const schema = {
+    "@type": "CreativeWork",
+    "@id": `${pageUrl}#creative-work`,
+    url: pageUrl,
+    name: stripSchemaText(name),
+    description: stripSchemaText(description),
+    publisher: {
+      "@id": schemaId(ORGANIZATION_ID),
+    },
+  }
+
+  if (image) {
+    schema.image = resolveSchemaUrl(image)
+  }
+
+  return schema
+}
+
+export function buildFaqSchema(faqs = []) {
+  const mainEntity = faqs
+    .map((faq) => ({
+      "@type": "Question",
+      name: stripSchemaText(faq.question),
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: stripSchemaText(faq.answer),
+      },
+    }))
+    .filter((faq) => faq.name && faq.acceptedAnswer.text)
+
+  if (mainEntity.length === 0) return null
+
+  return {
+    "@type": "FAQPage",
+    mainEntity,
+  }
+}
+
+export function buildBreadcrumbSchema(items = []) {
+  const itemListElement = items
+    .map((item, index) => {
+      const name = stripSchemaText(item.name || item.label)
+      const itemUrl = item.url || item.path
+
+      if (!name || !itemUrl) return null
+
+      return {
+        "@type": "ListItem",
+        position: index + 1,
+        name,
+        item: resolveSchemaUrl(itemUrl),
+      }
+    })
+    .filter(Boolean)
+
+  if (itemListElement.length === 0) return null
+
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement,
+  }
+}
+
+export function buildItemListSchema(items = [], { path = "/", name = "Items" } = {}) {
+  const itemListElement = items
+    .map((item, index) => {
+      const itemName = stripSchemaText(item.name || item.title)
+      const itemUrl = item.url || item.path
+
+      if (!itemName || !itemUrl) return null
+
+      return {
+        "@type": "ListItem",
+        position: index + 1,
+        name: itemName,
+        url: resolveSchemaUrl(itemUrl),
+      }
+    })
+    .filter(Boolean)
+
+  if (itemListElement.length === 0) return null
+
+  return {
+    "@type": "ItemList",
+    "@id": `${resolveSchemaUrl(path)}#item-list`,
+    name,
+    itemListElement,
+  }
+}
+
+export function buildHowToSchema({ name, description, steps = [], path = "/", url } = {}) {
+  const cleanedSteps = steps.map(stripSchemaText).filter(Boolean)
+
+  if (cleanedSteps.length < 2) return null
+
+  return {
+    "@type": "HowTo",
+    "@id": `${url || resolveSchemaUrl(path)}#how-to`,
+    name: stripSchemaText(name),
+    description: stripSchemaText(description),
+    step: cleanedSteps.map((step, index) => ({
+      "@type": "HowToStep",
+      position: index + 1,
+      text: step,
+    })),
+  }
+}
+
+export function buildOfferCatalogSchema(offers = []) {
+  const itemListElement = offers
+    .map((offer) => {
+      if (!offer.name || offer.price === null || offer.price === undefined) return null
+
+      return {
+        "@type": "Offer",
+        name: offer.name,
+        price: String(offer.price),
+        priceCurrency: offer.priceCurrency || "USD",
+        url: resolveSchemaUrl(offer.url || "/pricing"),
+      }
+    })
+    .filter(Boolean)
+
+  if (itemListElement.length === 0) return null
+
+  return {
+    "@type": "OfferCatalog",
+    name: "OpnForm plans",
+    itemListElement,
+  }
+}

--- a/client/pages/enterprise.vue
+++ b/client/pages/enterprise.vue
@@ -822,28 +822,19 @@ const enterpriseFaqs = [
   },
 ]
 
-const enterpriseFaqSchema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: enterpriseFaqs.map((faq) => ({
-    "@type": "Question",
-    name: faq.question,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: faq.answer,
-    },
-  })),
-}
-
-useHead({
-  script: [
-    {
-      key: "enterprise-faq-schema",
-      type: "application/ld+json",
-      textContent: JSON.stringify(enterpriseFaqSchema),
-    },
-  ],
-})
+useJsonLd("enterprise-schema", buildSchemaGraph([
+  buildWebPageSchema({
+    name: "Secure Form Builder for Teams and Enterprises",
+    description:
+      "Build secure forms, surveys, and workflows with OpnForm Enterprise. Manage access, automate data collection, and choose cloud, France hosting, or self-hosted deployment.",
+    path: "/enterprise",
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Enterprise", path: "/enterprise" },
+  ]),
+  buildFaqSchema(enterpriseFaqs),
+]))
 
 const finalCtaProofs = ["SSO/SAML", "France hosting", "Self-hosting support"]
 

--- a/client/pages/features/[slug].vue
+++ b/client/pages/features/[slug].vue
@@ -158,4 +158,33 @@ useOpnSeoMeta({
   title: () => feature.value?.seoTitle ?? feature.value?.title ?? 'Features',
   description: () => feature.value?.seoDescription ?? feature.value?.summary ?? 'Explore OpnForm features for building powerful online forms.',
 })
+
+const featureSchema = computed(() => {
+  if (!feature.value) return null
+
+  return buildSchemaGraph([
+    buildWebPageSchema({
+      name: feature.value.seoTitle ?? feature.value.title,
+      description: feature.value.seoDescription ?? feature.value.summary,
+      path: route.path,
+    }),
+    buildBreadcrumbSchema([
+      { name: "Home", path: "/" },
+      { name: "Features", path: "/features" },
+      { name: feature.value.title, path: route.path },
+    ]),
+    buildItemListSchema(
+      relatedFeatures.value.map((relatedFeature) => ({
+        name: relatedFeature.title,
+        path: `/features/${relatedFeature.slug}`,
+      })),
+      {
+        path: route.path,
+        name: `Related ${feature.value.title} features`,
+      },
+    ),
+  ])
+})
+
+useJsonLd("feature-schema", featureSchema)
 </script>

--- a/client/pages/features/index.vue
+++ b/client/pages/features/index.vue
@@ -145,6 +145,31 @@ const { data: features, pending: isLoading } = await useAsyncData('features-list
 const sortedFeatures = computed(() => features.value ?? [])
 const categorySections = computed(() => groupFeaturesByCategory(sortedFeatures.value))
 
+const featuresSchema = computed(() => buildSchemaGraph([
+  buildCollectionPageSchema({
+    name: "Form Builder Features",
+    description:
+      "Explore all OpnForm features for building, sharing, automating, and managing beautiful online forms.",
+    path: "/features",
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Features", path: "/features" },
+  ]),
+  buildItemListSchema(
+    sortedFeatures.value.map((feature) => ({
+      name: feature.title,
+      path: `/features/${feature.slug}`,
+    })),
+    {
+      path: "/features",
+      name: "OpnForm features",
+    },
+  ),
+]))
+
+useJsonLd("features-schema", featuresSchema)
+
 function scrollToCategory (categorySlug) {
   document.getElementById(categorySlug)?.scrollIntoView({
     behavior: 'smooth',

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -184,6 +184,18 @@ useOpnSeoMeta({
     "Build beautiful online forms with OpnForm. Create forms, surveys, and workflows for free, collect unlimited responses, and keep control of your data.",
 })
 
+useJsonLd("homepage-schema", buildSchemaGraph([
+  buildOrganizationSchema(),
+  buildWebsiteSchema(),
+  buildSoftwareApplicationSchema(),
+  buildWebPageSchema({
+    name: "Free Online Form Builder with Unlimited Responses",
+    description:
+      "Build beautiful online forms with OpnForm. Create forms, surveys, and workflows for free, collect unlimited responses, and keep control of your data.",
+    path: "/",
+  }),
+]))
+
 const { isAuthenticated: authenticated } = useIsAuthenticated()
 </script>
 

--- a/client/pages/integrations/[slug].vue
+++ b/client/pages/integrations/[slug].vue
@@ -134,7 +134,8 @@ import integrationsCatalog from '~/data/forms/integrations.json'
 import { useNotionCmsStore } from '~/stores/notion_cms.js'
 
 const blockOverrides = { code: CustomBlock }
-const slug = computed(() => useRoute().params.slug)
+const route = useRoute()
+const slug = computed(() => route.params.slug)
 const dbId = '1eda631bec208005bd8ed9988b380263'
 
 const crisp = useCrisp()
@@ -226,4 +227,35 @@ useOpnSeoMeta({
   title: () => pageTitle.value,
   description: () => page.value?.['Summary - SEO description'] ?? fallbackDescription.value ?? 'Create beautiful forms for free. Unlimited fields, unlimited submissions.'
 })
+
+const integrationSchema = computed(() => {
+  if (!showNotionPage.value && !showFallbackPage.value) return null
+
+  const description = page.value?.['Summary - SEO description']
+    ?? fallbackDescription.value
+    ?? 'Connect OpnForm with your existing tools and workflows.'
+
+  return buildSchemaGraph([
+    buildWebPageSchema({
+      name: pageTitle.value,
+      description,
+      path: route.path,
+    }),
+    buildBreadcrumbSchema([
+      { name: "Home", path: "/" },
+      { name: "Integrations", path: "/integrations" },
+      { name: pageTitle.value, path: route.path },
+    ]),
+    showFallbackPage.value
+      ? buildHowToSchema({
+          name: `${fallbackIntegration.value.name} setup overview`,
+          description,
+          steps: fallbackSteps.value,
+          path: route.path,
+        })
+      : null,
+  ])
+})
+
+useJsonLd("integration-schema", integrationSchema)
 </script>

--- a/client/pages/integrations/index.vue
+++ b/client/pages/integrations/index.vue
@@ -275,6 +275,31 @@ const setupGuides = [
   }
 ]
 
+const integrationsSchema = computed(() => buildSchemaGraph([
+  buildCollectionPageSchema({
+    name: "OpnForm Integrations",
+    description:
+      "Connect OpnForm with notification, automation, and database tools to send submissions into your existing workflows.",
+    path: "/integrations",
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Integrations", path: "/integrations" },
+  ]),
+  buildItemListSchema(
+    integrationsList.value.map((integration) => ({
+      name: integration.title,
+      path: `/integrations/${integration.slug}`,
+    })),
+    {
+      path: "/integrations",
+      name: "OpnForm integrations",
+    },
+  ),
+]))
+
+useJsonLd("integrations-schema", integrationsSchema)
+
 </script>
 
 <style lang='scss'>

--- a/client/pages/pricing.vue
+++ b/client/pages/pricing.vue
@@ -743,7 +743,7 @@ definePageMeta({
 useOpnSeoMeta({
   title: "Pricing",
   description:
-    "All of our core features are free, and there is no quantity limit. You can also created more advanced and customized forms with OpnForms Pro.",
+    "Start free with unlimited forms and submissions. Upgrade to OpnForm Pro, Business, or Enterprise for advanced branding, collaboration, and self-hosted options.",
 })
 
 const { openSubscriptionModal } = useAppModals()
@@ -918,6 +918,32 @@ const faqs = [
       "Yes — multi-user collaboration is supported. Higher tiers add roles and permissions for larger teams.",
   },
 ]
+
+const pricingSchema = computed(() => buildSchemaGraph([
+  buildOrganizationSchema(),
+  buildWebsiteSchema(),
+  buildSoftwareApplicationSchema({
+    offers: buildOfferCatalogSchema([
+      { name: "Free", price: 0 },
+      { name: "Pro", price: getPlanPrice("pro", false) },
+      { name: "Business", price: getPlanPrice("business", false) },
+      { name: "Enterprise", price: getPlanPrice("enterprise", false) },
+    ]),
+  }),
+  buildWebPageSchema({
+    name: "Pricing",
+    description:
+      "Start free with unlimited forms and submissions. Upgrade to OpnForm Pro, Business, or Enterprise for advanced branding, collaboration, and self-hosted options.",
+    path: "/pricing",
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Pricing", path: "/pricing" },
+  ]),
+  buildFaqSchema(faqs),
+]))
+
+useJsonLd("pricing-schema", pricingSchema)
 
 const handlePlanCta = (plan) => {
   if (!authenticated.value) {

--- a/client/pages/templates/[slug].vue
+++ b/client/pages/templates/[slug].vue
@@ -385,6 +385,42 @@ useOpnSeoMeta(
     description: template.value?.short_description,
   })),
 )
+
+const templateSchema = computed(() => {
+  if (!template.value) return null
+
+  return buildSchemaGraph([
+    buildWebPageSchema({
+      name: template.value.name,
+      description: template.value.short_description,
+      path: route.path,
+    }),
+    buildCreativeWorkSchema({
+      name: template.value.name,
+      description: template.value.short_description,
+      path: route.path,
+      image: template.value.image_url,
+    }),
+    buildBreadcrumbSchema([
+      { name: "Home", path: "/" },
+      { name: "Templates", path: "/templates" },
+      { name: template.value.name, path: route.path },
+    ]),
+    buildFaqSchema(template.value.questions || []),
+    buildItemListSchema(
+      relatedTemplates.value.map((relatedTemplate) => ({
+        name: relatedTemplate.name,
+        path: `/templates/${relatedTemplate.slug}`,
+      })),
+      {
+        path: route.path,
+        name: `Related ${template.value.name} templates`,
+      },
+    ),
+  ])
+})
+
+useJsonLd("template-schema", templateSchema)
 </script>
 
 <style>

--- a/client/pages/templates/index.vue
+++ b/client/pages/templates/index.vue
@@ -31,10 +31,39 @@ defineRouteRules({
 })
 
 useOpnSeoMeta({
-  title: "Form Templates",
+  title: "Free Online Form Templates",
   description:
-    "Our collection of beautiful templates to create your own forms!",
+    "Browse free online form templates for contact forms, registrations, surveys, orders, feedback, applications, and more. Customize and publish with OpnForm.",
 })
 
-const { data: templates, isLoading: loading } = useTemplates().list()
+const { data: templates, isLoading: loading, suspense: templatesSuspense } = useTemplates().list()
+
+if (import.meta.server) {
+  await templatesSuspense().catch(() => null)
+}
+
+const templatesSchema = computed(() => buildSchemaGraph([
+  buildCollectionPageSchema({
+    name: "Free Online Form Templates",
+    description:
+      "Browse free online form templates for contact forms, registrations, surveys, orders, feedback, applications, and more. Customize and publish with OpnForm.",
+    path: "/templates",
+  }),
+  buildBreadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Templates", path: "/templates" },
+  ]),
+  buildItemListSchema(
+    (templates.value || []).map((template) => ({
+      name: template.name,
+      path: `/templates/${template.slug}`,
+    })),
+    {
+      path: "/templates",
+      name: "OpnForm form templates",
+    },
+  ),
+]))
+
+useJsonLd("templates-schema", templatesSchema)
 </script>

--- a/client/pages/templates/industries/[slug].vue
+++ b/client/pages/templates/industries/[slug].vue
@@ -62,7 +62,11 @@ const route = useRoute()
 const { list } = useTemplates()
 const { industries: industriesMap } = useTemplateMeta()
 
-const { data: allTemplates, isLoading: loading } = list()
+const { data: allTemplates, isLoading: loading, suspense: templatesSuspense } = list()
+
+if (import.meta.server) {
+  await templatesSuspense().catch(() => null)
+}
 
 const industry = computed(() => industriesMap.get(route.params.slug))
 
@@ -113,6 +117,35 @@ useHead({
     return titleChunk ? titleChunk : "Form Templates - OpnForm"
   },
 })
+
+const templateIndustrySchema = computed(() => {
+  if (!industry.value) return null
+
+  return buildSchemaGraph([
+    buildCollectionPageSchema({
+      name: industry.value.meta_title,
+      description: industry.value.meta_description,
+      path: `/templates/industries/${industry.value.slug}`,
+    }),
+    buildBreadcrumbSchema([
+      { name: "Home", path: "/" },
+      { name: "Templates", path: "/templates" },
+      { name: industry.value.name, path: `/templates/industries/${industry.value.slug}` },
+    ]),
+    buildItemListSchema(
+      templates.value.map((template) => ({
+        name: template.name,
+        path: `/templates/${template.slug}`,
+      })),
+      {
+        path: `/templates/industries/${industry.value.slug}`,
+        name: `${industry.value.name} templates`,
+      },
+    ),
+  ])
+})
+
+useJsonLd("template-industry-schema", templateIndustrySchema)
 </script>
 
 <style lang="scss">

--- a/client/pages/templates/types/[slug].vue
+++ b/client/pages/templates/types/[slug].vue
@@ -63,7 +63,11 @@ const route = useRoute()
 const { list } = useTemplates()
 const { types: typesMap } = useTemplateMeta()
 
-const { data: allTemplates, isLoading: loading } = list()
+const { data: allTemplates, isLoading: loading, suspense: templatesSuspense } = list()
+
+if (import.meta.server) {
+  await templatesSuspense().catch(() => null)
+}
 
 const type = computed(() => typesMap.get(route.params.slug))
 
@@ -114,6 +118,35 @@ useHead({
     return titleChunk ? titleChunk : "Form Templates - OpnForm"
   },
 })
+
+const templateTypeSchema = computed(() => {
+  if (!type.value) return null
+
+  return buildSchemaGraph([
+    buildCollectionPageSchema({
+      name: type.value.meta_title,
+      description: type.value.meta_description,
+      path: `/templates/types/${type.value.slug}`,
+    }),
+    buildBreadcrumbSchema([
+      { name: "Home", path: "/" },
+      { name: "Templates", path: "/templates" },
+      { name: type.value.name, path: `/templates/types/${type.value.slug}` },
+    ]),
+    buildItemListSchema(
+      templates.value.map((template) => ({
+        name: template.name,
+        path: `/templates/${template.slug}`,
+      })),
+      {
+        path: `/templates/types/${type.value.slug}`,
+        name: `${type.value.name} templates`,
+      },
+    ),
+  ])
+})
+
+useJsonLd("template-type-schema", templateTypeSchema)
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
## Summary
- add shared JSON-LD/schema helpers with safe script serialization
- add structured data across homepage, pricing, enterprise, comparison, templates, integrations, and feature pages
- render template ItemList schemas server-side when the templates API is available

## Notes
- This PR is intentionally based on `381a6-feature-page` so the diff contains only the schema work. The feature pages touched by this change do not exist on `main` yet.
- The previous accidental commit on PR #1168 was removed from that branch.

## Validation
- `npm run lint`
- `npm run build`
- direct JSON-LD serializer check with `</script>` payload
- SSR preview with mocked `/templates` API confirming `ItemList` on template pages