### PR TITLE
Point Make integration to the private app invitation

### DIFF
--- a/api/resources/data/forms/integrations.json
+++ b/api/resources/data/forms/integrations.json
@@ -86,7 +86,7 @@
     "required_tier": "free",
     "is_external": true,
     "is_editable": false,
-    "url": "https://www.make.com/en/integrations/opnform"
+    "url": "https://www.make.com/en/hq/app-invitation/1b83982e264d282615eefd213de7113c"
   },
   "pabbly": {
     "name": "Pabbly",

--- a/client/data/forms/integrations.json
+++ b/client/data/forms/integrations.json
@@ -86,7 +86,7 @@
     "required_tier": "free",
     "is_external": true,
     "is_editable": false,
-    "url": "https://www.make.com/en/integrations/opnform"
+    "url": "https://www.make.com/en/hq/app-invitation/1b83982e264d282615eefd213de7113c"
   },
   "pabbly": {
     "name": "Pabbly",


### PR DESCRIPTION
## Summary
- replace the unavailable marketplace URL with the current private Make app invitation
- keep the client and API integration catalogs synchronized

This should be switched to the official Marketplace URL after Make approves the app.

## Validation
- jq empty on both JSON catalogs
- cmp confirms both copies are identical
- git diff --check