### PR TITLE
Fix double escaping in email submission data

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -295,6 +295,7 @@ class FormSubmissionFormatter
 
             if ($this->createLinks && empty($field['value_is_html'])) {
                 $field['value'] = $this->escapeHtmlValue($field['value']);
+                $field['value_is_html'] = true;
             }
 
             $transformedFields[] = $field;

--- a/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
+++ b/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
@@ -455,3 +455,35 @@ test('email notification escapes submission html while keeping generated links c
     expect($html)->toContain('href="https://example.com/path"');
     expect($html)->toContain('>https://example.com/path<');
 });
+
+test('email notification renders plain submission values once in the submission data block', function () {
+    $user = $this->actingAsProUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $textField = collect($form->properties)->firstWhere('name', 'Name');
+    $submissionData = [
+        $textField['id'] => "Café d'Art & <b>test</b>",
+    ];
+
+    $integrationData = (object) [
+        'sender_name' => 'Test Sender',
+        'subject' => 'Test Subject',
+        'email_content' => '<p>Body</p>',
+        'include_submission_data' => true,
+    ];
+
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, $submissionData),
+        $integrationData
+    );
+
+    $html = (string) $notification->toMail(new AnonymousNotifiable())->render();
+
+    expect($html)->toContain('Café d');
+    expect($html)->toContain('&lt;b&gt;test&lt;/b&gt;');
+    expect($html)->not->toContain('&amp;#039;');
+    expect($html)->not->toContain('&amp;amp;');
+    expect($html)->not->toContain('&amp;lt;b&amp;gt;test&amp;lt;/b&amp;gt;');
+    expect($html)->not->toContain("Café d'Art & <b>test</b>");
+});


### PR DESCRIPTION
## What changed

- Prevent already-escaped plain submission values from being escaped again in email notifications.
- Add a regression test for apostrophes, ampersands, HTML-like input, and UTF-8 accents in the automatic submission-data block.

## Root cause

The notification formatter escaped plain values for safe HTML rendering, then the email template escaped them a second time. This caused values such as `I'm` to appear as `I&#039;m` in email notifications.

## Impact

New notification emails render plain submission values correctly while preserving XSS protection. Existing submission data needs no migration because it is stored unescaped.

## Validation

- `APP_ENV=codex ./vendor/bin/pest tests/Feature/Integrations/Email/EmailIntegrationTest.php --display-warnings`
- `APP_ENV=codex ./vendor/bin/pest tests/Feature/Forms/EmailNotificationTest.php --filter='renders rich text field values as html in submission data' --display-warnings`
- `./vendor/bin/pint --test app/Service/Forms/FormSubmissionFormatter.php tests/Feature/Integrations/Email/EmailIntegrationTest.php`
- `git diff --check`