### PR TITLE
Allow bounded form list page sizes

### DIFF
--- a/api/app/Http/Controllers/Forms/FormController.php
+++ b/api/app/Http/Controllers/Forms/FormController.php
@@ -18,6 +18,7 @@ use App\Service\Forms\FormCleaner;
 use App\Service\Storage\FileUploadPathService;
 use App\Service\Storage\StorageFileNameParser;
 use App\Service\Storage\UploadSecurityService;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -35,10 +36,12 @@ class FormController extends Controller
         $this->formCleaner = new FormCleaner();
     }
 
-    public function index(Workspace $workspace)
+    public function index(Request $request, Workspace $workspace)
     {
         $this->authorize('ownsWorkspace', $workspace);
         $this->authorize('viewAny', Form::class);
+
+        $perPage = min(max($request->integer('per_page', 10), 1), 100);
 
         // Select only columns needed for FormListResource (excludes heavy 'properties' and 'removed_properties')
         $forms = $workspace->forms()
@@ -59,7 +62,8 @@ class FormController extends Controller
             ->withCount(['submissions as submissions_count' => fn ($q) => $q->where('status', FormSubmission::STATUS_COMPLETED)])
             ->withTotalViews()
             ->orderByDesc('updated_at')
-            ->paginate(10);
+            ->paginate($perPage)
+            ->withQueryString();
 
         return FormListResource::collection($forms);
     }

--- a/api/tests/Feature/Forms/FormTest.php
+++ b/api/tests/Feature/Forms/FormTest.php
@@ -35,6 +35,42 @@ it('can fetch forms', function () {
         ->assertJsonPath('data.0.title', $form->title);
 });
 
+it('supports a bounded form list page size', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+
+    foreach (range(1, 15) as $index) {
+        $this->createForm($user, $workspace, [
+            'title' => "Pagination test form {$index}",
+        ]);
+    }
+
+    $this->getJson(route('open.workspaces.forms.index', [
+        'workspace' => $workspace->id,
+        'per_page' => 20,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonCount(15, 'data')
+        ->assertJsonPath('meta.per_page', 20);
+
+    $this->getJson(route('open.workspaces.forms.index', [
+        'workspace' => $workspace->id,
+        'per_page' => 5,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonPath('meta.per_page', 5)
+        ->assertJsonPath('meta.last_page', 3)
+        ->assertJsonPath('links.next', fn (string $url) => str_contains($url, 'per_page=5'));
+
+    $this->getJson(route('open.workspaces.forms.index', [
+        'workspace' => $workspace->id,
+        'per_page' => 1000,
+    ]))
+        ->assertSuccessful()
+        ->assertJsonCount(15, 'data')
+        ->assertJsonPath('meta.per_page', 100);
+});
+
 it('returns lightweight form list without properties', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);


### PR DESCRIPTION
## Summary
- accept a bounded per_page query parameter on workspace form lists
- preserve query parameters across paginator links
- cover requested, capped, and multi-page behavior

## Validation
- ./vendor/bin/pest tests/Feature/Forms/FormTest.php --filter='can fetch forms|supports a bounded form list page size|returns lightweight form list without properties'
- ./vendor/bin/pint --test app/Http/Controllers/Forms/FormController.php tests/Feature/Forms/FormTest.php
- git diff --check

Needed by the Make dynamic form selector to fetch larger workspaces without timing out.