### PR TITLE
Add UTF-8 BOM to async CSV exports

### DIFF
--- a/api/app/Service/Forms/FormExportService.php
+++ b/api/app/Service/Forms/FormExportService.php
@@ -112,6 +112,9 @@ class FormExportService
 
         $output = fopen('php://temp', 'r+');
 
+        // Help spreadsheet applications such as Excel detect UTF-8 correctly.
+        fwrite($output, "\xEF\xBB\xBF");
+
         // Write header row (clean column names)
         $headers = $this->cleanColumnNames(array_keys($rows[0]));
         fputcsv($output, $headers);

--- a/api/tests/Feature/Forms/FormSubmissionExportTest.php
+++ b/api/tests/Feature/Forms/FormSubmissionExportTest.php
@@ -450,6 +450,22 @@ it('uses the workspace policy for asynchronous CSV download links', function () 
     Storage::assertExists(FormExportService::EXPORT_FILE_PATH . 'weekend-submissions.csv');
 });
 
+it('includes a UTF-8 BOM in asynchronous CSV exports', function () {
+    Storage::fake();
+    $exportService = app(FormExportService::class);
+    $fileName = 'unicode-submissions.csv';
+
+    $exportService->generateAndUploadCsvFile([
+        ['name' => 'பெயர்'],
+    ], $fileName, now()->addHour());
+
+    $csv = Storage::get(FormExportService::EXPORT_FILE_PATH . $fileName);
+
+    expect($csv)
+        ->toStartWith("\xEF\xBB\xBF")
+        ->toContain('பெயர்');
+});
+
 it('allows export status polling when the general api rate limit is exhausted', function () {
     $this->withMiddleware(ThrottleRequests::class);
 


### PR DESCRIPTION
## What changed

- Prefix asynchronously generated CSV files with a UTF-8 byte-order mark.
- Add regression coverage using the Tamil text from the bug report.

## Why

The synchronous export path already enables a UTF-8 BOM through Laravel Excel configuration, but the asynchronous export path builds CSV content directly. Without the marker, Microsoft Excel can interpret UTF-8 text with the wrong encoding.

Closes #839

## Validation

- `php -l app/Service/Forms/FormExportService.php` using PHP 8.3: passed.
- `php -l tests/Feature/Forms/FormSubmissionExportTest.php` using PHP 8.3: passed.
- The full Laravel feature test was not run because this host does not have the repository's PHP/PostgreSQL development stack configured.
