### PR TITLE
Fix cloud SMTP plan badge

### DIFF
--- a/client/components/workspaces/settings/Emails.vue
+++ b/client/components/workspaces/settings/Emails.vue
@@ -7,7 +7,7 @@
           Configure a custom SMTP sender for this workspace.
         </p>
         <PlanTag
-          required-tier="self_hosted"
+          :required-tier="isSelfHosted ? 'self_hosted' : 'pro'"
         />
       </div>
 


### PR DESCRIPTION
## Summary

- Show the Pro badge for workspace custom SMTP on OpnForm Cloud.
- Keep the Self-hosted Enterprise badge for self-hosted installations.

## Root cause

The Email Settings screen hard-coded the `self_hosted` tier even when the application was running in cloud mode. Custom SMTP is a Pro feature on cloud.

## Validation

- `npm run lint`