### PR TITLE
[codex] Fix self-hosted PDF editor and password form issues

### DIFF
--- a/client/components/open/pdf-editor/PdfZoneEditor.vue
+++ b/client/components/open/pdf-editor/PdfZoneEditor.vue
@@ -896,12 +896,12 @@ watch(lastAddedZoneId, async (zoneId) => {
   await nextTick()
   const pageEl = pageRefs.value[zone.page]
   if (pageEl) {
-    pageEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    pageEl.scrollIntoView({ behavior: 'auto', block: 'start' })
   }
   await nextTick()
   const zoneEl = zoneRefs.value[zoneId]
   if (zoneEl) {
-    zoneEl.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' })
+    zoneEl.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
   }
   pdfStore.clearLastAddedZone()
 })

--- a/client/pages/forms/[slug]/index.vue
+++ b/client/pages/forms/[slug]/index.vue
@@ -80,10 +80,12 @@ const onFormSubmitted = () => {
 }
 
 const passwordEntered = function (password) {
+  const usesHttps = import.meta.client && window.location.protocol === 'https:'
   const cookie = useCookie('password-' + slug, {
     maxAge: 60 * 60 * 7,
-    sameSite: 'none',
-    secure: true
+    // Secure cookies are rejected on plain HTTP self-hosted instances.
+    sameSite: usesHttps ? 'none' : 'lax',
+    secure: usesHttps
   })
   cookie.value = sha256(password)
   


### PR DESCRIPTION
## Summary

Fixes two self-hosted issues reproduced locally in Firefox:

- Keep newly added PDF template zones visible and draggable when the editor scrolls to a tall PDF page.
- Allow password-protected forms to unlock on plain-HTTP self-hosted instances by not forcing a `Secure` cookie outside HTTPS.

## Root Cause

### PDF editor zones

The add-zone watcher first centered the entire page with `scrollIntoView({ block: 'center' })`. On a page taller than the viewport, this could place the top of the PDF surface behind the app chrome, making a newly added top-left zone appear hidden/offscreen and impossible to drag.

The scroll now anchors the page at the start and only brings the zone into the nearest visible area.

### Password-protected forms

The public form page always created the password cookie with `SameSite=None` and `Secure`. Firefox rejects that cookie on plain HTTP non-localhost origins, which is a common self-hosted/internal deployment shape.

When the cookie is rejected, the password hash cannot be reused for the refetch. The API request then has no `form-password` header, the form remains protected, and the UI shows `Invalid password` even though the typed password is correct.

The cookie now keeps `SameSite=None` + `Secure` on HTTPS, and falls back to `SameSite=Lax` without `Secure` on HTTP.

## Impact

Self-hosted users can unlock protected forms on HTTP deployments, while HTTPS deployments keep the cross-site-compatible secure cookie behavior. PDF template zones added on uploaded/from-scratch templates remain reachable for editing.

## Validation

- `docker exec opnform-client npm run lint`
- `docker exec opnform-api vendor/bin/pest tests/Feature/Forms/FormPasswordTest.php`
- `git diff --check`

### Password E2E reproduction

Tested in Firefox on a local HTTP self-host-style origin: `http://localhost.localtest.me:8088`, with the API served under `/api`.

Old behavior reproduced the bug:

- Firefox rejected `password-password-e2e-form` because a non-HTTPS cookie was set as `Secure`.
- No password cookie was stored.
- The API refetch had no `form-password` header.
- The UI stayed protected and showed `Invalid password`.

Fixed behavior passed:

- Firefox stored `password-password-e2e-form` as `SameSite=Lax`, `secure=false`.
- The API refetch sent the expected SHA-256 `form-password` header for `password`.
- `/api/forms/password-e2e-form` returned `200`.
- `/api/forms/password-e2e-form/view` returned `200`.
- The form fields rendered after unlock.

### PDF editor validation

Manual Firefox validation on the local stack:

- Newly added PDF zone stays visible after creation.
- The zone can be dragged in the uploaded-template path.