### PR TITLE
Fix signature previews in submissions

### DIFF
--- a/api/app/Http/Controllers/Forms/FormSubmissionController.php
+++ b/api/app/Http/Controllers/Forms/FormSubmissionController.php
@@ -173,7 +173,7 @@ class FormSubmissionController extends Controller
         );
     }
 
-    public function submissionFile(Form $form, $filename)
+    public function submissionFile(Request $request, Form $form, $filename)
     {
         // Decode the base64url encoded filename
         // See: https://github.com/OpnForm/OpnForm/issues/1024
@@ -186,6 +186,33 @@ class FormSubmissionController extends Controller
             return $this->error([
                 'message' => 'File not found.',
             ], 404);
+        }
+
+        $isInlineSignature = $request->boolean('inline')
+            && str_starts_with($decodedFilename, 'sign_')
+            && strtolower(pathinfo($decodedFilename, PATHINFO_EXTENSION)) === 'png';
+
+        if ($isInlineSignature) {
+            $headers = [
+                'Content-Type' => 'image/png',
+                'X-Content-Type-Options' => 'nosniff',
+                'Content-Disposition' => 'inline; filename="' . basename($filePath) . '"',
+            ];
+
+            if (config('filesystems.default') !== 's3') {
+                return response()->file(Storage::path($filePath), $headers);
+            }
+
+            return redirect(
+                Storage::temporaryUrl(
+                    $filePath,
+                    now()->addMinute(),
+                    [
+                        'ResponseContentDisposition' => $headers['Content-Disposition'],
+                        'ResponseContentType' => $headers['Content-Type'],
+                    ]
+                )
+            );
         }
 
         if (config('filesystems.default') !== 's3') {

--- a/api/app/Http/Resources/FormSubmissionResource.php
+++ b/api/app/Http/Resources/FormSubmissionResource.php
@@ -83,7 +83,7 @@ class FormSubmissionResource extends JsonResource
                 $fileItems = is_array($value) ? $value : [$value];
                 $mapped = collect($fileItems)
                     ->filter(fn ($file) => !is_null($file) && $file !== '')
-                    ->map(function ($file) {
+                    ->map(function ($file) use ($type) {
                         $file = (string) $file;
                         if (FilenameUrlEncoder::isEncoded($file)) {
                             $file = FilenameUrlEncoder::decode($file);
@@ -93,12 +93,13 @@ class FormSubmissionResource extends JsonResource
                         // See: https://github.com/OpnForm/OpnForm/issues/1024
                         $encodedFilename = FilenameUrlEncoder::encode($file);
 
+                        $routeParameters = [$this->form_id, $encodedFilename];
+                        if ($type === 'signature') {
+                            $routeParameters['inline'] = 1;
+                        }
+
                         return [
-                            'file_url' => URL::signedRoute(
-                                'open.forms.submissions.file',
-                                [$this->form_id, $encodedFilename],
-                                now()->addMinutes(10)
-                            ),
+                            'file_url' => URL::signedRoute('open.forms.submissions.file', $routeParameters, now()->addMinutes(10)),
                             'file_name' => $file,
                         ];
                     });

--- a/api/tests/Feature/Forms/FileDownloadSecurityTest.php
+++ b/api/tests/Feature/Forms/FileDownloadSecurityTest.php
@@ -43,6 +43,45 @@ it('forces attachment download with safe headers for submission files', function
         ->toBe('nosniff');
 });
 
+it('serves generated signatures inline with a safe image content type', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+    $signatureId = 'signature_' . uniqid();
+    $form->properties = array_merge($form->properties, [
+        ['id' => $signatureId, 'name' => 'Signature', 'type' => 'signature'],
+    ]);
+    $form->save();
+
+    Storage::fake();
+
+    $fileName = 'sign_' . uniqid() . '.png';
+    Storage::put(
+        FileUploadPathService::getFileUploadPath($form->id, $fileName),
+        base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMBAQEAAP8AAAAASUVORK5CYII=', true)
+    );
+
+    $form->submissions()->create([
+        'form_id' => $form->id,
+        'data' => [$signatureId => $fileName],
+        'status' => FormSubmission::STATUS_COMPLETED,
+    ]);
+
+    $submissions = $this->getJson(route('open.forms.submissions.index', [$form->id]))
+        ->assertOk();
+    $signatureUrl = $submissions->json('data.0.data.' . $signatureId . '.0.file_url');
+
+    expect($signatureUrl)->toContain('inline=1');
+
+    $response = $this->get($signatureUrl)->assertOk();
+    expect($response->headers->get('content-disposition'))
+        ->toStartWith('inline;');
+    expect(strtolower($response->headers->get('content-type')))
+        ->toStartWith('image/png');
+    expect($response->headers->get('x-content-type-options'))
+        ->toBe('nosniff');
+});
+
 it('does not eager load workspace users for signed submission file downloads', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);


### PR DESCRIPTION
## Summary

- serve generated PNG signatures inline so they render in submission views
- keep regular uploads and non-PNG files as forced downloads
- add a regression test covering the signed URL and security headers

## Testing

- `php vendor/bin/pest tests/Feature/Forms/FileDownloadSecurityTest.php`
- `php vendor/bin/pint --test app/Http/Controllers/Forms/FormSubmissionController.php app/Http/Resources/FormSubmissionResource.php tests/Feature/Forms/FileDownloadSecurityTest.php`

Fixes #1089.
Related: #1063.
