### PR TITLE
Fix Codex worktree runtimes and frontend lifecycle

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -6,10 +6,14 @@ const isUnitTestMode = !!process.env.VITEST
 const isE2EMode = process.env.E2E === '1'
 const isDevtoolsEnabled =
   process.env.NUXT_DEVTOOLS === '1' && !isE2EMode && process.env.NODE_ENV !== 'production'
+const buildDir = process.env.NUXT_BUILD_DIR
+const viteCacheDir = process.env.NUXT_VITE_CACHE_DIR
 
 export default defineNuxtConfig({
   loglevel: process.env.NUXT_LOG_LEVEL || 'info',
   devtools: {enabled: isDevtoolsEnabled},
+  ...(buildDir ? {buildDir} : {}),
+  ...(viteCacheDir ? {vite: {cacheDir: viteCacheDir}} : {}),
   css: ['~/css/app.css'],
 
   // Disable certain plugins during testing

--- a/scripts/codex-worktree-lib.sh
+++ b/scripts/codex-worktree-lib.sh
@@ -21,7 +21,10 @@ CODEX_API_PORT="${CODEX_API_PORT:-$((26000 + CODEX_HASH))}"
 CODEX_APP_PORT="${CODEX_APP_PORT:-$((32000 + CODEX_HASH))}"
 CODEX_API_SCREEN="opnform-codex-api-$CODEX_HASH"
 CODEX_CLIENT_SCREEN="opnform-codex-client-$CODEX_HASH"
-CODEX_CLIENT_NODE_STAMP="$CODEX_STATE_DIR/client-node.version"
+CODEX_CLIENT_DEPENDENCY_STAMP="$CODEX_STATE_DIR/client-dependencies.sha256"
+CODEX_CLIENT_INSTALL_LOCK="$CODEX_STATE_DIR/client-install.lock"
+CODEX_CLIENT_NUXT_DIR="$CODEX_STATE_DIR/client/nuxt"
+CODEX_CLIENT_VITE_CACHE_DIR="$CODEX_STATE_DIR/client/vite"
 
 CODEX_API_BASE_URL="http://$CODEX_API_HOST:$CODEX_API_PORT"
 CODEX_APP_URL="http://$CODEX_APP_HOST:$CODEX_APP_PORT"
@@ -147,6 +150,8 @@ NUXT_PUBLIC_ENV=codex
 NUXT_PUBLIC_CODEX_AUTO_LOGIN=true
 NUXT_PUBLIC_CODEX_AUTO_LOGIN_EMAIL=e2e@example.test
 NUXT_PUBLIC_CODEX_AUTO_LOGIN_PASSWORD=Abcd@1234
+NUXT_BUILD_DIR="$CODEX_CLIENT_NUXT_DIR"
+NUXT_VITE_CACHE_DIR="$CODEX_CLIENT_VITE_CACHE_DIR"
 EOF
 
   cat >"$CODEX_ENV_FILE" <<EOF
@@ -163,6 +168,8 @@ CODEX_API_BASE_URL=$CODEX_API_BASE_URL
 CODEX_APP_URL=$CODEX_APP_URL
 CODEX_API_HEALTH_URL=$CODEX_API_HEALTH_URL
 CODEX_APP_HEALTH_URL=$CODEX_APP_HEALTH_URL
+CODEX_CLIENT_NUXT_DIR="$CODEX_CLIENT_NUXT_DIR"
+CODEX_CLIENT_VITE_CACHE_DIR="$CODEX_CLIENT_VITE_CACHE_DIR"
 EOF
 }
 
@@ -284,6 +291,89 @@ remove_node_modules() {
   fi
 }
 
+hash_stdin() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{ print $1 }'
+    return 0
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{ print $1 }'
+    return 0
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 | awk '{ print $NF }'
+    return 0
+  fi
+
+  echo "A SHA-256 utility is required to fingerprint Codex client dependencies." >&2
+  return 1
+}
+
+client_dependencies_fingerprint() {
+  lock_file="$ROOT_DIR/client/package-lock.json"
+  if [ ! -f "$lock_file" ]; then
+    echo "client/package-lock.json is required for deterministic Codex installs." >&2
+    return 1
+  fi
+
+  lock_hash=$(hash_stdin <"$lock_file")
+  printf 'version=1\nnode=%s\nlock=%s\n' "$CODEX_NODE_VERSION" "$lock_hash" | hash_stdin
+}
+
+acquire_client_install_lock() {
+  ensure_codex_state_dir
+  attempt=0
+
+  while ! mkdir "$CODEX_CLIENT_INSTALL_LOCK" 2>/dev/null; do
+    attempt=$((attempt + 1))
+    lock_pid=$(cat "$CODEX_CLIENT_INSTALL_LOCK/pid" 2>/dev/null || true)
+
+    case "$lock_pid" in
+      ''|*[!0-9]*)
+        if [ "$attempt" -ge 5 ]; then
+          echo "Removing incomplete Codex client install lock." >&2
+          rm -rf "$CODEX_CLIENT_INSTALL_LOCK"
+          attempt=0
+          continue
+        fi
+        ;;
+      *)
+        if ! kill -0 "$lock_pid" >/dev/null 2>&1; then
+          echo "Removing stale Codex client install lock from process $lock_pid." >&2
+          rm -rf "$CODEX_CLIENT_INSTALL_LOCK"
+          attempt=0
+          continue
+        fi
+        ;;
+    esac
+
+    if [ "$attempt" -eq 1 ]; then
+      echo "Waiting for another Codex client dependency install to finish."
+    elif [ "$attempt" -ge "${CODEX_CLIENT_INSTALL_LOCK_TIMEOUT:-600}" ]; then
+      echo "Timed out waiting for the Codex client dependency install lock." >&2
+      return 1
+    fi
+
+    sleep 1
+  done
+
+  CODEX_CLIENT_INSTALL_LOCK_ACQUIRED=1
+  printf '%s\n' "$$" >"$CODEX_CLIENT_INSTALL_LOCK/pid"
+}
+
+release_client_install_lock() {
+  if [ "${CODEX_CLIENT_INSTALL_LOCK_ACQUIRED:-0}" = "1" ]; then
+    rm -rf "$CODEX_CLIENT_INSTALL_LOCK"
+    CODEX_CLIENT_INSTALL_LOCK_ACQUIRED=0
+  fi
+}
+
+invalidate_client_artifacts() {
+  rm -rf "$CODEX_CLIENT_NUXT_DIR" "$CODEX_CLIENT_VITE_CACHE_DIR"
+}
+
 node_version_is_supported() {
   version="$1"
   major=${version%%.*}
@@ -352,33 +442,45 @@ select_node_runtime() {
 
 ensure_node_dependencies() {
   select_node_runtime
-  node_version="v$CODEX_NODE_VERSION"
 
-  install_reason=""
-  if [ ! -d "$ROOT_DIR/client/node_modules" ]; then
-    install_reason="missing node_modules"
-  elif [ ! -x "$ROOT_DIR/client/node_modules/.bin/nuxt" ]; then
-    install_reason="Nuxt binary missing"
-  elif [ ! -f "$CODEX_CLIENT_NODE_STAMP" ]; then
-    install_reason="Node runtime stamp missing"
-  elif [ "$(cat "$CODEX_CLIENT_NODE_STAMP" 2>/dev/null || true)" != "$node_version" ]; then
-    install_reason="Node runtime changed"
-  fi
+  (
+    CODEX_CLIENT_INSTALL_LOCK_ACQUIRED=0
+    trap 'release_client_install_lock' EXIT
+    trap 'exit 1' HUP INT TERM
+    acquire_client_install_lock
 
-  if [ -n "$install_reason" ]; then
-    echo "Installing client dependencies with Node $node_version and npm $("$CODEX_NPM_BIN" --version) ($install_reason)."
+    fingerprint=$(client_dependencies_fingerprint)
+    install_reason=""
+    if [ ! -d "$ROOT_DIR/client/node_modules" ]; then
+      install_reason="missing node_modules"
+    elif [ ! -x "$ROOT_DIR/client/node_modules/.bin/nuxt" ]; then
+      install_reason="Nuxt binary missing"
+    elif [ ! -f "$CODEX_CLIENT_DEPENDENCY_STAMP" ]; then
+      install_reason="dependency fingerprint missing"
+    elif [ "$(cat "$CODEX_CLIENT_DEPENDENCY_STAMP" 2>/dev/null || true)" != "$fingerprint" ]; then
+      install_reason="dependency fingerprint changed"
+    fi
+
+    if [ -z "$install_reason" ]; then
+      exit 0
+    fi
+
+    echo "Installing client dependencies with Node v$CODEX_NODE_VERSION and npm $("$CODEX_NPM_BIN" --version) ($install_reason)."
+    invalidate_client_artifacts
     if [ -d "$ROOT_DIR/client/node_modules" ]; then
       remove_node_modules
     fi
 
+    mkdir -p "$CODEX_CLIENT_NUXT_DIR" "$CODEX_CLIENT_VITE_CACHE_DIR"
     (
       cd "$ROOT_DIR/client"
-      "$CODEX_NPM_BIN" ci --no-audit --no-fund
+      NUXT_BUILD_DIR="$CODEX_CLIENT_NUXT_DIR" \
+        NUXT_VITE_CACHE_DIR="$CODEX_CLIENT_VITE_CACHE_DIR" \
+        "$CODEX_NPM_BIN" ci --no-audit --no-fund
     )
-  fi
 
-  ensure_codex_state_dir
-  printf '%s\n' "$node_version" >"$CODEX_CLIENT_NODE_STAMP"
+    printf '%s\n' "$fingerprint" >"$CODEX_CLIENT_DEPENDENCY_STAMP"
+  )
 }
 
 port_is_listening() {

--- a/scripts/codex-worktree-lib.sh
+++ b/scripts/codex-worktree-lib.sh
@@ -183,12 +183,86 @@ print_codex_environment_summary() {
 }
 
 ensure_php_dependencies() {
+  select_php_runtime
+
   if [ ! -f "$ROOT_DIR/api/vendor/autoload.php" ]; then
+    composer_bin="${CODEX_COMPOSER_BIN:-$(command -v composer 2>/dev/null || true)}"
+    if [ -z "$composer_bin" ] || [ ! -f "$composer_bin" ]; then
+      echo "Composer is required to install the Codex API dependencies." >&2
+      exit 1
+    fi
+
     (
       cd "$ROOT_DIR/api"
-      composer install --no-interaction --prefer-dist
+      "$CODEX_PHP_BIN" "$composer_bin" install --no-interaction --prefer-dist
     )
   fi
+}
+
+php_version_is_supported() {
+  version="$1"
+  major=${version%%.*}
+  remainder=${version#*.}
+  minor=${remainder%%.*}
+
+  case "$major.$minor" in
+    *[!0-9.]*|.*|*.) return 1 ;;
+  esac
+
+  [ "$major" -eq 8 ] && [ "$minor" -ge 3 ]
+}
+
+select_php_candidate() {
+  candidate="$1"
+
+  [ -n "$candidate" ] && [ -x "$candidate" ] || return 1
+
+  version=$("$candidate" -r 'echo PHP_VERSION;' 2>/dev/null || true)
+  php_version_is_supported "$version" || return 1
+
+  php_dir=$(dirname "$candidate")
+  PATH="$php_dir:$PATH"
+
+  CODEX_PHP_BIN="$candidate"
+  CODEX_PHP_VERSION="$version"
+  export PATH CODEX_PHP_BIN CODEX_PHP_VERSION
+  return 0
+}
+
+select_php_runtime() {
+  if [ -n "${CODEX_PHP_BIN:-}" ]; then
+    if select_php_candidate "$CODEX_PHP_BIN"; then
+      return 0
+    fi
+
+    echo "CODEX_PHP_BIN must point to a PHP ^8.3 runtime." >&2
+    exit 1
+  fi
+
+  homebrew_php="/opt/homebrew/bin/php"
+  homebrew_php_84="/opt/homebrew/opt/php@8.4/bin/php"
+  homebrew_php_83="/opt/homebrew/opt/php@8.3/bin/php"
+  local_php="/usr/local/bin/php"
+  local_php_84="/usr/local/opt/php@8.4/bin/php"
+  local_php_83="/usr/local/opt/php@8.3/bin/php"
+  herd_php_84="$HOME/Library/Application Support/Herd/bin/php84"
+  herd_php_83="$HOME/Library/Application Support/Herd/bin/php83"
+  herd_php="$HOME/Library/Application Support/Herd/bin/php"
+  bundled_php="$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/php/bin/php"
+  path_php=$(command -v php 2>/dev/null || true)
+
+  for candidate in \
+    "$homebrew_php" "$homebrew_php_84" "$homebrew_php_83" \
+    "$local_php" "$local_php_84" "$local_php_83" \
+    "$herd_php_84" "$herd_php_83" "$herd_php" \
+    "$bundled_php" "$path_php"; do
+    if select_php_candidate "$candidate"; then
+      return 0
+    fi
+  done
+
+  echo "A PHP runtime compatible with ^8.3 is required." >&2
+  exit 1
 }
 
 remove_node_modules() {

--- a/scripts/codex-worktree-reset-db.sh
+++ b/scripts/codex-worktree-reset-db.sh
@@ -13,8 +13,8 @@ rm -rf "$ROOT_DIR/api/storage/framework/cache/data"/* "$ROOT_DIR/api/storage/fra
 
 (
   cd "$ROOT_DIR/api"
-  APP_ENV=codex php artisan optimize:clear --env=codex
-  APP_ENV=codex php artisan migrate:fresh --seed --seeder=Database\\Seeders\\E2ETestSeeder --force --env=codex
+  APP_ENV=codex "$CODEX_PHP_BIN" artisan optimize:clear --env=codex
+  APP_ENV=codex "$CODEX_PHP_BIN" artisan migrate:fresh --seed --seeder=Database\\Seeders\\E2ETestSeeder --force --env=codex
 )
 
 echo "Codex worktree PostgreSQL database reset:"

--- a/scripts/codex-worktree-up.sh
+++ b/scripts/codex-worktree-up.sh
@@ -5,6 +5,9 @@ set -eu
 ROOT_DIR=$(cd -- "$(dirname "$0")/.." && pwd)
 . "$ROOT_DIR/scripts/codex-worktree-lib.sh"
 
+select_php_runtime
+select_node_runtime
+
 if [ ! -f "$CODEX_API_ENV_FILE" ] || [ ! -f "$CODEX_CLIENT_ENV_FILE" ]; then
   "$ROOT_DIR/scripts/codex-worktree-setup.sh"
   CODEX_ENV_SUMMARY_PRINTED=1
@@ -45,13 +48,13 @@ start_api() {
 
   if command -v screen >/dev/null 2>&1; then
     rm -f "$CODEX_STATE_DIR/api.pid"
-    screen -dmS "$CODEX_API_SCREEN" sh -lc "cd '$ROOT_DIR/api' && echo \$\$ >'$CODEX_STATE_DIR/api.pid' && exec env RUNNER_TRACKING_ID= APP_ENV=codex php artisan serve --host='$CODEX_API_HOST' --port='$CODEX_API_PORT' --env=codex >'$CODEX_STATE_DIR/api.log' 2>&1"
+    screen -dmS "$CODEX_API_SCREEN" sh -lc "cd '$ROOT_DIR/api' && echo \$\$ >'$CODEX_STATE_DIR/api.pid' && exec env RUNNER_TRACKING_ID= APP_ENV=codex '$CODEX_PHP_BIN' artisan serve --host='$CODEX_API_HOST' --port='$CODEX_API_PORT' --env=codex >'$CODEX_STATE_DIR/api.log' 2>&1"
     echo "$CODEX_API_SCREEN" >"$CODEX_STATE_DIR/api.screen"
   else
     rm -f "$CODEX_STATE_DIR/api.screen"
     (
       cd "$ROOT_DIR/api"
-      exec nohup env RUNNER_TRACKING_ID= APP_ENV=codex php artisan serve --host="$CODEX_API_HOST" --port="$CODEX_API_PORT" --env=codex
+      exec nohup env RUNNER_TRACKING_ID= APP_ENV=codex "$CODEX_PHP_BIN" artisan serve --host="$CODEX_API_HOST" --port="$CODEX_API_PORT" --env=codex
     ) >"$CODEX_STATE_DIR/api.log" 2>&1 &
     echo "$!" >"$CODEX_STATE_DIR/api.pid"
   fi

--- a/scripts/codex-worktree-up.sh
+++ b/scripts/codex-worktree-up.sh
@@ -79,11 +79,6 @@ start_client() {
     exit 1
   fi
 
-  # Vite's optimized dependency cache is transient. It can retain references
-  # to chunks removed by npm ci, causing the Nuxt dev server to crash on first
-  # navigation in a freshly created worktree.
-  rm -rf "$ROOT_DIR/client/node_modules/.cache/vite"
-
   if command -v screen >/dev/null 2>&1; then
     rm -f "$CODEX_STATE_DIR/client.pid"
     screen -dmS "$CODEX_CLIENT_SCREEN" sh -c "cd '$ROOT_DIR/client' && set -a && . '$CODEX_CLIENT_ENV_FILE' && set +a && echo \$\$ >'$CODEX_STATE_DIR/client.pid' && exec env PATH='$PATH' RUNNER_TRACKING_ID= NUXT_HOST='$CODEX_APP_HOST' NUXT_PORT='$CODEX_APP_PORT' '$CODEX_NPM_BIN' run dev -- --host '$CODEX_APP_HOST' --port '$CODEX_APP_PORT' >'$CODEX_STATE_DIR/client.log' 2>&1"

--- a/scripts/tests/codex-worktree-client-lifecycle-test.sh
+++ b/scripts/tests/codex-worktree-client-lifecycle-test.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+
+set -eu
+
+REPOSITORY_ROOT=$(cd -- "$(dirname "$0")/../.." && pwd)
+. "$REPOSITORY_ROOT/scripts/codex-worktree-lib.sh"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT INT TERM
+
+ROOT_DIR="$test_dir/repository"
+CODEX_STATE_DIR="$test_dir/state"
+CODEX_API_ENV_FILE="$ROOT_DIR/api/.env.codex"
+CODEX_CLIENT_ENV_FILE="$ROOT_DIR/client/.env.codex"
+CODEX_ENV_FILE="$CODEX_STATE_DIR/env"
+CODEX_CLIENT_DEPENDENCY_STAMP="$CODEX_STATE_DIR/client-dependencies.sha256"
+CODEX_CLIENT_INSTALL_LOCK="$CODEX_STATE_DIR/client-install.lock"
+CODEX_CLIENT_NUXT_DIR="$CODEX_STATE_DIR/client/nuxt"
+CODEX_CLIENT_VITE_CACHE_DIR="$CODEX_STATE_DIR/client/vite"
+
+fake_bin="$test_dir/bin"
+fake_node="$fake_bin/node"
+fake_npm="$fake_bin/npm"
+install_count_file="$test_dir/npm-ci.count"
+
+mkdir -p "$ROOT_DIR/api" "$ROOT_DIR/client" "$fake_bin"
+printf '%s\n' '{"lockfileVersion":3,"packages":{}}' >"$ROOT_DIR/client/package-lock.json"
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'printf "%s" "$FAKE_NODE_VERSION"' \
+  >"$fake_node"
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'if [ "$1" = "--version" ]; then' \
+  '  echo "11.0.0"' \
+  '  exit 0' \
+  'fi' \
+  'if [ "$1" != "ci" ]; then' \
+  '  echo "Unexpected npm command: $*" >&2' \
+  '  exit 1' \
+  'fi' \
+  'count=$(cat "$FAKE_NPM_COUNT_FILE" 2>/dev/null || echo 0)' \
+  'sleep "${FAKE_NPM_SLEEP:-0}"' \
+  'printf "%s\n" "$((count + 1))" >"$FAKE_NPM_COUNT_FILE"' \
+  'mkdir -p "$FAKE_CLIENT_DIR/node_modules/.bin" "$NUXT_BUILD_DIR" "$NUXT_VITE_CACHE_DIR"' \
+  'printf "%s\n" "#!/bin/sh" "exit 0" >"$FAKE_CLIENT_DIR/node_modules/.bin/nuxt"' \
+  'chmod +x "$FAKE_CLIENT_DIR/node_modules/.bin/nuxt"' \
+  >"$fake_npm"
+
+chmod +x "$fake_node" "$fake_npm"
+
+FAKE_NODE_VERSION=24.10.0
+FAKE_NPM_COUNT_FILE="$install_count_file"
+FAKE_CLIENT_DIR="$ROOT_DIR/client"
+CODEX_NODE_BIN="$fake_node"
+export FAKE_NODE_VERSION FAKE_NPM_COUNT_FILE FAKE_CLIENT_DIR CODEX_NODE_BIN
+
+write_codex_env_files
+grep -F "NUXT_BUILD_DIR=\"$CODEX_CLIENT_NUXT_DIR\"" "$CODEX_CLIENT_ENV_FILE" >/dev/null
+grep -F "NUXT_VITE_CACHE_DIR=\"$CODEX_CLIENT_VITE_CACHE_DIR\"" "$CODEX_CLIENT_ENV_FILE" >/dev/null
+
+ensure_node_dependencies
+[ "$(cat "$install_count_file")" = "1" ]
+[ -f "$CODEX_CLIENT_DEPENDENCY_STAMP" ]
+
+printf '%s\n' "keep" >"$CODEX_CLIENT_NUXT_DIR/restart-sentinel"
+printf '%s\n' "keep" >"$CODEX_CLIENT_VITE_CACHE_DIR/restart-sentinel"
+ensure_node_dependencies
+[ "$(cat "$install_count_file")" = "1" ]
+[ -f "$CODEX_CLIENT_NUXT_DIR/restart-sentinel" ]
+[ -f "$CODEX_CLIENT_VITE_CACHE_DIR/restart-sentinel" ]
+
+printf '%s\n' '{"lockfileVersion":3,"packages":{"changed":{}}}' >"$ROOT_DIR/client/package-lock.json"
+ensure_node_dependencies
+[ "$(cat "$install_count_file")" = "2" ]
+[ ! -e "$CODEX_CLIENT_NUXT_DIR/restart-sentinel" ]
+[ ! -e "$CODEX_CLIENT_VITE_CACHE_DIR/restart-sentinel" ]
+
+FAKE_NODE_VERSION=22.14.0
+export FAKE_NODE_VERSION
+ensure_node_dependencies
+[ "$(cat "$install_count_file")" = "3" ]
+
+printf '%s\n' '{"lockfileVersion":3,"packages":{"concurrent":{}}}' >"$ROOT_DIR/client/package-lock.json"
+FAKE_NPM_SLEEP=1
+export FAKE_NPM_SLEEP
+ensure_node_dependencies &
+first_install_pid=$!
+ensure_node_dependencies &
+second_install_pid=$!
+wait "$first_install_pid"
+wait "$second_install_pid"
+
+[ "$(cat "$install_count_file")" = "4" ]
+[ ! -e "$CODEX_CLIENT_INSTALL_LOCK" ]
+
+printf '%s\n' '{"lockfileVersion":3,"packages":{"stale-lock":{}}}' >"$ROOT_DIR/client/package-lock.json"
+mkdir "$CODEX_CLIENT_INSTALL_LOCK"
+printf '%s\n' "2147483647" >"$CODEX_CLIENT_INSTALL_LOCK/pid"
+FAKE_NPM_SLEEP=0
+export FAKE_NPM_SLEEP
+ensure_node_dependencies
+
+[ "$(cat "$install_count_file")" = "5" ]
+[ ! -e "$CODEX_CLIENT_INSTALL_LOCK" ]
+
+echo "Codex client lifecycle tests passed."

--- a/scripts/tests/codex-worktree-runtime-test.sh
+++ b/scripts/tests/codex-worktree-runtime-test.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=$(cd -- "$(dirname "$0")/../.." && pwd)
+. "$ROOT_DIR/scripts/codex-worktree-lib.sh"
+
+assert_php_version_supported() {
+  version="$1"
+  if ! php_version_is_supported "$version"; then
+    echo "Expected PHP $version to be supported." >&2
+    exit 1
+  fi
+}
+
+assert_php_version_rejected() {
+  version="$1"
+  if php_version_is_supported "$version"; then
+    echo "Expected PHP $version to be rejected." >&2
+    exit 1
+  fi
+}
+
+assert_php_version_rejected "8.2.29"
+assert_php_version_supported "8.3.0"
+assert_php_version_supported "8.4.3"
+assert_php_version_rejected "9.0.0"
+assert_php_version_rejected "invalid"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT INT TERM
+fake_php="$test_dir/php"
+
+printf '%s\n' '#!/bin/sh' 'printf "%s" "$FAKE_PHP_VERSION"' >"$fake_php"
+chmod +x "$fake_php"
+
+FAKE_PHP_VERSION=8.4.3
+export FAKE_PHP_VERSION
+PATH="/usr/bin:/bin:$test_dir"
+select_php_candidate "$fake_php"
+
+[ "$CODEX_PHP_BIN" = "$fake_php" ]
+[ "$CODEX_PHP_VERSION" = "8.4.3" ]
+[ "${PATH%%:*}" = "$test_dir" ]
+
+FAKE_PHP_VERSION=8.2.29
+export FAKE_PHP_VERSION
+if select_php_candidate "$fake_php"; then
+  echo "Expected an incompatible PHP candidate to be rejected." >&2
+  exit 1
+fi
+
+echo "Codex PHP runtime selection tests passed."


### PR DESCRIPTION
## What changed

### Runtime selection

- discover and validate a PHP runtime compatible with the API's `^8.3` requirement, with an explicit `CODEX_PHP_BIN` override
- run Composer and every Codex Artisan command through the selected PHP binary
- retain both PHP and Node selections in the parent `codex-worktree-up.sh` process so fresh setup can start both servers

### Nuxt/Vite lifecycle

- place Codex Nuxt build output and Vite's dependency cache under the worktree state directory (`.e2e/codex/client`)
- replace the unconditional Vite cache purge on every `Start app` with a SHA-256 dependency fingerprint built from the exact `package-lock.json` contents and selected Node version
- invalidate Nuxt/Vite artifacts and run `npm ci` only when that fingerprint changes, dependencies are absent, or the Nuxt binary is missing
- serialize frontend installs through an atomic POSIX directory lock; waiters re-check the fingerprint after acquiring it, stale process locks are recovered, and the lock is released on shell exit/signals
- add focused shell coverage for PHP compatibility and the frontend lifecycle, including restart persistence, lockfile/runtime invalidation, concurrent installs, and stale-lock recovery

## Root causes

The API bootstrap invoked `composer` and `php artisan` through the ambient `PATH`. On the affected machine Herd's PHP 8.2 appeared first even though compatible PHP 8.4 was installed through Homebrew, so Composer rejected `php: ^8.3` and Artisan failed.

The frontend workaround removed Vite's optimized dependency cache on every start. That avoided stale chunks after `npm ci`, but discarded a healthy cache during ordinary restarts and did not prevent concurrent setup processes from racing over `node_modules`.

## Resulting behavior

- A normal stop/start with the same lockfile and Node version performs no install and no scripted cache purge; Nuxt starts normally with its persistent Vite cache and HMR lifecycle.
- A lockfile or exact Node-version change causes one serialized `npm ci` and clears only the Codex Nuxt/Vite state before regeneration.
- Missing `node_modules` or `.bin/nuxt` also forces the same clean install path.
- Non-Codex Nuxt commands are unchanged because custom `buildDir`/`vite.cacheDir` values are applied only when the Codex environment variables are present.
- `Destroy app` removes the isolated frontend artifacts with the rest of `.e2e/codex`.

## Constraints

- A SHA-256 provider (`shasum`, `sha256sum`, or `openssl`) is required.
- Install-lock wait time defaults to 600 seconds and can be overridden with `CODEX_CLIENT_INSTALL_LOCK_TIMEOUT`.
- The fingerprint intentionally tracks dependency inputs (lockfile + exact Node version); ordinary source edits do not reinstall dependencies and remain handled by Nuxt/Vite HMR.

## Validation

- `scripts/tests/codex-worktree-runtime-test.sh`
- `scripts/tests/codex-worktree-client-lifecycle-test.sh` (restart persistence, lockfile and Node invalidation, two concurrent installers resulting in one `npm ci`, stale-lock recovery)
- POSIX shell syntax checks and `git diff --check`
- real `scripts/codex-worktree-up.sh`: selected Homebrew PHP 8.4.3 while PATH PHP was Herd 8.2.29; Composer, package discovery, migrations, seeding, Laravel, and Nuxt succeeded
- real frontend lifecycle: Nuxt output generated under `.e2e/codex/client/nuxt`, Vite cache under `.e2e/codex/client/vite`, both health endpoints passed, and a stop/start performed no reinstall while preserving a Vite cache sentinel
- backend: 1,753 tests passed (5,133 assertions) with `OPEN_AI_API_KEY=codex-test-key`
- frontend: 677 tests passed
- Pint: 813 files passed
- ESLint: passed
- PHPStan completed with `--memory-limit=1G` and reports two pre-existing `owners` relation errors in `Console/Commands/Billing/BackfillLifetimeLicenseWorkspaceEntitlements.php`; that file is untouched by this PR
