### PR TITLE
fix(submissions): show signature previews on a white background

### DIFF
--- a/client/components/open/tables/components/OpenFile.vue
+++ b/client/components/open/tables/components/OpenFile.vue
@@ -13,6 +13,7 @@
         v-if="file.is_image"
         type="button"
         class="block h-8 w-8 overflow-hidden rounded border border-neutral-200 transition-opacity hover:opacity-80 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+        :class="{ 'bg-white': isSignature }"
         :aria-label="`Preview ${file.displayed_file_name}`"
         @click="openFilePreview(file)"
       >
@@ -79,7 +80,8 @@
       <template #body>
         <div
           v-if="selectedFile?.is_image"
-          class="flex min-h-64 items-center justify-center bg-neutral-950"
+          class="flex min-h-64 items-center justify-center"
+          :class="isSignature ? 'bg-white' : 'bg-neutral-950'"
         >
           <img
             class="max-h-[75vh] w-full object-contain"
@@ -151,6 +153,10 @@ const props = defineProps({
 })
 
 const PDF_PREVIEW_PAGE_LIMIT = 10
+
+// Signatures are saved as transparent PNGs, so the dark preview backdrop used for
+// photos hides the ink. Show them on white, matching the downloaded file.
+const isSignature = computed(() => props.property?.type === "signature")
 
 const failedImages = ref([])
 const isFilePreviewOpen = ref(false)


### PR DESCRIPTION
## Problem

A signature in the submissions table is invisible when previewed — black ink on a black backdrop:

The preview modal in `OpenFile.vue` renders *every* image on `bg-neutral-950`:

```html
<div
  v-if="selectedFile?.is_image"
  class="flex min-h-64 items-center justify-center bg-neutral-950"
>
```

That dark lightbox is a good default for uploaded photos, but signatures are stored as **transparent PNGs**, and `SignatureInput` draws them with `penColor` `#000` in light mode. Inspecting a stored signature confirms it:

```
size (1260, 300)   opaque px 6892
avg ink RGB (0, 0, 0)   luminance 0.0
```

So the ink is exactly the same colour as the backdrop. Downloading the identical file and opening it renders fine, which is what makes the bug confusing to report.

## Fix

`OpenFile` is registered for both the `files` and `signature` column types and already receives the column definition through its `property` prop (`:property="col"` in `OpenTable.vue`) — the prop was declared but unused. Use it to pick the backdrop: signatures get white, photos keep the dark lightbox.

The 8×8 table thumbnail gets the same treatment, since it is invisible in dark mode for the same reason.

## Known limitation

`SignatureInput` sets `penColor` from the *signer's* theme (`this.isDark ? '#fff' : '#000'`), so a respondent who signs in dark mode stores white-on-transparent ink, which is invisible on white — and equally invisible in PDF exports, prints and downloads, independent of this change. A more complete fix would be to always draw signatures in a dark ink, or to flatten them onto a white background at save time. Happy to follow up with that in a separate PR if you'd like.

## Verification

Built the client image from this branch and deployed it. Compiled output confirms the binding survives the build:

```js
class: Q(["flex min-h-64 items-center justify-center", s(t) ? "bg-white" : "bg-neutral-950"])
// t = computed(() => props.property?.type === "signature")
```

Signature previews now render black-on-white and are legible; photo previews are unchanged on `bg-neutral-950`.
