### PR TITLE
ESC-891 = Refactor slider input handling and improve field option validations

### DIFF
--- a/client/components/forms/core/SliderInput.vue
+++ b/client/components/forms/core/SliderInput.vue
@@ -93,13 +93,14 @@ export default {
     },
     sliderLabelsList() {
       const midPoint = (this.maxSlider - this.minSlider) / 2 + this.minSlider
+      const formattedMid = Number.isInteger(midPoint) ? midPoint : parseFloat(midPoint.toFixed(2))
       const labels = [
         {
           label: `${this.minSlider}`,
           style: "flex items-center justify-start",
         },
         {
-          label: Math.floor(midPoint),
+          label: formattedMid,
           style: "flex items-center justify-center",
         },
         {

--- a/client/components/open/forms/BlockRenderer.vue
+++ b/client/components/open/forms/BlockRenderer.vue
@@ -317,9 +317,9 @@ const boundProps = computed(() => {
     inputProperties.maxScale = parseFloat(field.scale_max_value) ?? 5
     inputProperties.stepScale = parseFloat(field.scale_step_value) ?? 1
   } else if (field.type === 'slider') {
-    inputProperties.minSlider = parseInt(field.slider_min_value) ?? 0
-    inputProperties.maxSlider = parseInt(field.slider_max_value) ?? 50
-    inputProperties.stepSlider = parseInt(field.slider_step_value) ?? 5
+    inputProperties.minSlider = parseFloat(field.slider_min_value) ?? 0
+    inputProperties.maxSlider = parseFloat(field.slider_max_value) ?? 50
+    inputProperties.stepSlider = parseFloat(field.slider_step_value) ?? 5
   } else if (field.type === 'number' || (field.type === 'phone_number' && field.use_simple_text_input)) {
     inputProperties.pattern = '/d*'
   } else if (field.type === 'phone_number' && !field.use_simple_text_input) {

--- a/client/components/open/forms/fields/components/FieldOptions.vue
+++ b/client/components/open/forms/fields/components/FieldOptions.vue
@@ -199,7 +199,8 @@
       <text-input
         name="slider_step_value"
         native-type="number"
-        :min="1"
+        :min="0.01"
+        step="any"
         class="mt-4"
         :form="field"
         required


### PR DESCRIPTION
- Updated SliderInput.vue to format the midpoint label correctly, ensuring it displays two decimal places when necessary.
- Changed BlockRenderer.vue to parse slider values as floats instead of integers, enhancing precision for slider configurations.
- Adjusted FieldOptions.vue to set the minimum value for slider step input to 0.01 and allow any step value, improving user input flexibility.