### PR TITLE
fix: stabilize Codex worktree frontend startup

### DIFF
--- a/scripts/codex-worktree-lib.sh
+++ b/scripts/codex-worktree-lib.sh
@@ -228,10 +228,12 @@ select_node_runtime() {
   fi
 
   herd_node="$HOME/Library/Application Support/Herd/config/nvm/versions/node/v20.20.1/bin/node"
+  homebrew_node="/opt/homebrew/bin/node"
+  local_node="/usr/local/bin/node"
   bundled_node="$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node"
   path_node=$(command -v node 2>/dev/null || true)
 
-  for candidate in "$herd_node" "$bundled_node" "$path_node"; do
+  for candidate in "$herd_node" "$homebrew_node" "$local_node" "$bundled_node" "$path_node"; do
     if select_node_candidate "$candidate"; then
       return 0
     fi

--- a/scripts/codex-worktree-up.sh
+++ b/scripts/codex-worktree-up.sh
@@ -76,6 +76,11 @@ start_client() {
     exit 1
   fi
 
+  # Vite's optimized dependency cache is transient. It can retain references
+  # to chunks removed by npm ci, causing the Nuxt dev server to crash on first
+  # navigation in a freshly created worktree.
+  rm -rf "$ROOT_DIR/client/node_modules/.cache/vite"
+
   if command -v screen >/dev/null 2>&1; then
     rm -f "$CODEX_STATE_DIR/client.pid"
     screen -dmS "$CODEX_CLIENT_SCREEN" sh -c "cd '$ROOT_DIR/client' && set -a && . '$CODEX_CLIENT_ENV_FILE' && set +a && echo \$\$ >'$CODEX_STATE_DIR/client.pid' && exec env PATH='$PATH' RUNNER_TRACKING_ID= NUXT_HOST='$CODEX_APP_HOST' NUXT_PORT='$CODEX_APP_PORT' '$CODEX_NPM_BIN' run dev -- --host '$CODEX_APP_HOST' --port '$CODEX_APP_PORT' >'$CODEX_STATE_DIR/client.log' 2>&1"


### PR DESCRIPTION
## Summary

- Prefer installed Homebrew Node runtimes before the bundled Codex runtime when selecting Node for a worktree.
- Clear Vite's optimized-dependency cache before launching the Nuxt development server.

## Root cause

A worktree could select a Node binary without its matching `npm`, or keep Vite cache entries that reference chunks removed by `npm ci`. The latter caused missing optimized chunks and could terminate the Nuxt dev server on first navigation.

## Validation

- `sh -n scripts/codex-worktree-lib.sh scripts/codex-worktree-up.sh`
- Restarted the isolated worktree from cold; API and UI both returned `200`.
