### PR TITLE
Fix Postgres healthcheck database target

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -84,7 +84,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME:-forge}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-forge}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-forge}"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       POSTGRES_USER: ${DB_USERNAME:-forge}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-forge}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-forge}"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 30s
       timeout: 5s
     volumes:

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -157,6 +157,14 @@ import CloudVersion from "/snippets/cloud-version.mdx";
 
 When running OpnForm with Docker, there are some important considerations for handling environment variables:
 
+<Note>
+    Docker Compose uses shell variables, a root `.env` file next to
+    `docker-compose.yml`, or a file passed with `--env-file` when it resolves
+    `${...}` values in the Compose file. The service-level `env_file` entries
+    such as `./api/.env` and `./client/.env` only pass variables into the
+    containers after the Compose file has already been resolved.
+</Note>
+
 ### Updating Environment Variables
 
 When changing environment variables in your `.env` files, you need to recreate the containers for the changes to take effect. Simply restarting the containers is not sufficient as Docker only loads environment variables when containers are created.


### PR DESCRIPTION
## Summary
- update Postgres healthchecks to pass both `POSTGRES_USER` and `POSTGRES_DB` to `pg_isready`
- document that service-level `env_file` entries do not feed Compose `${...}` interpolation

## Why
The old healthcheck only passed `-U`, so PostgreSQL could default the probe database name to the user name. With custom database names, the app can work while the database container logs `FATAL: database "forge" does not exist` on every healthcheck interval.

Fixes #781

## Validation
- `docker compose -f docker-compose.yml config --quiet`
- `docker compose -f docker-compose.dev.yml config --quiet`
- checked resolved production Compose config with default and custom DB env values
- ran an isolated Compose smoke test confirming `$${POSTGRES_USER}` / `$${POSTGRES_DB}` are passed to Docker as `${POSTGRES_USER}` / `${POSTGRES_DB}` and expanded inside the container healthcheck shell