### PR TITLE
Fix E2E form event handling

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -413,6 +413,7 @@ jobs:
         if: ${{ failure() && !cancelled() }}
         run: |
           docker compose -f docker-compose.e2e.yml logs --no-color > e2e-docker.log
+          docker compose -f docker-compose.e2e.yml exec -T api cat storage/logs/laravel.log > e2e-laravel.log || true
           if [ -f .e2e-ui.log ]; then
             cp .e2e-ui.log e2e-ui.log
           fi
@@ -442,6 +443,7 @@ jobs:
           name: e2e-debug-logs
           path: |
             e2e-docker.log
+            e2e-laravel.log
             e2e-ui.log
           if-no-files-found: ignore
           retention-days: 14

--- a/api/app/Listeners/Forms/FormCreationConfirmation.php
+++ b/api/app/Listeners/Forms/FormCreationConfirmation.php
@@ -5,6 +5,7 @@ namespace App\Listeners\Forms;
 use App\Events\Models\FormCreated;
 use App\Mail\Forms\FormCreationConfirmationMail;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
 
 class FormCreationConfirmation implements ShouldQueue
@@ -17,6 +18,10 @@ class FormCreationConfirmation implements ShouldQueue
      */
     public function handle(FormCreated $event)
     {
+        if (App::environment('e2e')) {
+            return;
+        }
+
         Mail::to($event->form->creator)->send(new FormCreationConfirmationMail($event->form));
     }
 }

--- a/api/app/Listeners/Forms/FormSpamCheckListener.php
+++ b/api/app/Listeners/Forms/FormSpamCheckListener.php
@@ -18,7 +18,7 @@ class FormSpamCheckListener implements ShouldQueue
 
     public function handle(FormSaved $event): void
     {
-        if (App::environment('testing')) {
+        if (App::environment(['testing', 'e2e'])) {
             return;
         }
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -38,7 +38,7 @@ services:
       QUEUE_CONNECTION: sync
       FILESYSTEM_DRIVER: local
       LOCAL_FILESYSTEM_VISIBILITY: public
-      MAIL_MAILER: log
+      MAIL_MAILER: array
       MAIL_FROM_ADDRESS: dev@localhost
       MAIL_FROM_NAME: OpnForm-E2E
       PHP_MEMORY_LIMIT: "1G"


### PR DESCRIPTION
## Summary

- skip the form-creation email and spam-check listeners only in the isolated `e2e` environment
- use the in-memory mail transport for E2E, while keeping synchronous submission events that the dashboard scenario verifies
- retain Laravel logs in the failed-job artifact for actionable follow-up diagnostics

## Root cause

The E2E stack executed queued form-creation listeners synchronously and rendered notification emails to Monolog. The GitHub runner exhausted PHP memory while serializing that log payload, causing all form-creation scenarios to fail.

## Validation

- `docker compose -f docker-compose.e2e.yml config`
- `php -l api/app/Listeners/Forms/FormCreationConfirmation.php`
- `php -l api/app/Listeners/Forms/FormSpamCheckListener.php`
- full Playwright E2E suite: 16 passed, with `laravel.log` remaining empty