### PR TITLE
Fix edited submission uploads in PDFs

### DIFF
--- a/api/app/Http/Resources/FormSubmissionResource.php
+++ b/api/app/Http/Resources/FormSubmissionResource.php
@@ -84,6 +84,11 @@ class FormSubmissionResource extends JsonResource
                 $mapped = collect($fileItems)
                     ->filter(fn ($file) => !is_null($file) && $file !== '')
                     ->map(function ($file) {
+                        $file = (string) $file;
+                        if (FilenameUrlEncoder::isEncoded($file)) {
+                            $file = FilenameUrlEncoder::decode($file);
+                        }
+
                         // Use base64url encoding to avoid URL encoding issues with special characters
                         // See: https://github.com/OpnForm/OpnForm/issues/1024
                         $encodedFilename = FilenameUrlEncoder::encode($file);

--- a/api/app/Jobs/Form/StoreFormSubmissionJob.php
+++ b/api/app/Jobs/Form/StoreFormSubmissionJob.php
@@ -11,6 +11,7 @@ use App\Models\Forms\FormSubmission;
 use App\Service\Billing\Feature;
 use App\Service\Forms\FormAutoIncrementSequence;
 use App\Service\Forms\FormLogicPropertyResolver;
+use App\Service\Storage\FilenameUrlEncoder;
 use App\Service\Storage\StorageFileNameParser;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -373,6 +374,18 @@ class StoreFormSubmissionJob implements ShouldQueue
         // Handle pre-existing full URLs (e.g., from prefill)
         if (filter_var($value, FILTER_VALIDATE_URL) !== false && str_contains($value, parse_url(config('app.url'))['host'])) {
             $fileName = explode('?', basename($value))[0];
+            if (FilenameUrlEncoder::isEncoded($fileName)) {
+                $fileName = FilenameUrlEncoder::decode($fileName);
+            }
+
+            // Existing submission uploads are returned as signed URLs. Keep their
+            // canonical storage name when an edit submits that URL back to us.
+            if ($this->isSkipForUpload($fileName)) {
+                $parser = StorageFileNameParser::parse($fileName);
+
+                return $parser->getMovedFileName() ?? $fileName;
+            }
+
             $path = FormController::ASSETS_UPLOAD_PATH . '/' . $fileName; // Assuming assets are in a defined path
             $newPath = FileUploadPathService::getFileUploadPath($this->form->id, $fileName);
             Storage::move($path, $newPath);

--- a/api/app/Service/Pdf/PdfContentRenderer.php
+++ b/api/app/Service/Pdf/PdfContentRenderer.php
@@ -3,6 +3,7 @@
 namespace App\Service\Pdf;
 
 use App\Models\Forms\Form;
+use App\Service\Storage\FilenameUrlEncoder;
 use Illuminate\Support\Facades\Log;
 use setasign\Fpdi\Fpdi;
 
@@ -83,6 +84,10 @@ class PdfContentRenderer
 
     private function isImageReference(string $value): bool
     {
+        if (FilenameUrlEncoder::isEncoded($value)) {
+            return true;
+        }
+
         if (preg_match('/\.(jpg|jpeg|png|gif|webp)$/i', $value)) {
             return true;
         }

--- a/api/tests/Feature/Forms/FormSubmissionResourceTest.php
+++ b/api/tests/Feature/Forms/FormSubmissionResourceTest.php
@@ -60,3 +60,27 @@ it('sanitizes rich_text and maps files in FormSubmissionResource', function () {
     // Plain text remains raw (escaping is at render time)
     expect($data[$textId])->toBe($textPayload);
 });
+
+it('normalizes an encoded legacy file name before exposing its signed URL', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+    $filesId = 'fl_' . Str::uuid()->toString();
+    $form->properties = array_merge($form->properties, [
+        ['id' => $filesId, 'name' => 'Files', 'type' => 'files'],
+    ]);
+    $form->save();
+
+    $fileName = 'receipt_550e8400-e29b-41d4-a716-446655440000.png';
+    $submission = $form->submissions()->create([
+        'data' => [$filesId => [\App\Service\Storage\FilenameUrlEncoder::encode($fileName)]],
+        'status' => FormSubmission::STATUS_COMPLETED,
+    ]);
+
+    $response = $this->getJson(route('open.forms.submissions.fetch', [$form->id, $submission->id]))
+        ->assertOk();
+
+    $file = $response->json('data')[$filesId][0];
+    expect($file['file_name'])->toBe($fileName)
+        ->and($file['file_url'])->toContain(\App\Service\Storage\FilenameUrlEncoder::encode($fileName));
+});

--- a/api/tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php
+++ b/api/tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php
@@ -10,6 +10,8 @@ use App\Service\Pdf\PdfGeneratorService;
 use App\Service\Pdf\PdfImageRenderer;
 use App\Service\Pdf\PdfImageResolver;
 use App\Service\Pdf\PdfRichTextRenderer;
+use App\Service\Storage\FileUploadPathService;
+use App\Service\Storage\FilenameUrlEncoder;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use setasign\Fpdi\Fpdi;
@@ -271,6 +273,54 @@ describe('PdfGeneratorService', function () {
         expect(Storage::get($resultPath))->toStartWith('%PDF');
         Http::assertSentCount(1);
     });
+
+    it('generates a PDF with both a legacy encoded upload and a signature', function () {
+        $pdfContent = createTestPdf();
+        $templatePath = 'pdf-templates/1/template.pdf';
+        Storage::put($templatePath, $pdfContent);
+
+        $form = createTestForm([
+            'properties' => [
+                ['id' => 'receipt', 'name' => 'Receipt', 'type' => 'files'],
+                ['id' => 'signature', 'name' => 'Signature', 'type' => 'signature'],
+            ],
+        ]);
+        $receiptFileName = 'receipt_550e8400-e29b-41d4-a716-446655440000.png';
+        $signatureFileName = 'sign_550e8400-e29b-41d4-a716-446655440001.png';
+        Storage::put(FileUploadPathService::getFileUploadPath($form->id, $receiptFileName), tinyPngBytes());
+        Storage::put(FileUploadPathService::getFileUploadPath($form->id, $signatureFileName), tinyPngBytes());
+
+        $template = PdfTemplate::create([
+            'form_id' => $form->id,
+            'name' => 'Upload and signature template',
+            'filename' => 'template.pdf',
+            'original_filename' => 'Template.pdf',
+            'file_path' => $templatePath,
+            'file_size' => strlen($pdfContent),
+            'page_count' => 1,
+            'page_manifest' => [
+                ['id' => 'page-1', 'type' => 'source', 'source_page' => 1],
+            ],
+            'zone_mappings' => [
+                ['id' => 'receipt-zone', 'page_id' => 'page-1', 'field_id' => 'receipt', 'x' => 10, 'y' => 10, 'width' => 30, 'height' => 20],
+                ['id' => 'signature-zone', 'page_id' => 'page-1', 'field_id' => 'signature', 'x' => 50, 'y' => 10, 'width' => 30, 'height' => 20],
+            ],
+            'filename_pattern' => 'output',
+        ]);
+
+        $submission = $form->submissions()->create([
+            'data' => [
+                'receipt' => [FilenameUrlEncoder::encode($receiptFileName)],
+                'signature' => $signatureFileName,
+            ],
+        ]);
+
+        $resultPath = (new PdfGeneratorService())->generateFromTemplate($form, $submission, $template);
+        $result = Storage::get($resultPath);
+
+        expect($result)->toStartWith('%PDF')
+            ->and(substr_count($result, '/Subtype /Image'))->toBeGreaterThanOrEqual(2);
+    });
 });
 
 describe('PdfNotSupportedException', function () {
@@ -390,6 +440,71 @@ describe('PdfContentRenderer scalar values', function () {
         );
 
         expect($richTextRenderer->rendered)->toBeFalse();
+    });
+
+    it('renders encoded upload names as images instead of PDF text', function () {
+        $imageResolver = new class () extends PdfImageResolver {
+            public array $resolvedValues = [];
+
+            public function resolveContent(string $imageValue): ?string
+            {
+                $this->resolvedValues[] = $imageValue;
+
+                return tinyPngBytes();
+            }
+        };
+
+        $imageRenderer = new class () extends PdfImageRenderer {
+            public ?string $renderedContent = null;
+
+            public function render(
+                Fpdi $pdf,
+                string $imageContent,
+                float $x,
+                float $y,
+                float $width,
+                float $height
+            ): void {
+                $this->renderedContent = $imageContent;
+            }
+        };
+
+        $richTextRenderer = new class () extends PdfRichTextRenderer {
+            public bool $rendered = false;
+
+            public function render(
+                Fpdi $pdf,
+                string $text,
+                float $x,
+                float $y,
+                float $width,
+                float $height,
+                array $zone,
+                float $pageWidth
+            ): void {
+                $this->rendered = true;
+            }
+        };
+
+        $renderer = new PdfContentRenderer(null, $imageResolver, $imageRenderer, $richTextRenderer);
+        $pdf = new Fpdi();
+        $pdf->AddPage();
+        $encodedFileName = FilenameUrlEncoder::encode('receipt_550e8400-e29b-41d4-a716-446655440000.png');
+
+        $renderer->renderContent(
+            $pdf,
+            $encodedFileName,
+            10,
+            10,
+            80,
+            20,
+            ['font_size' => 12, 'font_color' => '#000000'],
+            210
+        );
+
+        expect($imageResolver->resolvedValues)->toBe([$encodedFileName])
+            ->and($imageRenderer->renderedContent)->toBe(tinyPngBytes())
+            ->and($richTextRenderer->rendered)->toBeFalse();
     });
 
     it('renders inline rich text segments without dropping styled required marks', function () {

--- a/api/tests/Feature/Submissions/EditSubmissionTest.php
+++ b/api/tests/Feature/Submissions/EditSubmissionTest.php
@@ -1,5 +1,11 @@
 <?php
 
+use App\Models\Forms\FormSubmission;
+use App\Service\Storage\FilenameUrlEncoder;
+use App\Service\Storage\FileUploadPathService;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+
 it('can update form submission', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);
@@ -54,4 +60,38 @@ it('cannot update form submission as non admin', function () {
     $this->actingAs($secondUser);
     $updateResponse = $this->putJson(route('open.forms.submissions.update', ['form' => $form, 'submission_id' => $submission->id]), $updatedFormData)
         ->assertStatus(403);
+});
+
+it('keeps an existing upload canonical when an edited submission submits its signed URL', function () {
+    Storage::fake('local');
+
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+    $fileFieldId = collect($form->properties)->firstWhere('type', 'files')['id'];
+
+    $fileName = 'receipt_550e8400-e29b-41d4-a716-446655440000.png';
+    Storage::put(
+        FileUploadPathService::getFileUploadPath($form->id, $fileName),
+        base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMBAQEAAP8AAAAASUVORK5CYII=', true)
+    );
+
+    $submission = $form->submissions()->create([
+        'data' => [$fileFieldId => [$fileName]],
+        'status' => FormSubmission::STATUS_COMPLETED,
+    ]);
+
+    $signedUploadUrl = URL::signedRoute(
+        'open.forms.submissions.file',
+        [$form->id, FilenameUrlEncoder::encode($fileName)]
+    );
+
+    $this->putJson(route('open.forms.submissions.update', [
+        'form' => $form,
+        'submission_id' => $submission->id,
+    ]), [
+        $fileFieldId => [$signedUploadUrl],
+    ])->assertSuccessful();
+
+    expect($submission->fresh()->data[$fileFieldId])->toBe([$fileName]);
 });


### PR DESCRIPTION
## Summary

Fixes PDF generation after editing a submission that already contains an uploaded image.

## Root cause

The submission editor resubmitted a signed file URL. Its URL-safe encoded filename was then stored as the submission value, so the PDF renderer no longer recognized it as an image and rendered the token as text.

## Changes

- Decode signed upload URLs before persisting them and retain the canonical stored filename.
- Normalize previously persisted encoded names when exposing submission file links.
- Treat legacy encoded filenames as image references during PDF generation.

## Impact

New edits preserve existing uploads. Previously affected submissions render their upload correctly in newly generated PDFs and expose usable file links without a data migration.

## Validation

- `./vendor/bin/pest tests/Feature/Submissions/EditSubmissionTest.php tests/Feature/Forms/FormSubmissionResourceTest.php tests/Feature/Integrations/Pdf/PdfGeneratorServiceTest.php tests/Unit/Service/Storage/FilenameUrlEncoderTest.php tests/Unit/Service/Pdf/PdfImageResolverTest.php`
  - 61 passed, 146 assertions
- `./vendor/bin/pint --test`
  - 813 files compliant