### PR TITLE
fix: prevent OIDC restart during account linking

### DIFF
--- a/api/tests/Feature/Enterprise/Oidc/OidcLinkControllerTest.php
+++ b/api/tests/Feature/Enterprise/Oidc/OidcLinkControllerTest.php
@@ -14,6 +14,43 @@ afterEach(function () {
 });
 
 describe('OidcLinkController', function () {
+    it('completes an account link after the one-time password login allowed by forced OIDC', function () {
+        $connection = IdentityConnection::factory()->create([
+            'enabled' => true,
+            'type' => IdentityConnection::TYPE_OIDC,
+        ]);
+        $user = $this->createUser();
+        $linkToken = app(OidcLinkService::class)->createLinkToken(
+            connectionId: $connection->id,
+            subject: 'existing-account-subject',
+            email: $user->email,
+            claims: ['email' => $user->email],
+        );
+        config(['oidc.force_login' => true]);
+
+        $loginResponse = $this->postJson('/login', [
+            'email' => $user->email,
+            'password' => 'Abcd@1234',
+            'oidc_link_token' => $linkToken,
+        ])->assertSuccessful();
+
+        $this->withToken($loginResponse->json('token'))
+            ->postJson('/auth/oidc/link', [
+                'link_token' => $linkToken,
+            ])
+            ->assertSuccessful()
+            ->assertJson(['linked' => true]);
+
+        $this->assertDatabaseHas('user_identities', [
+            'user_id' => $user->id,
+            'connection_id' => $connection->id,
+            'subject' => 'existing-account-subject',
+            'email' => $user->email,
+        ]);
+
+        config(['oidc.force_login' => false]);
+    });
+
     it('links an existing account with a valid token', function () {
         $user = $this->actingAsUser();
         $connection = IdentityConnection::factory()->create();

--- a/client/components/pages/auth/components/LoginForm.vue
+++ b/client/components/pages/auth/components/LoginForm.vue
@@ -257,7 +257,7 @@ onBeforeUnmount(() => {
 
 // Methods
 const checkOidcOptions = async () => {
-  if (!oidcAvailable.value || !form.email || form.busy || isOidcRateLimited.value) {
+  if (isLinkingExistingAccount.value || !oidcAvailable.value || !form.email || form.busy || isOidcRateLimited.value) {
     return
   }
 

--- a/client/test/nuxt/oidc-link-flow.spec.ts
+++ b/client/test/nuxt/oidc-link-flow.spec.ts
@@ -535,4 +535,48 @@ describe('OIDC link flow', () => {
         expect(vm.form.oidc_link_token).toBe('link-token-123')
         expect(vm.form.mutate).toHaveBeenCalledOnce()
     })
+
+    it('does not restart OIDC when an account-linking request checks the email field', async () => {
+        linkTokenValue.value = 'link-token-123'
+        setupGlobals({}, {
+            featureFlags: {
+                'oidc.available': true,
+                'oidc.forced': true,
+            },
+        })
+
+        const wrapper = mount(LoginForm, {
+            global: {
+                stubs: {
+                    ForgotPasswordModal: true,
+                    TwoFactorVerificationModal: true,
+                    VForm: {
+                        template: '<form><slot /></form>',
+                        props: ['form'],
+                    },
+                    TextInput: {
+                        template: '<input :name="name" />',
+                        props: ['name'],
+                    },
+                    CheckboxInput: true,
+                    UAlert: true,
+                    UButton: true,
+                    VTransition: {
+                        template: '<div><slot /></div>',
+                    },
+                    NuxtLink: true,
+                    ClientOnly: true,
+                    GoogleOneTap: true,
+                },
+            },
+        })
+
+        const vm = wrapper.vm as any
+        vm.form.email = 'existing@example.com'
+        vm.form.post = vi.fn()
+
+        await vm.checkOidcOptions()
+
+        expect(vm.form.post).not.toHaveBeenCalled()
+    })
 })

--- a/client/test/nuxt/oidc-link-flow.spec.ts
+++ b/client/test/nuxt/oidc-link-flow.spec.ts
@@ -536,7 +536,7 @@ describe('OIDC link flow', () => {
         expect(vm.form.mutate).toHaveBeenCalledOnce()
     })
 
-    it('does not restart OIDC when an account-linking request checks the email field', async () => {
+    it('does not restart OIDC when the email field loses focus during account linking', async () => {
         linkTokenValue.value = 'link-token-123'
         setupGlobals({}, {
             featureFlags: {
@@ -555,8 +555,9 @@ describe('OIDC link flow', () => {
                         props: ['form'],
                     },
                     TextInput: {
-                        template: '<input :name="name" />',
+                        template: '<input :name="name" @blur="$emit(\'blur\')" />',
                         props: ['name'],
+                        emits: ['blur'],
                     },
                     CheckboxInput: true,
                     UAlert: true,
@@ -573,9 +574,10 @@ describe('OIDC link flow', () => {
 
         const vm = wrapper.vm as any
         vm.form.email = 'existing@example.com'
-        vm.form.post = vi.fn()
+        vm.form.post = vi.fn(() => Promise.resolve({ action: 'none' }))
 
-        await vm.checkOidcOptions()
+        await wrapper.find('input[name="email"]').trigger('blur')
+        await flushPromises()
 
         expect(vm.form.post).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
## Summary
- Prevent OIDC email discovery from restarting SSO while an account-link token is active.
- Preserve the password-based account-linking flow after an Entra callback requires linking.
- Add a browser-level regression test for the email-field blur scenario reported by the self-hosted Entra customer.
- Verify the complete API link flow under OIDC_FORCE_LOGIN, from the one-time password sign-in through identity creation.

## Validation
- npm run test -- test/nuxt/oidc-link-flow.spec.ts --run
- npm run lint
- ./vendor/bin/pest tests/Feature/Enterprise/Oidc/OidcLinkControllerTest.php