### PR TITLE
[codex] Add modern PDF parser support

### DIFF
--- a/api/app/Service/Pdf/Compat/SetasignFpdiPdfParser/PdfParser/PdfParser.php
+++ b/api/app/Service/Pdf/Compat/SetasignFpdiPdfParser/PdfParser/PdfParser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace setasign\FpdiPdfParser\PdfParser;
+
+use App\Service\Pdf\Modern\ModernPdfParser;
+use setasign\Fpdi\PdfParser\StreamReader;
+
+class PdfParser extends ModernPdfParser
+{
+    /**
+     * @param array<string, mixed> $parserParams
+     */
+    public function __construct(StreamReader $streamReader, array $parserParams = [])
+    {
+        if ($parserParams !== []) {
+            // FPDI forwards params for commercial parser compatibility; OpnForm does not need extra parser options.
+            $parserParams = [];
+        }
+
+        parent::__construct($streamReader);
+    }
+}

--- a/api/app/Service/Pdf/Modern/ModernCrossReference.php
+++ b/api/app/Service/Pdf/Modern/ModernCrossReference.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace App\Service\Pdf\Modern;
+
+use setasign\Fpdi\PdfParser\CrossReference\CrossReference;
+use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use setasign\Fpdi\PdfParser\CrossReference\FixedReader;
+use setasign\Fpdi\PdfParser\CrossReference\ReaderInterface;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfIndirectObject;
+use setasign\Fpdi\PdfParser\Type\PdfName;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfType;
+use setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+class ModernCrossReference extends CrossReference
+{
+    private ObjectStreamResolver $objectStreamResolver;
+
+    private ?PdfDictionary $primaryTrailer = null;
+
+    /**
+     * @var array<int, true>
+     */
+    private array $hybridXrefStreamOffsets = [];
+
+    public function __construct(PdfParser $parser, $fileHeaderOffset = 0)
+    {
+        $parser->getTokenizer()->clearStack();
+
+        $this->parser = $parser;
+        $this->fileHeaderOffset = $fileHeaderOffset;
+        $this->objectStreamResolver = new ObjectStreamResolver($parser);
+
+        $offset = $this->findStartXref();
+        $reader = null;
+
+        while ($offset != false) {
+            try {
+                $reader = $this->readXref($offset + $this->fileHeaderOffset);
+            } catch (CrossReferenceException $e) {
+                if ($e->getCode() === CrossReferenceException::INVALID_DATA && $this->fileHeaderOffset !== 0) {
+                    $this->fileHeaderOffset = 0;
+                    $reader = $this->readXref($offset);
+                } else {
+                    throw $e;
+                }
+            }
+
+            $trailer = $reader->getTrailer();
+            $this->checkForEncryption($trailer);
+            $this->primaryTrailer ??= $trailer;
+
+            $hybridReader = $this->readHybridXrefStream($trailer);
+            if ($hybridReader !== null) {
+                $this->readers[] = $hybridReader;
+            }
+
+            $this->readers[] = $reader;
+
+            if (isset($trailer->value['Prev'])) {
+                $offset = $trailer->value['Prev']->value;
+            } else {
+                $offset = false;
+            }
+        }
+
+        if ($reader instanceof FixedReader) {
+            $reader->fixFaultySubSectionShift();
+        }
+
+        if ($reader === null) {
+            throw new CrossReferenceException('No cross-reference found.', CrossReferenceException::NO_XREF_FOUND);
+        }
+    }
+
+    public function getTrailer()
+    {
+        return $this->primaryTrailer ?? parent::getTrailer();
+    }
+
+    public function getIndirectObject($objectNumber)
+    {
+        $objectNumber = (int) $objectNumber;
+        $location = $this->findLocationFor($objectNumber);
+
+        if ($location === null) {
+            throw new CrossReferenceException(
+                sprintf('Object (id:%s) not found.', $objectNumber),
+                CrossReferenceException::OBJECT_NOT_FOUND,
+            );
+        }
+
+        if ($location['type'] === 'compressed') {
+            return $this->objectStreamResolver->resolve(
+                $objectNumber,
+                $location['object_stream_number'],
+                $location['index'],
+            );
+        }
+
+        return $this->readIndirectObjectAtOffset($objectNumber, $location['offset']);
+    }
+
+    protected function initReaderInstance($initValue)
+    {
+        if ($initValue instanceof PdfIndirectObject) {
+            try {
+                $stream = PdfStream::ensure($initValue->value);
+            } catch (PdfTypeException $e) {
+                throw new CrossReferenceException(
+                    'Invalid object type at xref reference offset.',
+                    CrossReferenceException::INVALID_DATA,
+                    $e,
+                );
+            }
+
+            $type = PdfDictionary::get($stream->value, 'Type');
+            if (!$type instanceof PdfName || $type->value !== 'XRef') {
+                throw new CrossReferenceException(
+                    'The xref position points to an incorrect object type.',
+                    CrossReferenceException::INVALID_DATA,
+                );
+            }
+
+            $this->checkForEncryption($stream->value);
+
+            return new XrefStreamReader($this->parser, $stream);
+        }
+
+        return parent::initReaderInstance($initValue);
+    }
+
+    private function readHybridXrefStream(PdfDictionary $trailer): ?ReaderInterface
+    {
+        if (!isset($trailer->value['XRefStm'])) {
+            return null;
+        }
+
+        $xrefStreamOffset = $this->numericValue($trailer->value['XRefStm']);
+        if (isset($this->hybridXrefStreamOffsets[$xrefStreamOffset])) {
+            return null;
+        }
+
+        $this->hybridXrefStreamOffsets[$xrefStreamOffset] = true;
+
+        try {
+            return $this->readXref($xrefStreamOffset + $this->fileHeaderOffset);
+        } catch (CrossReferenceException $e) {
+            if ($e->getCode() === CrossReferenceException::INVALID_DATA && $this->fileHeaderOffset !== 0) {
+                return $this->readXref($xrefStreamOffset);
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{type:string,offset:int}|array{type:string,object_stream_number:int,index:int}|null
+     */
+    private function findLocationFor(int $objectNumber): ?array
+    {
+        foreach ($this->getReaders() as $reader) {
+            if ($reader instanceof XrefStreamReader) {
+                if ($reader->hasOffsetFor($objectNumber)) {
+                    return [
+                        'type' => 'offset',
+                        'offset' => $reader->getOffsetFor($objectNumber),
+                    ];
+                }
+
+                $compressedEntry = $reader->getCompressedEntryFor($objectNumber);
+                if ($compressedEntry !== null) {
+                    return [
+                        'type' => 'compressed',
+                        'object_stream_number' => $compressedEntry['object_stream_number'],
+                        'index' => $compressedEntry['index'],
+                    ];
+                }
+
+                if ($reader->hasFreeEntryFor($objectNumber)) {
+                    return null;
+                }
+
+                continue;
+            }
+
+            $offset = $reader->getOffsetFor($objectNumber);
+            if ($offset !== false) {
+                return [
+                    'type' => 'offset',
+                    'offset' => $offset,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    private function readIndirectObjectAtOffset(int $objectNumber, int $offset): PdfIndirectObject
+    {
+        $parser = $this->parser;
+        $parser->getTokenizer()->clearStack();
+        $parser->getStreamReader()->reset($offset + $this->fileHeaderOffset);
+
+        try {
+            $object = $parser->readValue(null, PdfIndirectObject::class);
+        } catch (PdfTypeException $e) {
+            throw new CrossReferenceException(
+                sprintf('Object (id:%s) not found at location (%s).', $objectNumber, $offset),
+                CrossReferenceException::OBJECT_NOT_FOUND,
+                $e,
+            );
+        }
+
+        if (!$object instanceof PdfIndirectObject || $object->objectNumber !== $objectNumber) {
+            $actualObjectNumber = $object instanceof PdfIndirectObject ? $object->objectNumber : 'unknown';
+
+            throw new CrossReferenceException(
+                sprintf('Wrong object found, got %s while %s was expected.', $actualObjectNumber, $objectNumber),
+                CrossReferenceException::OBJECT_NOT_FOUND,
+            );
+        }
+
+        return $object;
+    }
+
+    private function numericValue($value): int
+    {
+        $resolved = PdfType::resolve($value, $this->parser);
+
+        if (!$resolved instanceof PdfNumeric) {
+            throw new CrossReferenceException(
+                'Numeric value expected in cross-reference trailer.',
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        return (int) $resolved->value;
+    }
+}

--- a/api/app/Service/Pdf/Modern/ModernPdfParser.php
+++ b/api/app/Service/Pdf/Modern/ModernPdfParser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Service\Pdf\Modern;
+
+use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\PdfParserException;
+
+class ModernPdfParser extends PdfParser
+{
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfParserException
+     */
+    public function getCrossReference()
+    {
+        if ($this->xref === null) {
+            $this->xref = new ModernCrossReference($this, $this->resolveFileHeader());
+        }
+
+        return $this->xref;
+    }
+}

--- a/api/app/Service/Pdf/Modern/ModernPdfStreamDecoder.php
+++ b/api/app/Service/Pdf/Modern/ModernPdfStreamDecoder.php
@@ -1,0 +1,375 @@
+<?php
+
+namespace App\Service\Pdf\Modern;
+
+use setasign\Fpdi\PdfParser\Filter\Ascii85;
+use setasign\Fpdi\PdfParser\Filter\AsciiHex;
+use setasign\Fpdi\PdfParser\Filter\FilterException;
+use setasign\Fpdi\PdfParser\Filter\Flate;
+use setasign\Fpdi\PdfParser\Filter\Lzw;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\Type\PdfArray;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfIndirectObject;
+use setasign\Fpdi\PdfParser\Type\PdfIndirectObjectReference;
+use setasign\Fpdi\PdfParser\Type\PdfName;
+use setasign\Fpdi\PdfParser\Type\PdfNull;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfType;
+
+class ModernPdfStreamDecoder
+{
+    public static function decode(PdfStream $stream, PdfParser $parser, bool $resolveIndirectMetadata = true): string
+    {
+        $data = $stream->getStream();
+        $filters = self::filters($stream, $parser, $resolveIndirectMetadata);
+
+        if ($filters === []) {
+            return $data;
+        }
+
+        $decodeParams = self::decodeParams($stream, $parser, $resolveIndirectMetadata);
+
+        foreach ($filters as $key => $filter) {
+            $decodeParam = $decodeParams[$key] ?? null;
+
+            $data = match ($filter->value) {
+                'FlateDecode', 'Fl' => (new Flate())->decode($data),
+                'LZWDecode', 'LZW' => (new Lzw())->decode($data),
+                'ASCII85Decode', 'A85' => (new Ascii85())->decode($data),
+                'ASCIIHexDecode', 'AHx' => (new AsciiHex())->decode($data),
+                'Crypt' => self::decodeCrypt($decodeParam, $data),
+                default => throw new FilterException(
+                    sprintf('Unsupported filter "%s".', $filter->value),
+                    FilterException::UNSUPPORTED_FILTER,
+                ),
+            };
+
+            if ($decodeParam instanceof PdfDictionary) {
+                $data = self::decodePredictor($data, $decodeParam, $parser);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<int, PdfName>
+     */
+    private static function filters(PdfStream $stream, PdfParser $parser, bool $resolveIndirectMetadata): array
+    {
+        $filters = PdfDictionary::get($stream->value, 'Filter');
+        if ($resolveIndirectMetadata) {
+            $filters = PdfType::resolve($filters, $parser);
+        }
+
+        if ($filters instanceof PdfNull) {
+            return [];
+        }
+
+        if ($filters instanceof PdfName) {
+            return [$filters];
+        }
+
+        if (self::isIndirect($filters)) {
+            throw new FilterException(
+                'XRef stream filter metadata must use direct objects.',
+                FilterException::UNSUPPORTED_FILTER,
+            );
+        }
+
+        if (!$filters instanceof PdfArray) {
+            throw new FilterException('PDF stream filter must be a name or array.', FilterException::UNSUPPORTED_FILTER);
+        }
+
+        $resolved = [];
+
+        foreach ($filters->value as $filter) {
+            if ($resolveIndirectMetadata) {
+                $filter = PdfType::resolve($filter, $parser);
+            }
+
+            if ($filter instanceof PdfNull) {
+                continue;
+            }
+
+            if (self::isIndirect($filter)) {
+                throw new FilterException(
+                    'XRef stream filter metadata must use direct objects.',
+                    FilterException::UNSUPPORTED_FILTER,
+                );
+            }
+
+            if (!$filter instanceof PdfName) {
+                throw new FilterException(
+                    'PDF stream filter array must contain only names.',
+                    FilterException::UNSUPPORTED_FILTER,
+                );
+            }
+
+            $resolved[] = $filter;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<int, PdfDictionary|null>
+     */
+    private static function decodeParams(PdfStream $stream, PdfParser $parser, bool $resolveIndirectMetadata): array
+    {
+        $decodeParams = PdfDictionary::get($stream->value, 'DecodeParms');
+        if ($resolveIndirectMetadata) {
+            $decodeParams = PdfType::resolve($decodeParams, $parser);
+        }
+
+        if ($decodeParams instanceof PdfNull) {
+            return [];
+        }
+
+        if ($decodeParams instanceof PdfDictionary) {
+            return [$decodeParams];
+        }
+
+        if (self::isIndirect($decodeParams)) {
+            throw new FilterException(
+                'XRef stream DecodeParms metadata must use direct objects.',
+                FilterException::UNSUPPORTED_FILTER,
+            );
+        }
+
+        if (!$decodeParams instanceof PdfArray) {
+            throw new FilterException(
+                'PDF stream DecodeParms must be a dictionary, array, or null.',
+                FilterException::UNSUPPORTED_FILTER,
+            );
+        }
+
+        $resolved = [];
+
+        foreach ($decodeParams->value as $decodeParam) {
+            if ($resolveIndirectMetadata) {
+                $decodeParam = PdfType::resolve($decodeParam, $parser);
+            }
+
+            if ($decodeParam instanceof PdfNull) {
+                $resolved[] = null;
+                continue;
+            }
+
+            if (self::isIndirect($decodeParam)) {
+                throw new FilterException(
+                    'XRef stream DecodeParms metadata must use direct objects.',
+                    FilterException::UNSUPPORTED_FILTER,
+                );
+            }
+
+            if (!$decodeParam instanceof PdfDictionary) {
+                throw new FilterException(
+                    'PDF stream DecodeParms array must contain only dictionaries or null values.',
+                    FilterException::UNSUPPORTED_FILTER,
+                );
+            }
+
+            $resolved[] = $decodeParam;
+        }
+
+        return $resolved;
+    }
+
+    private static function isIndirect(PdfType $value): bool
+    {
+        return $value instanceof PdfIndirectObjectReference || $value instanceof PdfIndirectObject;
+    }
+
+    private static function decodeCrypt(?PdfDictionary $decodeParam, string $data): string
+    {
+        if (!$decodeParam instanceof PdfDictionary) {
+            return $data;
+        }
+
+        $name = PdfDictionary::get($decodeParam, 'Name');
+        if ($name instanceof PdfName && $name->value === 'Identity') {
+            return $data;
+        }
+
+        throw new FilterException(
+            'Support for Crypt filters other than "Identity" is not implemented.',
+            FilterException::UNSUPPORTED_FILTER,
+        );
+    }
+
+    private static function decodePredictor(string $data, PdfDictionary $decodeParam, PdfParser $parser): string
+    {
+        $predictor = self::numericDecodeParam($decodeParam, 'Predictor', 1, $parser);
+
+        if ($predictor === 1 || $data === '') {
+            return $data;
+        }
+
+        $colors = self::numericDecodeParam($decodeParam, 'Colors', 1, $parser);
+        $bitsPerComponent = self::numericDecodeParam($decodeParam, 'BitsPerComponent', 8, $parser);
+        $columns = self::numericDecodeParam($decodeParam, 'Columns', 1, $parser);
+
+        if ($columns <= 0 || $colors <= 0 || $bitsPerComponent <= 0) {
+            throw new FilterException('Invalid predictor decode parameters.', FilterException::UNSUPPORTED_FILTER);
+        }
+
+        if ($predictor === 2) {
+            return self::decodeTiffPredictor($data, $colors, $bitsPerComponent, $columns);
+        }
+
+        if ($predictor >= 10 && $predictor <= 15) {
+            return self::decodePngPredictor($data, $colors, $bitsPerComponent, $columns);
+        }
+
+        throw new FilterException(
+            sprintf('Unsupported predictor "%s".', $predictor),
+            FilterException::UNSUPPORTED_FILTER,
+        );
+    }
+
+    private static function decodeTiffPredictor(
+        string $data,
+        int $colors,
+        int $bitsPerComponent,
+        int $columns,
+    ): string {
+        if ($bitsPerComponent !== 8) {
+            throw new FilterException(
+                'TIFF predictors with bits per component other than 8 are not implemented.',
+                FilterException::NOT_IMPLEMENTED,
+            );
+        }
+
+        $rowLength = self::rowLength($colors, $bitsPerComponent, $columns);
+        $bytesPerPixel = self::bytesPerPixel($colors, $bitsPerComponent);
+        $decoded = '';
+
+        for ($offset = 0, $length = strlen($data); $offset < $length; $offset += $rowLength) {
+            $row = substr($data, $offset, $rowLength);
+            $rowBytes = strlen($row);
+
+            for ($i = $bytesPerPixel; $i < $rowBytes; $i++) {
+                $row[$i] = chr((ord($row[$i]) + ord($row[$i - $bytesPerPixel])) & 0xff);
+            }
+
+            $decoded .= $row;
+        }
+
+        return $decoded;
+    }
+
+    private static function decodePngPredictor(
+        string $data,
+        int $colors,
+        int $bitsPerComponent,
+        int $columns,
+    ): string {
+        if (!in_array($bitsPerComponent, [1, 2, 4, 8, 16], true)) {
+            throw new FilterException(
+                sprintf('Unsupported PNG predictor bits per component "%s".', $bitsPerComponent),
+                FilterException::UNSUPPORTED_FILTER,
+            );
+        }
+
+        $rowLength = self::rowLength($colors, $bitsPerComponent, $columns);
+        $incomingRowLength = $rowLength + 1;
+        $remainder = strlen($data) % $incomingRowLength;
+        if ($remainder !== 0) {
+            $data .= str_repeat("\0", $incomingRowLength - $remainder);
+        }
+
+        $bytesPerPixel = self::bytesPerPixel($colors, $bitsPerComponent);
+        $decoded = '';
+        $previousRow = str_repeat("\0", $rowLength);
+
+        for ($offset = 0, $length = strlen($data); $offset < $length; $offset += $incomingRowLength) {
+            $filterType = ord($data[$offset]);
+            $row = substr($data, $offset + 1, $rowLength);
+            $decodedRow = '';
+
+            for ($i = 0; $i < $rowLength; $i++) {
+                $raw = ord($row[$i]);
+                $left = $i >= $bytesPerPixel ? ord($decodedRow[$i - $bytesPerPixel]) : 0;
+                $up = ord($previousRow[$i]);
+                $upperLeft = $i >= $bytesPerPixel ? ord($previousRow[$i - $bytesPerPixel]) : 0;
+
+                $decodedRow .= chr(($raw + self::pngPredictorValue($filterType, $left, $up, $upperLeft)) & 0xff);
+            }
+
+            $decoded .= $decodedRow;
+            $previousRow = $decodedRow;
+        }
+
+        return $decoded;
+    }
+
+    private static function pngPredictorValue(int $filterType, int $left, int $up, int $upperLeft): int
+    {
+        return match ($filterType) {
+            0 => 0,
+            1 => $left,
+            2 => $up,
+            3 => intdiv($left + $up, 2),
+            4 => self::paeth($left, $up, $upperLeft),
+            default => throw new FilterException(
+                sprintf('Unsupported PNG predictor row filter "%s".', $filterType),
+                FilterException::UNSUPPORTED_FILTER,
+            ),
+        };
+    }
+
+    private static function paeth(int $left, int $up, int $upperLeft): int
+    {
+        $p = $left + $up - $upperLeft;
+        $pa = abs($p - $left);
+        $pb = abs($p - $up);
+        $pc = abs($p - $upperLeft);
+
+        if ($pa <= $pb && $pa <= $pc) {
+            return $left;
+        }
+
+        if ($pb <= $pc) {
+            return $up;
+        }
+
+        return $upperLeft;
+    }
+
+    private static function numericDecodeParam(
+        PdfDictionary $dictionary,
+        string $key,
+        int $default,
+        PdfParser $parser,
+    ): int {
+        $value = PdfDictionary::get($dictionary, $key, PdfNumeric::create($default));
+
+        if ($value instanceof PdfNull) {
+            return $default;
+        }
+
+        $resolved = PdfType::resolve($value, $parser);
+
+        if (!$resolved instanceof PdfNumeric) {
+            throw new FilterException(
+                sprintf('Numeric predictor decode parameter "%s" expected.', $key),
+                FilterException::UNSUPPORTED_FILTER,
+            );
+        }
+
+        return (int) $resolved->value;
+    }
+
+    private static function rowLength(int $colors, int $bitsPerComponent, int $columns): int
+    {
+        return max(1, (int) ceil($colors * $columns * $bitsPerComponent / 8));
+    }
+
+    private static function bytesPerPixel(int $colors, int $bitsPerComponent): int
+    {
+        return max(1, (int) ceil($colors * $bitsPerComponent / 8));
+    }
+}

--- a/api/app/Service/Pdf/Modern/ObjectStreamResolver.php
+++ b/api/app/Service/Pdf/Modern/ObjectStreamResolver.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Service\Pdf\Modern;
+
+use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\StreamReader;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfIndirectObject;
+use setasign\Fpdi\PdfParser\Type\PdfName;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfType;
+use setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+class ObjectStreamResolver
+{
+    /**
+     * @var array<int, array<int, PdfIndirectObject>>
+     */
+    private array $objectsByStream = [];
+
+    public function __construct(private readonly PdfParser $parser)
+    {
+    }
+
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    public function resolve(int $objectNumber, int $objectStreamNumber, int $objectIndex): PdfIndirectObject
+    {
+        $objects = $this->objectsByStream[$objectStreamNumber] ??= $this->readObjectStream($objectStreamNumber);
+
+        if (isset($objects[$objectNumber])) {
+            return $objects[$objectNumber];
+        }
+
+        throw new CrossReferenceException(
+            sprintf(
+                'Object (id:%s) not found in object stream (id:%s, index:%s).',
+                $objectNumber,
+                $objectStreamNumber,
+                $objectIndex,
+            ),
+            CrossReferenceException::OBJECT_NOT_FOUND,
+        );
+    }
+
+    /**
+     * @return array<int, PdfIndirectObject>
+     *
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function readObjectStream(int $objectStreamNumber): array
+    {
+        $object = $this->parser->getIndirectObject($objectStreamNumber, true);
+        $stream = PdfStream::ensure($object->value);
+        $type = PdfDictionary::get($stream->value, 'Type');
+
+        if (!$type instanceof PdfName || $type->value !== 'ObjStm') {
+            throw new CrossReferenceException(
+                sprintf('Object (id:%s) is not an object stream.', $objectStreamNumber),
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        $objectCount = $this->numericValue(PdfDictionary::get($stream->value, 'N'));
+        $firstObjectOffset = $this->numericValue(PdfDictionary::get($stream->value, 'First'));
+        $data = ModernPdfStreamDecoder::decode($stream, $this->parser);
+
+        if ($firstObjectOffset < 0 || $firstObjectOffset > strlen($data)) {
+            throw new CrossReferenceException(
+                sprintf('Object stream (id:%s) has an invalid first object offset.', $objectStreamNumber),
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        $pairs = $this->readObjectTable(substr($data, 0, $firstObjectOffset), $objectCount, $objectStreamNumber);
+        $objects = [];
+
+        foreach ($pairs as $index => ['number' => $number, 'offset' => $relativeOffset]) {
+            $nextOffset = $pairs[$index + 1]['offset'] ?? (strlen($data) - $firstObjectOffset);
+            $length = $nextOffset - $relativeOffset;
+
+            if ($relativeOffset < 0 || $length < 0) {
+                throw new CrossReferenceException(
+                    sprintf('Object stream (id:%s) contains invalid object offsets.', $objectStreamNumber),
+                    CrossReferenceException::INVALID_DATA,
+                );
+            }
+
+            $slice = substr($data, $firstObjectOffset + $relativeOffset, $length);
+            $valueParser = new ModernPdfParser(StreamReader::createByString($slice));
+            $value = $valueParser->readValue();
+
+            if (!$value instanceof PdfType) {
+                throw new CrossReferenceException(
+                    sprintf('Unable to parse object (id:%s) from object stream (id:%s).', $number, $objectStreamNumber),
+                    CrossReferenceException::INVALID_DATA,
+                );
+            }
+
+            $objects[$number] = PdfIndirectObject::create($number, 0, $value);
+        }
+
+        return $objects;
+    }
+
+    /**
+     * @return array<int, array{number:int,offset:int}>
+     *
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function readObjectTable(string $header, int $objectCount, int $objectStreamNumber): array
+    {
+        $parser = new ModernPdfParser(StreamReader::createByString($header));
+        $pairs = [];
+
+        for ($i = 0; $i < $objectCount; $i++) {
+            $number = $parser->readValue(null, PdfNumeric::class);
+            $offset = $parser->readValue(null, PdfNumeric::class);
+
+            if (!$number instanceof PdfNumeric || !$offset instanceof PdfNumeric) {
+                throw new CrossReferenceException(
+                    sprintf('Object stream (id:%s) has an invalid object table.', $objectStreamNumber),
+                    CrossReferenceException::INVALID_DATA,
+                );
+            }
+
+            $pairs[] = [
+                'number' => (int) $number->value,
+                'offset' => (int) $offset->value,
+            ];
+        }
+
+        if ($pairs === [] && $objectCount > 0) {
+            throw new CrossReferenceException(
+                sprintf('Object stream (id:%s) has an invalid object table.', $objectStreamNumber),
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function numericValue(PdfType $value): int
+    {
+        $resolved = PdfType::resolve($value, $this->parser);
+
+        if (!$resolved instanceof PdfNumeric) {
+            throw new CrossReferenceException(
+                'Numeric value expected in object stream.',
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        return (int) $resolved->value;
+    }
+}

--- a/api/app/Service/Pdf/Modern/XrefStreamReader.php
+++ b/api/app/Service/Pdf/Modern/XrefStreamReader.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Service\Pdf\Modern;
+
+use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use setasign\Fpdi\PdfParser\CrossReference\ReaderInterface;
+use setasign\Fpdi\PdfParser\PdfParser;
+use setasign\Fpdi\PdfParser\Type\PdfArray;
+use setasign\Fpdi\PdfParser\Type\PdfDictionary;
+use setasign\Fpdi\PdfParser\Type\PdfNumeric;
+use setasign\Fpdi\PdfParser\Type\PdfStream;
+use setasign\Fpdi\PdfParser\Type\PdfType;
+use setasign\Fpdi\PdfParser\Type\PdfTypeException;
+
+class XrefStreamReader implements ReaderInterface
+{
+    private PdfDictionary $trailer;
+
+    /**
+     * @var array<int, int>
+     */
+    private array $offsets = [];
+
+    /**
+     * @var array<int, array{object_stream_number:int,index:int}>
+     */
+    private array $compressedEntries = [];
+
+    /**
+     * @var array<int, true>
+     */
+    private array $freeEntries = [];
+
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    public function __construct(
+        private readonly PdfParser $parser,
+        private readonly PdfStream $stream,
+    ) {
+        $this->trailer = $stream->value;
+        $this->read();
+    }
+
+    public function getOffsetFor($objectNumber)
+    {
+        return $this->offsets[(int) $objectNumber] ?? false;
+    }
+
+    public function getTrailer()
+    {
+        return $this->trailer;
+    }
+
+    public function hasOffsetFor(int $objectNumber): bool
+    {
+        return array_key_exists($objectNumber, $this->offsets);
+    }
+
+    /**
+     * @return array{object_stream_number:int,index:int}|null
+     */
+    public function getCompressedEntryFor(int $objectNumber): ?array
+    {
+        return $this->compressedEntries[$objectNumber] ?? null;
+    }
+
+    public function hasFreeEntryFor(int $objectNumber): bool
+    {
+        return isset($this->freeEntries[$objectNumber]);
+    }
+
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function read(): void
+    {
+        $widths = $this->readWidths();
+        $entryLength = array_sum($widths);
+
+        if ($entryLength <= 0) {
+            throw new CrossReferenceException(
+                'Invalid xref stream entry width.',
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        $index = $this->readIndex();
+        $data = ModernPdfStreamDecoder::decode($this->stream, $this->parser, resolveIndirectMetadata: false);
+        $position = 0;
+
+        for ($i = 0, $count = count($index); $i < $count; $i += 2) {
+            $objectNumber = $index[$i];
+            $objectCount = $index[$i + 1];
+
+            for ($entry = 0; $entry < $objectCount; $entry++, $objectNumber++) {
+                if ($position + $entryLength > strlen($data)) {
+                    throw new CrossReferenceException(
+                        'Unexpected end of xref stream.',
+                        CrossReferenceException::UNEXPECTED_END,
+                    );
+                }
+
+                $type = $widths[0] === 0 ? 1 : $this->readInteger($data, $position, $widths[0]);
+                $field2 = $this->readInteger($data, $position, $widths[1]);
+                $field3 = $this->readInteger($data, $position, $widths[2]);
+
+                match ($type) {
+                    0 => $this->freeEntries[$objectNumber] = true,
+                    1 => $this->offsets[$objectNumber] = $field2,
+                    2 => $this->compressedEntries[$objectNumber] = [
+                        'object_stream_number' => $field2,
+                        'index' => $field3,
+                    ],
+                    default => null,
+                };
+            }
+        }
+    }
+
+    /**
+     * @return array{0:int,1:int,2:int}
+     *
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function readWidths(): array
+    {
+        $widths = PdfArray::ensure(PdfDictionary::get($this->trailer, 'W'), 3)->value;
+
+        return [
+            $this->numericValue($widths[0]),
+            $this->numericValue($widths[1]),
+            $this->numericValue($widths[2]),
+        ];
+    }
+
+    /**
+     * @return array<int, int>
+     *
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function readIndex(): array
+    {
+        $index = PdfDictionary::get($this->trailer, 'Index');
+
+        if ($index instanceof PdfArray) {
+            $values = [];
+
+            foreach ($index->value as $value) {
+                $values[] = $this->numericValue($value);
+            }
+
+            if (count($values) % 2 !== 0) {
+                throw new CrossReferenceException(
+                    'Invalid xref stream index.',
+                    CrossReferenceException::INVALID_DATA,
+                );
+            }
+
+            return $values;
+        }
+
+        return [0, $this->numericValue(PdfDictionary::get($this->trailer, 'Size'))];
+    }
+
+    /**
+     * @throws CrossReferenceException
+     * @throws PdfTypeException
+     */
+    private function numericValue(PdfType $value): int
+    {
+        $resolved = PdfType::resolve($value, $this->parser);
+
+        if (!$resolved instanceof PdfNumeric) {
+            throw new CrossReferenceException(
+                'Numeric value expected in xref stream.',
+                CrossReferenceException::INVALID_DATA,
+            );
+        }
+
+        return (int) $resolved->value;
+    }
+
+    private function readInteger(string $data, int &$position, int $width): int
+    {
+        $value = 0;
+
+        for ($i = 0; $i < $width; $i++, $position++) {
+            $value = ($value << 8) + ord($data[$position]);
+        }
+
+        return $value;
+    }
+}

--- a/api/app/Service/Pdf/PdfGeneratorService.php
+++ b/api/app/Service/Pdf/PdfGeneratorService.php
@@ -11,7 +11,7 @@ use App\Service\Forms\FormSubmissionFormatter;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use setasign\Fpdi\Fpdi;
-use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use Throwable;
 
 class PdfGeneratorService
 {
@@ -71,7 +71,7 @@ class PdfGeneratorService
             // Create FPDI instance
             $pdf = new Fpdi();
             $sourcePageCount = $pdf->setSourceFile($tempFile);
-        } catch (CrossReferenceException $e) {
+        } catch (Throwable $e) {
             @unlink($tempFile);
             throw new PdfNotSupportedException();
         }
@@ -101,16 +101,21 @@ class PdfGeneratorService
             $sourcePage = isset($entry['source_page']) ? (int) $entry['source_page'] : null;
             $pageId = $entry['id'] ?? null;
 
-            if ($type === 'source' && $sourcePage !== null && $sourcePage >= 1 && $sourcePage <= $sourcePageCount) {
-                $templateId = $pdf->importPage($sourcePage);
-                $size = $pdf->getTemplateSize($templateId);
-                $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
-                $pdf->useTemplate($templateId, 0, 0, $size['width'], $size['height']);
-            } else {
-                // Blank pages inherit dimensions from first source page.
-                $templateId = $pdf->importPage(1);
-                $size = $pdf->getTemplateSize($templateId);
-                $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+            try {
+                if ($type === 'source' && $sourcePage !== null && $sourcePage >= 1 && $sourcePage <= $sourcePageCount) {
+                    $templateId = $pdf->importPage($sourcePage);
+                    $size = $pdf->getTemplateSize($templateId);
+                    $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                    $pdf->useTemplate($templateId, 0, 0, $size['width'], $size['height']);
+                } else {
+                    // Blank pages inherit dimensions from first source page.
+                    $templateId = $pdf->importPage(1);
+                    $size = $pdf->getTemplateSize($templateId);
+                    $pdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                }
+            } catch (Throwable $e) {
+                @unlink($tempFile);
+                throw new PdfNotSupportedException();
             }
 
             if (is_string($pageId) && isset($zonesByPage[$pageId])) {

--- a/api/app/Service/Pdf/PdfRichTextRenderer.php
+++ b/api/app/Service/Pdf/PdfRichTextRenderer.php
@@ -92,7 +92,8 @@ class PdfRichTextRenderer
                     continue;
                 }
 
-                $tokenWidth = $pdf->GetStringWidth($token);
+                $encodedToken = $this->encodeTextForFpdf($token);
+                $tokenWidth = $pdf->GetStringWidth($encodedToken);
                 if ($currentLineX > $x && $currentLineX + $tokenWidth > $x + $width) {
                     if (!$this->moveToNextLine($pdf, $lineHeight, $x, $currentLineX, $zoneBottom)) {
                         return;
@@ -107,10 +108,21 @@ class PdfRichTextRenderer
                 }
 
                 $pdf->SetX($currentLineX);
-                $pdf->Cell($tokenWidth, $lineHeight, $token, 0, 0, '', false);
+                $pdf->Cell($tokenWidth, $lineHeight, $encodedToken, 0, 0, '', false);
                 $currentLineX += $tokenWidth;
             }
         }
+    }
+
+    private function encodeTextForFpdf(string $text): string
+    {
+        if (function_exists('mb_convert_encoding')) {
+            return mb_convert_encoding($text, 'Windows-1252', 'UTF-8');
+        }
+
+        $encoded = iconv('UTF-8', 'Windows-1252//TRANSLIT', $text);
+
+        return $encoded === false ? '' : $encoded;
     }
 
     private function moveToNextLine(Fpdi $pdf, float $lineHeight, float $x, float &$currentLineX, float $zoneBottom): bool

--- a/api/app/Service/Pdf/PdfTemplateRebuildService.php
+++ b/api/app/Service/Pdf/PdfTemplateRebuildService.php
@@ -5,7 +5,7 @@ namespace App\Service\Pdf;
 use App\Exceptions\PdfNotSupportedException;
 use Illuminate\Support\Facades\Storage;
 use setasign\Fpdi\Fpdi;
-use setasign\Fpdi\PdfParser\CrossReference\CrossReferenceException;
+use Throwable;
 
 /**
  * Rebuilds template PDF files from explicit logical page manifests.
@@ -54,7 +54,9 @@ class PdfTemplateRebuildService
             }
 
             return $pdf->Output('S');
-        } catch (CrossReferenceException $e) {
+        } catch (PdfNotSupportedException $e) {
+            throw $e;
+        } catch (Throwable $e) {
             throw new PdfNotSupportedException();
         } finally {
             @unlink($tempFile);

--- a/api/composer.json
+++ b/api/composer.json
@@ -104,7 +104,8 @@
         "psr-4": {
           "App\\": "app/",
           "Database\\Factories\\": "database/factories/",
-          "Database\\Seeders\\": "database/seeders/"
+          "Database\\Seeders\\": "database/seeders/",
+          "setasign\\FpdiPdfParser\\": "app/Service/Pdf/Compat/SetasignFpdiPdfParser/"
         },
         "files": [
           "app/helpers.php"

--- a/api/tests/Feature/Integrations/Pdf/ModernPdfParserTest.php
+++ b/api/tests/Feature/Integrations/Pdf/ModernPdfParserTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use App\Models\PdfTemplate;
+use App\Service\Pdf\Modern\ModernPdfParser;
+use App\Service\Pdf\PdfGeneratorService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use setasign\Fpdi\Fpdi;
+use setasign\FpdiPdfParser\PdfParser\PdfParser;
+
+beforeEach(function () {
+    Storage::fake('local');
+});
+
+describe('Modern PDF parser compatibility', function () {
+    it('uses the FPDI parser shim globally', function () {
+        $path = tempnam(sys_get_temp_dir(), 'modern_pdf_');
+        file_put_contents($path, createModernPdfWithXrefStreamAndObjectStream());
+
+        $pdf = new class () extends Fpdi {
+            public function parserFor(string $filePath)
+            {
+                $this->setSourceFile($filePath);
+
+                return $this->getPdfReader($this->currentReaderId)->getParser();
+            }
+        };
+
+        try {
+            $parser = $pdf->parserFor($path);
+        } finally {
+            @unlink($path);
+        }
+
+        expect($parser::class)->toBe(PdfParser::class);
+        expect($parser)->toBeInstanceOf(ModernPdfParser::class);
+    });
+
+    it('loads a PDF with xref streams and compressed object streams through plain FPDI', function () {
+        $path = tempnam(sys_get_temp_dir(), 'modern_pdf_');
+        file_put_contents($path, createModernPdfWithXrefStreamAndObjectStream());
+
+        try {
+            $pdf = new Fpdi();
+            $pageCount = $pdf->setSourceFile($path);
+            $templateId = $pdf->importPage(1);
+            $size = $pdf->getTemplateSize($templateId);
+
+            expect($pageCount)->toBe(1);
+            expect(round($size['width'], 1))->toBe(215.9);
+            expect(round($size['height'], 1))->toBe(279.4);
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    it('accepts modern PDFs during template upload page counting', function () {
+        $user = $this->actingAsProUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace);
+        $file = UploadedFile::fake()->createWithContent(
+            'modern-template.pdf',
+            createModernPdfWithXrefStreamAndObjectStream(),
+        );
+
+        $response = $this->postJson(
+            route('open.forms.pdf-templates.store', $form),
+            ['file' => $file],
+        );
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.page_count', 1);
+    });
+
+    it('generates submission PDFs from modern PDF templates', function () {
+        $user = $this->actingAsProUser();
+        $workspace = $this->createUserWorkspace($user);
+        $form = $this->createForm($user, $workspace, [
+            'properties' => [
+                ['id' => 'name', 'name' => 'Name', 'type' => 'text'],
+            ],
+        ]);
+
+        $pdfContent = createModernPdfWithXrefStreamAndObjectStream();
+        $templatePath = "pdf-templates/{$form->id}/modern-template.pdf";
+        Storage::put($templatePath, $pdfContent);
+
+        $template = PdfTemplate::create([
+            'form_id' => $form->id,
+            'name' => 'Modern Template',
+            'filename' => 'modern-template.pdf',
+            'original_filename' => 'Modern Template.pdf',
+            'file_path' => $templatePath,
+            'file_size' => strlen($pdfContent),
+            'page_count' => 1,
+            'page_manifest' => [
+                ['id' => 'page-1', 'type' => 'source', 'source_page' => 1],
+            ],
+            'zone_mappings' => [
+                [
+                    'id' => 'zone-name',
+                    'page_id' => 'page-1',
+                    'x' => 10,
+                    'y' => 10,
+                    'width' => 50,
+                    'height' => 10,
+                    'field_id' => 'name',
+                    'font_size' => 12,
+                    'font_color' => '#000000',
+                ],
+            ],
+            'filename_pattern' => PdfTemplate::DEFAULT_FILENAME_PATTERN,
+        ]);
+        $submission = $form->submissions()->create([
+            'data' => ['name' => 'Alice'],
+        ]);
+
+        $resultPath = (new PdfGeneratorService())->generateFromTemplate($form, $submission, $template);
+
+        expect(Storage::exists($resultPath))->toBeTrue();
+        expect(Storage::get($resultPath))->toStartWith('%PDF');
+    });
+});
+
+function createModernPdfWithXrefStreamAndObjectStream(): string
+{
+    $pdf = "%PDF-1.6\n%\xE2\xE3\xCF\xD3\n";
+    $offsets = [];
+
+    $addObject = function (int $number, string $body) use (&$pdf, &$offsets): void {
+        $offsets[$number] = strlen($pdf);
+        $pdf .= "{$number} 0 obj\n{$body}\nendobj\n";
+    };
+
+    $addObject(1, '<< /Type /Catalog /Pages 2 0 R >>');
+
+    $pageContent = "BT\n/F1 12 Tf\n72 720 Td\n(Modern PDF) Tj\nET\n";
+    $addObject(4, "<< /Length " . strlen($pageContent) . " >>\nstream\n{$pageContent}endstream");
+
+    $pagesObject = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+    $pageObject = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >> >> /Contents 4 0 R >>';
+    $objectStreamBody = $pagesObject . "\n" . $pageObject;
+    $objectStreamHeader = '2 0 3 ' . (strlen($pagesObject) + 1) . ' ';
+    $objectStreamData = $objectStreamHeader . $objectStreamBody;
+    $compressedObjectStream = gzcompress($objectStreamData);
+
+    $addObject(
+        10,
+        '<< /Type /ObjStm /N 2 /First ' . strlen($objectStreamHeader)
+            . ' /Length ' . strlen($compressedObjectStream)
+            . " /Filter /FlateDecode >>\nstream\n{$compressedObjectStream}\nendstream",
+    );
+
+    $xrefOffset = strlen($pdf);
+    $xrefEntry = fn (int $type, int $field2, int $field3): string => pack('CNn', $type, $field2, $field3);
+    $xrefData = ''
+        . $xrefEntry(0, 0, 65535)
+        . $xrefEntry(1, $offsets[1], 0)
+        . $xrefEntry(2, 10, 0)
+        . $xrefEntry(2, 10, 1)
+        . $xrefEntry(1, $offsets[4], 0)
+        . $xrefEntry(1, $xrefOffset, 0)
+        . $xrefEntry(1, $offsets[10], 0);
+    $compressedXref = gzcompress($xrefData);
+
+    $pdf .= "5 0 obj\n"
+        . '<< /Type /XRef /Size 11 /Root 1 0 R /Index [0 6 10 1] /W [1 4 2] /Length '
+        . strlen($compressedXref)
+        . " /Filter /FlateDecode >>\nstream\n{$compressedXref}\nendstream\nendobj\n";
+    $pdf .= "startxref\n{$xrefOffset}\n%%EOF\n";
+
+    return $pdf;
+}

--- a/api/tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php
+++ b/api/tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php
@@ -439,6 +439,46 @@ describe('PdfContentRenderer scalar values', function () {
         expect($starCell['color'])->toBe([239, 68, 68]);
         expect($starCell['style'])->toContain('B');
     });
+
+    it('encodes rich text cells as Windows-1252 for FPDF core fonts', function () {
+        $renderer = new PdfRichTextRenderer();
+        $pdf = new class () extends Fpdi {
+            public array $cells = [];
+            public array $widthTexts = [];
+
+            public function GetStringWidth($s)
+            {
+                $this->widthTexts[] = $s;
+
+                return parent::GetStringWidth($s);
+            }
+
+            public function Cell($w, $h = 0, $txt = '', $border = 0, $ln = 0, $align = '', $fill = false, $link = '')
+            {
+                $this->cells[] = $txt;
+
+                parent::Cell($w, $h, $txt, $border, $ln, $align, $fill, $link);
+            }
+        };
+        $pdf->AddPage();
+
+        $renderer->render(
+            $pdf,
+            '<p>Délivrée&nbsp;été</p>',
+            10,
+            10,
+            80,
+            8,
+            ['font_size' => 10, 'font_color' => '#374151'],
+            210
+        );
+
+        $cellText = implode('', $pdf->cells);
+
+        expect(bin2hex($cellText))->toBe('44e96c697672e965a0e974e9');
+        expect(mb_convert_encoding($cellText, 'UTF-8', 'Windows-1252'))->toBe("Délivrée\u{00A0}été");
+        expect($pdf->widthTexts)->toBe($pdf->cells);
+    });
 });
 
 /**


### PR DESCRIPTION
## What changed

- Added the modern FPDI parser shim under `setasign\FpdiPdfParser\...` and ported the Raydocs modern xref/object-stream parser into `App\Service\Pdf\Modern`.
- Registered the shim in Composer autoload so plain `Fpdi` uses it automatically.
- Encoded rich-text PDF cell content as Windows-1252 immediately before FPDF width measurement and cell writing, while keeping HTML parsing in UTF-8.
- Broadened the FPDI parse/import failure handling in PDF generation and template rebuild paths to return `PdfNotSupportedException` instead of leaking parser exceptions.

## Why

Modern PDFs using xref streams and compressed object streams fail with FPDI's free parser. This lets OpnForm upload, count pages, and generate output from those templates without adding the Raydocs `PdfFailureClassifier`.

## Validation

- `composer install --no-interaction`
- `./vendor/bin/pint app/Service/Pdf/Modern app/Service/Pdf/Compat/SetasignFpdiPdfParser/PdfParser/PdfParser.php app/Service/Pdf/PdfGeneratorService.php app/Service/Pdf/PdfRichTextRenderer.php app/Service/Pdf/PdfTemplateRebuildService.php tests/Feature/Integrations/Pdf/ModernPdfParserTest.php tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php`
- `./vendor/bin/pest --filter=Pdf`