### PR TITLE
Fix self-hosted custom code entitlement

### DIFF
--- a/api/app/Models/LicenseKey.php
+++ b/api/app/Models/LicenseKey.php
@@ -66,6 +66,7 @@ class LicenseKey extends Model
             'custom_smtp' => true,
             'audit_logs' => true,
             'external_storage' => true,
+            'custom_code' => true,
         ];
     }
 }

--- a/api/database/migrations/2026_07_14_000000_add_custom_code_to_self_hosted_license_features.php
+++ b/api/database/migrations/2026_07_14_000000_add_custom_code_to_self_hosted_license_features.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::table('license_keys')
+            ->where('plan', 'self_hosted')
+            ->chunkById(1000, function ($licenseKeys): void {
+                foreach ($licenseKeys as $licenseKey) {
+                    $features = json_decode($licenseKey->features ?? '[]', true) ?: [];
+
+                    if (($features['custom_code'] ?? false) === true) {
+                        continue;
+                    }
+
+                    $features['custom_code'] = true;
+
+                    DB::table('license_keys')
+                        ->where('id', $licenseKey->id)
+                        ->update([
+                            'features' => json_encode($features),
+                            'updated_at' => now(),
+                        ]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // Existing licenses may have been issued with this entitlement, so leave it intact on rollback.
+    }
+};

--- a/api/tests/Feature/SelfHosted/LicenseKeyServiceTest.php
+++ b/api/tests/Feature/SelfHosted/LicenseKeyServiceTest.php
@@ -47,6 +47,8 @@ describe('generateKeyForSession', function () {
         expect($key->status)->toBe('active');
         expect($key->plan)->toBe('self_hosted');
         expect($key->features)->toHaveKey('sso');
+        expect($key->features)->toHaveKey('custom_code');
+        expect($key->features['custom_code'])->toBeTrue();
         expect(LicenseCheckoutSession::where('stripe_session_id', 'cs_test_session')->value('license_key_id'))->toBe($key->id);
     });
 

--- a/docs/deployment/self-hosted-license.mdx
+++ b/docs/deployment/self-hosted-license.mdx
@@ -59,8 +59,8 @@ Self-hosted Enterprise unlocks advanced workspace and organization controls:
 | Custom code | Workspace and form custom code when enabled for self-hosted deployments |
 
 <Note>
-    Your license key controls which Enterprise areas are enabled. Some licenses
-    may include a subset of Enterprise features.
+    An active self-hosted Enterprise license enables every Enterprise feature
+    listed above for the instance.
 </Note>
 
 ## Instance configuration vs Enterprise workspace features


### PR DESCRIPTION
## Summary

- grant `custom_code` to newly issued self-hosted Enterprise licenses
- backfill the entitlement for existing self-hosted license records
- document that an active self-hosted Enterprise license enables the full Enterprise feature set

## Root cause

`custom_code` is license-gated on self-hosted instances but was omitted from the default feature payload returned by the central license API. Existing license records therefore caused the workspace Custom Code settings to remain locked.

## Validation

- `./vendor/bin/pest tests/Feature/SelfHosted/LicenseKeyServiceTest.php` (43 assertions; existing test-suite warnings)
- `./vendor/bin/pint --test app/Models/LicenseKey.php database/migrations/2026_07_14_000000_add_custom_code_to_self_hosted_license_features.php tests/Feature/SelfHosted/LicenseKeyServiceTest.php`
- migration exercised against a temporary SQLite database with both a self-hosted and non-self-hosted license record