### PR TITLE
fix: normalize public form favicon scheme

### DIFF
--- a/client/lib/forms/public-page-meta.js
+++ b/client/lib/forms/public-page-meta.js
@@ -1,0 +1,17 @@
+export function normalizePublicPageAssetUrl (assetUrl, pageUrl) {
+  if (!assetUrl || !pageUrl) return assetUrl
+
+  try {
+    const page = new URL(pageUrl)
+    const asset = new URL(assetUrl, page)
+
+    if (page.protocol === 'https:' && asset.protocol === 'http:' && asset.host === page.host) {
+      asset.protocol = 'https:'
+      return asset.toString()
+    }
+  } catch {
+    return assetUrl
+  }
+
+  return assetUrl
+}

--- a/client/pages/forms/[slug]/index.vue
+++ b/client/pages/forms/[slug]/index.vue
@@ -46,6 +46,7 @@ import {
   useDarkMode
 } from '~/lib/forms/public-page'
 import { FormMode } from "~/lib/forms/FormModeStrategy.js"
+import { normalizePublicPageAssetUrl } from '~/lib/forms/public-page-meta.js'
 import { formsApi } from '~/api'
 import { customDomainUsed } from '~/lib/utils.js'
 
@@ -54,6 +55,7 @@ const appStore = useAppStore()
 const darkMode = useDarkMode()
 const isIframe = useIsIframe()
 const slug = useRoute().params.slug
+const requestUrl = useRequestURL()
 const { t } = useI18n()
 const { performRedirect } = useSubdomainRedirect()
 
@@ -200,6 +202,10 @@ const pageMeta = computed(() => {
   return {}
 })
 
+const pageFaviconUrl = computed(() => {
+  return normalizePublicPageAssetUrl(pageMeta.value.page_favicon, requestUrl.href)
+})
+
 const getFontUrl = computed(() => {
   if(!form.value || !form.value.font_family) return null
   const family = form.value.font_family.replace(/ /g, '+')
@@ -214,19 +220,19 @@ const headLinks = computed(() => {
         href: getFontUrl.value
     })
   }
-  if (pageMeta.value.page_favicon) {
+  if (pageFaviconUrl.value) {
     links.push({
         rel: 'icon', type: 'image/x-icon',
-        href: pageMeta.value.page_favicon
+        href: pageFaviconUrl.value
     })
     links.push({
         rel: 'apple-touch-icon',
         type: 'image/png',
-        href: pageMeta.value.page_favicon
+        href: pageFaviconUrl.value
     })
     links.push({
       rel: 'shortcut icon',
-      href: pageMeta.value.page_favicon
+      href: pageFaviconUrl.value
     })
   }
   return links
@@ -302,7 +308,7 @@ useHead({
     return titleChunk ? `${titleChunk} - OpnForm` : 'OpnForm'
   },
   link: headLinks.value,
-  meta: pageMeta.value.page_favicon ? [
+  meta: pageFaviconUrl.value ? [
     {
       name: 'mobile-web-app-capable',
       content: 'yes'

--- a/client/test/unit/public-page-meta.test.ts
+++ b/client/test/unit/public-page-meta.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePublicPageAssetUrl } from '../../lib/forms/public-page-meta.js'
+
+describe('normalizePublicPageAssetUrl', () => {
+  it('upgrades same-host http assets when the page is https', () => {
+    expect(
+      normalizePublicPageAssetUrl(
+        'http://forms.example.com/forms/assets/favicon.png',
+        'https://forms.example.com/forms/demo'
+      )
+    ).toBe('https://forms.example.com/forms/assets/favicon.png')
+  })
+
+  it('keeps same-host http assets on http pages', () => {
+    expect(
+      normalizePublicPageAssetUrl(
+        'http://localhost/forms/assets/favicon.png',
+        'http://localhost/forms/demo'
+      )
+    ).toBe('http://localhost/forms/assets/favicon.png')
+  })
+
+  it('does not rewrite external http assets', () => {
+    expect(
+      normalizePublicPageAssetUrl(
+        'http://cdn.example.com/favicon.png',
+        'https://forms.example.com/forms/demo'
+      )
+    ).toBe('http://cdn.example.com/favicon.png')
+  })
+
+  it('leaves relative asset paths unchanged', () => {
+    expect(
+      normalizePublicPageAssetUrl(
+        '/forms/assets/favicon.png',
+        'https://forms.example.com/forms/demo'
+      )
+    ).toBe('/forms/assets/favicon.png')
+  })
+})


### PR DESCRIPTION
## Summary
- normalize same-host public form favicon URLs from `http://` to `https://` when the form page is served over HTTPS
- keep local HTTP/self-hosted pages and external favicon URLs unchanged
- add unit coverage for favicon URL normalization

## Verification
- `npm install`
- `npm test -- --run test/unit/public-page-meta.test.ts`
- `npx eslint "pages/forms/[slug]/index.vue" lib/forms/public-page-meta.js`
- `npm run build`
- `git diff --check`

Closes #1068.