### PR TITLE
fix(docker): don't forward empty X-Forwarded-Host/Proto to PHP

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -3,6 +3,20 @@ map $request_uri $api_uri {
     default $request_uri;
 }
 
+# Some upstream proxies (e.g. Cloudflare Tunnel) send Host and X-Forwarded-Proto
+# but omit X-Forwarded-Host. Forwarding the header as an empty value makes Laravel
+# resolve the host to "", so signed URLs are validated against "https:///..." and
+# always fail. Fall back to the request's own values when the header is absent.
+map $http_x_forwarded_host $fwd_host {
+    ""      $host;
+    default $http_x_forwarded_host;
+}
+
+map $http_x_forwarded_proto $fwd_proto {
+    ""      $scheme;
+    default $http_x_forwarded_proto;
+}
+
 server {
     listen 80;
     server_name opnform;
@@ -39,9 +53,9 @@ server {
         # Laravel accepts these headers only from IPs listed in TRUSTED_PROXIES.
         # This preserves the client IP behind an explicitly trusted reverse proxy.
         fastcgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
-        fastcgi_param HTTP_X_FORWARDED_HOST $http_x_forwarded_host;
+        fastcgi_param HTTP_X_FORWARDED_HOST $fwd_host;
         fastcgi_param HTTP_X_FORWARDED_PORT $http_x_forwarded_port;
-        fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $fwd_proto;
     }
 
     # Deny access to . files


### PR DESCRIPTION
## Problem

Every signed URL 403s with `{"message":"Invalid signature."}` when OpnForm sits behind a proxy that sends `Host` and `X-Forwarded-Proto` but **not** `X-Forwarded-Host`. Cloudflare Tunnel does exactly this — a captured request arriving at the ingress:

```
Host: form.example.app
X-Forwarded-Proto: https
X-Forwarded-For: 203.0.113.10
Cf-Connecting-Ip: 203.0.113.10
Cf-Visitor: {"scheme":"https"}
```

No `X-Forwarded-Host`. But `docker/nginx.conf` forwards it to php-fpm unconditionally:

```nginx
fastcgi_param HTTP_X_FORWARDED_HOST $http_x_forwarded_host;
```

so PHP receives a *present but empty* header. With a trusted proxy (`TRUSTED_PROXIES`), Symfony believes it and drops the hostname:

```
empty XFH  -> https:///open/forms/2/submissions/file/x     ← Warning: Uninitialized string offset 0
                                                              (symfony/http-foundation Request.php:969)
absent XFH -> https://form.example.app/open/forms/2/submissions/file/x
```

`URL::signedRoute()` signs the correct URL, `ValidateSignature` checks the mangled one, and the request is rejected.

This breaks **all** submission file downloads and image previews (`FormSubmissionResource` signs every file/signature URL), plus every other route behind the `signed` middleware, such as PDF template downloads.

## Fix

Fall back to the request's own `$host` / `$scheme` when the header is absent, instead of forwarding an empty value.

`X-Forwarded-Port` is deliberately left alone — an empty value *is* handled correctly by Symfony, and defaulting it to `$server_port` would produce `host:80` under `https` and break signatures a second way. `X-Forwarded-For` uses `$proxy_add_x_forwarded_for`, which is never empty.

## Verification

Same signed URL, before and after, on a real deployment behind Cloudflare Tunnel:

| Case | Before | After |
| --- | --- | --- |
| Valid signature, real file | 403 | **200** (correct bytes) |
| Valid signature, missing file | 403 | 404 |
| Tampered signature | 403 | 403 |
| Expired signature | 403 | 403 |
| Client-spoofed `X-Forwarded-Host` | — | 403 |

The last row is the one that matters for security: because the signature was generated against the real host, a client-supplied `X-Forwarded-Host` still cannot be used to forge a working URL. `nginx -t` passes; direct-to-ingress deployments are unaffected, since the maps only change behaviour when the header is missing.
