### PR TITLE
Animate form control focus and blur states

### DIFF
--- a/client/components/forms/core/ColorInput.vue
+++ b/client/components/forms/core/ColorInput.vue
@@ -11,6 +11,8 @@
         :disabled="disabled ? true : null"
         type="color"
         class="mr-2"
+        :class="ui.input({ class: props.ui?.slots?.input })"
+        :style="inputStyle"
         :name="name"
         @keydown.enter="onEnterPress"
       >
@@ -44,7 +46,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'focus', 'blur'])
 
-const { compVal, inputWrapperProps } = useFormInput(props, { emit }, {
+const { compVal, inputWrapperProps, inputStyle, ui } = useFormInput(props, { emit }, {
   variants: colorInputTheme
 })
 

--- a/client/components/forms/core/FlatSelectInput.vue
+++ b/client/components/forms/core/FlatSelectInput.vue
@@ -11,6 +11,7 @@
     />
     <div
       v-else
+      :style="inputStyle"
       :class="[
         ui.container({ class: props.ui?.slots?.container }),
         hasImages ? imageContainerClass : ''

--- a/client/components/forms/core/FocusedSelectorInput.vue
+++ b/client/components/forms/core/FocusedSelectorInput.vue
@@ -148,6 +148,7 @@ const {
   resolvedTheme,
   resolvedSize,
   resolvedBorderRadius,
+  hasError,
   ui
 } = useFormInput(props, { emit }, {
   variants: focusedSelectorInputTheme
@@ -162,6 +163,7 @@ const animatingOption = ref(null) // Track which option is animating
 const optionStyle = computed(() => ({
   '--bg-form-color': props.color,
   '--form-color': props.color,
+  '--form-focus-color': hasError.value ? 'var(--color-red-500)' : props.color,
   '--text-form-color': props.color
 }))
 

--- a/client/components/forms/core/FocusedSelectorInput.vue
+++ b/client/components/forms/core/FocusedSelectorInput.vue
@@ -161,6 +161,7 @@ const animatingOption = ref(null) // Track which option is animating
 // Computed properties
 const optionStyle = computed(() => ({
   '--bg-form-color': props.color,
+  '--form-color': props.color,
   '--text-form-color': props.color
 }))
 

--- a/client/components/forms/core/OptionSelectorInput.vue
+++ b/client/components/forms/core/OptionSelectorInput.vue
@@ -111,7 +111,8 @@ const {
   compVal,
   inputWrapperProps,
   resolvedTheme,
-  resolvedSize
+  resolvedSize,
+  hasError
 } = useFormInput(props, { emit })
 
 // Local state
@@ -123,7 +124,8 @@ const gridClass = computed(() => `grid-cols-${props.columns}`)
 
 const optionStyle = computed(() => ({
   '--bg-form-color': props.color,
-  '--form-color': props.color
+  '--form-color': props.color,
+  '--form-focus-color': hasError.value ? 'var(--color-red-500)' : props.color
 }))
 
 const variants = computed(() => tv(optionSelectorInputTheme, props.ui))

--- a/client/components/forms/core/OptionSelectorInput.vue
+++ b/client/components/forms/core/OptionSelectorInput.vue
@@ -122,7 +122,8 @@ const root = ref(null)
 const gridClass = computed(() => `grid-cols-${props.columns}`)
 
 const optionStyle = computed(() => ({
-  '--bg-form-color': props.color
+  '--bg-form-color': props.color,
+  '--form-color': props.color
 }))
 
 const variants = computed(() => tv(optionSelectorInputTheme, props.ui))

--- a/client/components/forms/core/ScaleInput.vue
+++ b/client/components/forms/core/ScaleInput.vue
@@ -18,7 +18,6 @@
           compVal !== i ? ui.buttonUnselected({ class: props.ui?.slots?.buttonUnselected }) : '',
           compVal !== i ? ui.buttonHover({ class: props.ui?.slots?.buttonHover }) : ''
         ]"
-        class="focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none"
         :style="btnStyle(i === compVal)"
         role="radio"
         :tabindex="getScaleTabIndex(i)"
@@ -117,8 +116,13 @@ export default {
       }
     },
     btnStyle(isSelected) {
-      if (!isSelected) return {}
+      const style = {
+        '--bg-form-color': this.color,
+        '--form-color': this.color
+      }
+      if (!isSelected) return style
       return {
+        ...style,
         color: this.textColor,
         backgroundColor: this.color,
       }

--- a/client/components/forms/core/ScaleInput.vue
+++ b/client/components/forms/core/ScaleInput.vue
@@ -118,7 +118,8 @@ export default {
     btnStyle(isSelected) {
       const style = {
         '--bg-form-color': this.color,
-        '--form-color': this.color
+        '--form-color': this.color,
+        '--form-focus-color': this.hasError ? 'var(--color-red-500)' : this.color
       }
       if (!isSelected) return style
       return {

--- a/client/components/forms/core/SliderInput.vue
+++ b/client/components/forms/core/SliderInput.vue
@@ -18,7 +18,7 @@
           v-model.number="compVal"
           type="range"
           :class="[ui.slider({ class: props.ui?.slots?.slider }), 'slider']"
-          :style="{ '--thumb-color': color }"
+          :style="[inputStyle, { '--thumb-color': color }]"
           :disabled="disabled"
           :min="minSlider"
           :max="maxSlider"

--- a/client/components/forms/core/ToggleSwitchInput.vue
+++ b/client/components/forms/core/ToggleSwitchInput.vue
@@ -9,9 +9,13 @@
         :id="id ? id : name"
         v-model="compVal"
         :disabled="disabled ? true : null"
-        :style="colorStyle"
+        :style="inputStyle"
         :ui="{
-          base: 'data-[state=checked]:bg-[var(--form-color,#3B82F6)] focus-visible:outline-[var(--form-color,#3B82F6)]'
+          base: [
+            'data-[state=checked]:bg-[var(--form-color,#3B82F6)]',
+            formControlTransition,
+            formControlFocusVisibleHalo
+          ]
         }"
         @keydown="handleKeydown"
       />
@@ -68,6 +72,7 @@
 import {inputProps, useFormInput} from "../useFormInput.js"
 import InputHelp from "~/components/forms/core/components/InputHelp.vue"
 import { toggleSwitchInputTheme } from "~/lib/forms/themes/toggle-switch-input.theme.js"
+import { formControlFocusVisibleHalo, formControlTransition } from "~/lib/forms/themes/focus-ring.theme.js"
 
 export default {
   name: "ToggleSwitchInput",
@@ -82,10 +87,6 @@ export default {
       variants: toggleSwitchInputTheme
     })
 
-    const colorStyle = computed(() => ({
-      '--form-color': props.color
-    }))
-
     const handleKeydown = (event) => {
       if (props.disabled) return
 
@@ -97,7 +98,8 @@ export default {
 
     return {
       ...formInput,
-      colorStyle,
+      formControlFocusVisibleHalo,
+      formControlTransition,
       handleKeydown,
       props
     }

--- a/client/components/forms/core/components/CheckboxIcon.vue
+++ b/client/components/forms/core/components/CheckboxIcon.vue
@@ -47,7 +47,8 @@ const resolvedTheme = computed(() => {
 
 // Color style for CSS custom property
 const colorStyle = computed(() => ({
-  '--form-color': props.color
+  '--form-color': props.color,
+  '--form-focus-color': props.color
 }))
 
 // OPTIMIZED: Single computed following Nuxt UI pattern

--- a/client/components/forms/core/components/RadioButtonIcon.vue
+++ b/client/components/forms/core/components/RadioButtonIcon.vue
@@ -47,7 +47,8 @@ const resolvedTheme = computed(() => {
 
 // Color style for CSS custom property
 const colorStyle = computed(() => ({
-  '--form-color': props.color
+  '--form-color': props.color,
+  '--form-focus-color': props.color
 }))
 
 // OPTIMIZED: Single computed following Nuxt UI pattern

--- a/client/components/forms/core/components/VCheckbox.vue
+++ b/client/components/forms/core/components/VCheckbox.vue
@@ -55,7 +55,8 @@ const resolvedSize = computed(() => {
 // Color style for CSS custom property
 const colorStyle = computed(() => ({
   '--accent-color': props.color,
-  '--form-color': props.color
+  '--form-color': props.color,
+  '--form-focus-color': props.color
 }))
 
 // OPTIMIZED: Single computed following Nuxt UI pattern

--- a/client/components/forms/core/components/VSelect.vue
+++ b/client/components/forms/core/components/VSelect.vue
@@ -358,12 +358,15 @@ export default {
 
     optionStyle () {
       return {
-        '--bg-form-color': this.color
+        '--bg-form-color': this.color,
+        '--form-color': this.color
       }
     },
     inputStyle () {
       return {
-        '--tw-ring-color': this.color
+        '--tw-ring-color': this.color,
+        '--form-color': this.color,
+        '--bg-form-color': this.color
       }
     },
     popoverContentStyle () {

--- a/client/components/forms/core/components/VSelect.vue
+++ b/client/components/forms/core/components/VSelect.vue
@@ -359,13 +359,15 @@ export default {
     optionStyle () {
       return {
         '--bg-form-color': this.color,
-        '--form-color': this.color
+        '--form-color': this.color,
+        '--form-focus-color': this.hasError ? 'var(--color-red-500)' : this.color
       }
     },
     inputStyle () {
       return {
         '--tw-ring-color': this.color,
         '--form-color': this.color,
+        '--form-focus-color': this.hasError ? 'var(--color-red-500)' : this.color,
         '--bg-form-color': this.color
       }
     },

--- a/client/components/forms/heavy/CodeInput.client.vue
+++ b/client/components/forms/heavy/CodeInput.client.vue
@@ -8,7 +8,10 @@
       <slot name="help" />
     </template>
 
-    <div :class="ui.container({ class: props.ui?.slots?.container })">
+    <div
+      :class="ui.container({ class: props.ui?.slots?.container })"
+      :style="inputStyle"
+    >
       <!-- Fullscreen button -->
       <UTooltip text="Open in fullscreen" :content="{ side: 'left' }" arrow>
         <UButton

--- a/client/components/forms/heavy/DateInput.vue
+++ b/client/components/forms/heavy/DateInput.vue
@@ -207,6 +207,8 @@ const handleCompValChange = () => {
 const setInputColor = () => {
   if (triggerButton.value) {
     triggerButton.value.style.setProperty('--tw-ring-color', props.color)
+    triggerButton.value.style.setProperty('--form-color', props.color)
+    triggerButton.value.style.setProperty('--bg-form-color', props.color)
   }
 }
 

--- a/client/components/forms/heavy/DateInput.vue
+++ b/client/components/forms/heavy/DateInput.vue
@@ -133,7 +133,8 @@ const props = defineProps({
 const {
   ui,
   compVal,
-  inputWrapperProps
+  inputWrapperProps,
+  hasError
 } = useFormInput(props, getCurrentInstance(), {
   variants: dateInputTheme
 })
@@ -208,6 +209,7 @@ const setInputColor = () => {
   if (triggerButton.value) {
     triggerButton.value.style.setProperty('--tw-ring-color', props.color)
     triggerButton.value.style.setProperty('--form-color', props.color)
+    triggerButton.value.style.setProperty('--form-focus-color', hasError.value ? 'var(--color-red-500)' : props.color)
     triggerButton.value.style.setProperty('--bg-form-color', props.color)
   }
 }
@@ -318,7 +320,7 @@ const formattedDatePreview = computed(() => {
   return formattedDate(fromDate.value)
 })
 
-watch(() => props.color, () => {
+watch([() => props.color, hasError], () => {
   setInputColor()
 }, { immediate: true })
 

--- a/client/components/forms/heavy/MatrixInput.vue
+++ b/client/components/forms/heavy/MatrixInput.vue
@@ -3,7 +3,10 @@
     <template #label>
       <slot name="label" />
     </template>
-    <div :class="ui.container({ class: props.ui?.slots?.container })">
+    <div
+      :class="ui.container({ class: props.ui?.slots?.container })"
+      :style="inputStyle"
+    >
       <table class="w-full table-auto">
         <thead class="">
           <tr>
@@ -87,7 +90,7 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'focus', 'blur'])
 
-const { compVal, inputWrapperProps, ui, resolvedTheme } = useFormInput(props, { emit }, {
+const { compVal, inputWrapperProps, inputStyle, ui, resolvedTheme } = useFormInput(props, { emit }, {
   variants: matrixInputTheme
 })
 

--- a/client/components/forms/heavy/RatingInput.vue
+++ b/client/components/forms/heavy/RatingInput.vue
@@ -6,6 +6,7 @@
 
     <div 
       class="stars-outer"
+      :style="inputStyle"
       role="slider"
       :aria-valuemin="0"
       :aria-valuemax="starsCount"

--- a/client/components/forms/heavy/SignatureInput.vue
+++ b/client/components/forms/heavy/SignatureInput.vue
@@ -32,9 +32,12 @@
       ref="signaturePad"
       class="not-draggable"
       :class="ui.container({ class: props.ui?.slots?.container })"
+      :style="inputStyle"
       height="150px"
       :name="name"
       :options="{ onEnd, penColor }"
+      tabindex="0"
+      @pointerdown="$event.currentTarget.focus()"
     />
 
     <template #bottom_after_help>

--- a/client/components/forms/useFormInput.js
+++ b/client/components/forms/useFormInput.js
@@ -63,14 +63,6 @@ export function useFormInput(props, context, options = {}) {
     return props.form || injectedForm?.value || null
   })
 
-  const inputStyle = computed(() => {
-    return {
-      "--tw-ring-color": props.color,
-      "--form-color": props.color,
-      "--bg-form-color": props.color,
-    }
-  })
-
   const hasValidation = computed(() => {
     return (
       resolvedForm.value !== null &&
@@ -81,6 +73,15 @@ export function useFormInput(props, context, options = {}) {
 
   const hasError = computed(() => {
     return hasValidation.value && resolvedForm.value?.errors?.has(props.name)
+  })
+
+  const inputStyle = computed(() => {
+    return {
+      "--tw-ring-color": props.color,
+      "--form-color": props.color,
+      "--form-focus-color": hasError.value ? "var(--color-red-500)" : props.color,
+      "--bg-form-color": props.color,
+    }
   })
 
   const compVal = computed({

--- a/client/components/forms/useFormInput.js
+++ b/client/components/forms/useFormInput.js
@@ -66,6 +66,8 @@ export function useFormInput(props, context, options = {}) {
   const inputStyle = computed(() => {
     return {
       "--tw-ring-color": props.color,
+      "--form-color": props.color,
+      "--bg-form-color": props.color,
     }
   })
 
@@ -196,4 +198,3 @@ export function useFormInput(props, context, options = {}) {
     ui,
   }
 }
-

--- a/client/lib/forms/themes/code-input.theme.js
+++ b/client/lib/forms/themes/code-input.theme.js
@@ -1,17 +1,21 @@
+import { formControlFocusWithin, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * CodeInput tailwind-variants configuration
  */
 export const codeInputTheme = {
   slots: {
     container: [
-      'h-40 max-h-96 overflow-y-auto relative'
+      'h-40 max-h-96 overflow-y-auto relative',
+      'focus-within:outline-none',
+      formControlTransition
     ]
   },
   variants: {
     theme: {
-      default: { container: 'border border-neutral-300 dark:border-neutral-600' },
-      minimal: { container: 'border-2 border-transparent bg-neutral-100 dark:bg-notion-dark-light' },
-      notion: { container: 'border border-notion-input-border dark:border-notion-input-borderDark' },
+      default: { container: ['border border-neutral-300 dark:border-neutral-600', formControlFocusWithin] },
+      minimal: { container: ['border-2 border-transparent bg-neutral-100 dark:bg-notion-dark-light', formControlFocusWithin] },
+      notion: { container: ['border border-notion-input-border dark:border-notion-input-borderDark', formControlFocusWithin] },
       transparent: { container: 'border-0 bg-transparent dark:bg-transparent !rounded-none shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)] transition-shadow duration-200 focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]' }
     },
     size: {
@@ -40,4 +44,3 @@ export const codeInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/code-input.theme.js
+++ b/client/lib/forms/themes/code-input.theme.js
@@ -16,7 +16,7 @@ export const codeInputTheme = {
       default: { container: ['border border-neutral-300 dark:border-neutral-600', formControlFocusWithin] },
       minimal: { container: ['border-2 border-transparent bg-neutral-100 dark:bg-notion-dark-light', formControlFocusWithin] },
       notion: { container: ['border border-notion-input-border dark:border-notion-input-borderDark', formControlFocusWithin] },
-      transparent: { container: 'border-0 bg-transparent dark:bg-transparent !rounded-none shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)] transition-shadow duration-200 focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]' }
+      transparent: { container: 'border-0 bg-transparent dark:bg-transparent !rounded-none shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)] transition-shadow duration-200 focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]' }
     },
     size: {
       xs: { container: 'rounded-none' },

--- a/client/lib/forms/themes/color-input.theme.js
+++ b/client/lib/forms/themes/color-input.theme.js
@@ -1,8 +1,17 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * ColorInput tailwind-variants configuration
  */
 export const colorInputTheme = {
   slots: {
+    input: [
+      'h-8 w-10 cursor-pointer rounded-md border border-neutral-300 bg-white p-0.5',
+      'dark:border-neutral-600 dark:bg-notion-dark-light',
+      'focus:outline-hidden',
+      formControlTransition,
+      formControlFocus
+    ],
     label: '',
     help: 'text-neutral-500'
   },
@@ -18,4 +27,3 @@ export const colorInputTheme = {
     size: 'md'
   }
 }
-

--- a/client/lib/forms/themes/date-input.theme.js
+++ b/client/lib/forms/themes/date-input.theme.js
@@ -52,7 +52,7 @@ export const dateInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-visible:ring-0 focus-visible:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-visible:ring-0 focus-visible:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         clearButton: 'border-none',
         inner: '!px-0'
@@ -92,7 +92,7 @@ export const dateInputTheme = {
     {
       theme: 'transparent',
       isOpen: true,
-      class: { input: 'ring-0 shadow-[inset_0_-2px_0_0_var(--color-form)] outline-none' }
+      class: { input: 'ring-0 shadow-[inset_0_-2px_0_0_var(--form-focus-color)] outline-none' }
     }
   ],
   defaultVariants: {

--- a/client/lib/forms/themes/date-input.theme.js
+++ b/client/lib/forms/themes/date-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlActive, formControlFocusVisible, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * DateInput tailwind-variants configuration
  */
@@ -6,7 +8,8 @@ export const dateInputTheme = {
     input: [
       'w-full border bg-white dark:bg-notion-dark-light',
       'text-neutral-700 dark:text-neutral-300',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:border-transparent'
+      'focus-visible:outline-none',
+      formControlTransition
     ],
     clearButton: 'hover:bg-neutral-50 dark:hover:bg-neutral-900 ltr:border-l rtl:border-r px-2 flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:ring-inset',
     inner: ''
@@ -16,13 +19,13 @@ export const dateInputTheme = {
       default: { 
         input: [
           'border-neutral-300 dark:border-neutral-600',
-          'focus-visible:ring-form/100'
+          formControlFocusVisible
         ]
       },
       simple: { 
         input: [
           'border-neutral-300 dark:border-neutral-600',
-          'focus-visible:ring-form/100'
+          formControlFocusVisible
         ]
       },
       notion: {
@@ -30,7 +33,7 @@ export const dateInputTheme = {
           'border-notion-input-border dark:border-notion-input-borderDark',
           'bg-notion-input-background dark:bg-notion-dark-light',
           'text-neutral-900 dark:text-neutral-100',
-          'focus-visible:ring-form/40'
+          formControlFocusVisible
         ]
       },
       minimal: {
@@ -38,7 +41,7 @@ export const dateInputTheme = {
           'border-2 border-transparent',
           'bg-neutral-100 dark:bg-notion-dark-light',
           'text-neutral-700 dark:text-neutral-300',
-          'focus-visible:ring-0 focus-visible:border-form'
+          formControlFocusVisible
         ]
       },
       transparent: {
@@ -58,7 +61,7 @@ export const dateInputTheme = {
     // Open state styling used when popover is open (even if trigger is not focused)
     isOpen: {
       true: {
-        input: 'ring-2 ring-form/100 outline-none'
+        input: formControlActive
       }
     },
     size: {

--- a/client/lib/forms/themes/file-input.theme.js
+++ b/client/lib/forms/themes/file-input.theme.js
@@ -1,20 +1,24 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * FileInput tailwind-variants configuration (also used by Barcode and Camera)
  */
 export const fileInputTheme = {
   slots: {
     container: [
-      'flex flex-col w-full items-center justify-center transition-colors duration-40',
+      'flex flex-col w-full items-center justify-center',
+      formControlTransition,
       'border border-dashed',
       'shadow-none',
       'hover:bg-neutral-50 dark:hover:bg-notion-dark-light',
-      'focus:outline-hidden focus:ring-2'
+      'focus:outline-hidden',
+      formControlFocus
     ]
   },
   variants: {
     theme: {
       default: { container: 'border-neutral-300 dark:border-neutral-600' },
-      minimal: { container: 'border-2 border-transparent bg-neutral-100 dark:bg-notion-dark-light text-neutral-700 dark:text-neutral-300 focus:ring-2 focus:ring-form/60' },
+      minimal: { container: 'border-2 border-transparent bg-neutral-100 dark:bg-notion-dark-light text-neutral-700 dark:text-neutral-300' },
       notion: {
         container: 'border-notion-input-border dark:border-notion-input-borderDark bg-notion-input-background dark:bg-notion-dark-light text-neutral-900 dark:text-neutral-100'
       },
@@ -48,4 +52,3 @@ export const fileInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/flat-select-input.theme.js
+++ b/client/lib/forms/themes/flat-select-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocusVisibleInset, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * FlatSelectInput tailwind-variants configuration
  */
@@ -7,15 +9,17 @@ export const flatSelectInputTheme = {
       'relative overflow-hidden',
       'border bg-white dark:bg-notion-dark-light',
       'text-neutral-700 dark:text-neutral-300',
-      'focus-within:outline-hidden'
+      'focus-within:outline-hidden',
+      formControlTransition
     ],
     // Keep base minimal; theme variants add interaction + spacing
     option: [
       'relative',
-      'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
+      'focus-visible:outline-none',
+      formControlFocusVisibleInset,
       'flex items-center',
       'border-t first:border-t-0 px-2',
-      'transition-colors duration-150'
+      formControlTransition
     ],
     help: 'text-neutral-500'
   },
@@ -29,7 +33,6 @@ export const flatSelectInputTheme = {
         ],
         option: [
           'relative',
-          'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
           'border-neutral-300 dark:border-neutral-600',
           'gap-x-2'
         ]
@@ -41,7 +44,6 @@ export const flatSelectInputTheme = {
         ],
         option: [
           'relative',
-          'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
           'border-neutral-300 dark:border-neutral-600',
           'gap-x-2'
         ]
@@ -55,7 +57,6 @@ export const flatSelectInputTheme = {
         ],
         option: [
           'relative',
-          'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
           'border-notion-input-border dark:border-notion-input-borderDark',
           'space-x-2'
         ]
@@ -69,7 +70,6 @@ export const flatSelectInputTheme = {
         ],
         option: [
           'relative',
-          'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
           'border-neutral-200 dark:border-neutral-700',
           'gap-x-2'
         ]
@@ -87,7 +87,6 @@ export const flatSelectInputTheme = {
         ],
         option: [
           'relative',
-          'focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:outline-none',
           'border-neutral-200 dark:border-neutral-700',
           'gap-x-2',
           '!px-0'

--- a/client/lib/forms/themes/flat-select-input.theme.js
+++ b/client/lib/forms/themes/flat-select-input.theme.js
@@ -83,7 +83,7 @@ export const flatSelectInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         option: [
           'relative',

--- a/client/lib/forms/themes/focus-ring.theme.js
+++ b/client/lib/forms/themes/focus-ring.theme.js
@@ -6,31 +6,37 @@ export const formControlTransition = [
 
 export const formControlFocus = [
   'focus:ring-0',
-  'focus:border-form',
-  'focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+  'focus:border-[var(--form-focus-color)]',
+  'focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-focus-color)_24%,transparent)]'
 ]
 
 export const formControlFocusVisible = [
   'focus-visible:ring-0',
-  'focus-visible:border-form',
-  'focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+  'focus-visible:border-[var(--form-focus-color)]',
+  'focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-focus-color)_24%,transparent)]'
+]
+
+export const formControlFocusVisibleHalo = [
+  'focus-visible:ring-0',
+  'focus-visible:outline-none',
+  'focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-focus-color)_24%,transparent)]'
 ]
 
 export const formControlFocusWithin = [
   'focus-within:ring-0',
-  'focus-within:border-form',
-  'focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+  'focus-within:border-[var(--form-focus-color)]',
+  'focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-focus-color)_24%,transparent)]'
 ]
 
 export const formControlFocusVisibleInset = [
   'focus-visible:ring-0',
-  'focus-visible:border-form',
-  'focus-visible:shadow-[inset_0_0_0_2px_color-mix(in_srgb,var(--form-color)_44%,transparent)]'
+  'focus-visible:border-[var(--form-focus-color)]',
+  'focus-visible:shadow-[inset_0_0_0_2px_color-mix(in_srgb,var(--form-focus-color)_44%,transparent)]'
 ]
 
 export const formControlActive = [
   'ring-0',
-  'border-form',
-  'shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]',
+  'border-[var(--form-focus-color)]',
+  'shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-focus-color)_24%,transparent)]',
   'outline-none'
 ]

--- a/client/lib/forms/themes/focus-ring.theme.js
+++ b/client/lib/forms/themes/focus-ring.theme.js
@@ -1,0 +1,36 @@
+export const formControlTransition = [
+  'transition-[color,background-color,border-color,box-shadow]',
+  'duration-200',
+  'ease-out'
+]
+
+export const formControlFocus = [
+  'focus:ring-0',
+  'focus:border-form',
+  'focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+]
+
+export const formControlFocusVisible = [
+  'focus-visible:ring-0',
+  'focus-visible:border-form',
+  'focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+]
+
+export const formControlFocusWithin = [
+  'focus-within:ring-0',
+  'focus-within:border-form',
+  'focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]'
+]
+
+export const formControlFocusVisibleInset = [
+  'focus-visible:ring-0',
+  'focus-visible:border-form',
+  'focus-visible:shadow-[inset_0_0_0_2px_color-mix(in_srgb,var(--form-color)_44%,transparent)]'
+]
+
+export const formControlActive = [
+  'ring-0',
+  'border-form',
+  'shadow-[0_0_0_3px_color-mix(in_srgb,var(--form-color)_24%,transparent)]',
+  'outline-none'
+]

--- a/client/lib/forms/themes/focused-selector-input.theme.js
+++ b/client/lib/forms/themes/focused-selector-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocusWithin } from './focus-ring.theme.js'
+
 /**
  * FocusedSelectorInput tailwind-variants configuration
  * Used for focused mode one-per-line option selection
@@ -8,7 +10,8 @@ export const focusedSelectorInputTheme = {
     option: [
       'w-full border border-transparent transition-all duration-200',
       'overflow-hidden',
-      'group'
+      'group',
+      formControlFocusWithin
     ],
     optionButton: [
       'w-full flex items-center gap-3 transition-all duration-200',
@@ -158,4 +161,3 @@ export const focusedSelectorInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/image-input.theme.js
+++ b/client/lib/forms/themes/image-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * ImageInput tailwind-variants configuration
  */
@@ -6,7 +8,9 @@ export const imageInputTheme = {
     button: [
       'cursor-pointer relative w-full',
       'flex-1 appearance-none w-full',
-      'focus:outline-hidden'
+      'focus:outline-hidden',
+      formControlTransition,
+      formControlFocus
     ],
     help: 'text-neutral-500'
   },
@@ -66,4 +70,3 @@ export const imageInputTheme = {
     hasError: false
   }
 }
-

--- a/client/lib/forms/themes/image-input.theme.js
+++ b/client/lib/forms/themes/image-input.theme.js
@@ -44,7 +44,7 @@ export const imageInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ]
       }
     },

--- a/client/lib/forms/themes/matrix-input.theme.js
+++ b/client/lib/forms/themes/matrix-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocusVisibleInset, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * MatrixInput tailwind-variants configuration
  */
@@ -6,7 +8,7 @@ export const matrixInputTheme = {
     container: 'border overflow-x-auto',
     cell: '',
     cellHover: '',
-    option: 'relative cursor-pointer',
+    option: ['relative cursor-pointer focus-visible:outline-none', formControlTransition],
     iconWrapper: 'flex items-center justify-center h-full w-full',
     headerCell: 'w-full flex items-center justify-center text-neutral-900 dark:text-neutral-100',
     rowCell: 'w-full text-neutral-900 dark:text-neutral-100'
@@ -21,7 +23,7 @@ export const matrixInputTheme = {
         ],
         cell: 'border-neutral-300 dark:border-neutral-600',
         cellHover: 'hover:bg-neutral-50 dark:hover:bg-neutral-900',
-        option: 'hover:bg-neutral-50 dark:hover:bg-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:ring-inset'
+        option: ['hover:bg-neutral-50 dark:hover:bg-neutral-900', formControlFocusVisibleInset]
       },
       simple: {
         container: [
@@ -30,7 +32,7 @@ export const matrixInputTheme = {
         ],
         cell: 'border-neutral-300 dark:border-neutral-600',
         cellHover: 'hover:bg-neutral-50 dark:hover:bg-neutral-900',
-        option: 'hover:bg-neutral-50 dark:hover:bg-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:ring-inset'
+        option: ['hover:bg-neutral-50 dark:hover:bg-neutral-900', formControlFocusVisibleInset]
       },
       notion: {
         container: [
@@ -39,7 +41,7 @@ export const matrixInputTheme = {
         ],
         cell: 'border-notion-input-border dark:border-notion-input-borderDark',
         cellHover: 'hover:backdrop-brightness-95',
-        option: 'hover:backdrop-brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-form/40 focus-visible:ring-inset'
+        option: ['hover:backdrop-brightness-95', formControlFocusVisibleInset]
       },
       minimal: {
         container: [
@@ -48,7 +50,7 @@ export const matrixInputTheme = {
         ],
         cell: 'border-transparent',
         cellHover: 'hover:bg-neutral-200/50 dark:hover:bg-neutral-900',
-        option: 'border-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-form focus-visible:outline-offset-[-2px] focus-visible:ring-0'
+        option: ['border-0', formControlFocusVisibleInset]
       },
       transparent: {
         container: [
@@ -61,7 +63,7 @@ export const matrixInputTheme = {
         ],
         cell: 'border-transparent',
         cellHover: 'hover:backdrop-brightness-[0.97] dark:hover:backdrop-brightness-90',
-        option: 'focus-visible:outline-none focus-visible:ring-0',
+        option: formControlFocusVisibleInset,
         rowCell: '!px-0'
       }
     },
@@ -114,4 +116,3 @@ export const matrixInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/matrix-input.theme.js
+++ b/client/lib/forms/themes/matrix-input.theme.js
@@ -59,7 +59,7 @@ export const matrixInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         cell: 'border-transparent',
         cellHover: 'hover:backdrop-brightness-[0.97] dark:hover:backdrop-brightness-90',

--- a/client/lib/forms/themes/mention-input.theme.js
+++ b/client/lib/forms/themes/mention-input.theme.js
@@ -37,7 +37,7 @@ export const mentionInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ]
       }
     },

--- a/client/lib/forms/themes/mention-input.theme.js
+++ b/client/lib/forms/themes/mention-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * MentionInput tailwind-variants configuration
  */
@@ -7,23 +9,25 @@ export const mentionInputTheme = {
       'flex-1 appearance-none w-full',
       'border',
       'focus:outline-hidden',
+      formControlTransition,
       'pr-12'
     ]
   },
   variants: {
     theme: {
       default: {
-        input: 'border-neutral-300 dark:border-neutral-600 bg-white text-neutral-700 dark:bg-notion-dark-light dark:text-neutral-300'
+        input: ['border-neutral-300 dark:border-neutral-600 bg-white text-neutral-700 dark:bg-notion-dark-light dark:text-neutral-300', formControlFocus]
       },
       minimal: {
         input: [
           'border-2 border-transparent',
           'bg-neutral-100 dark:bg-notion-dark-light',
-          'text-neutral-700 dark:text-neutral-300'
+          'text-neutral-700 dark:text-neutral-300',
+          formControlFocus
         ]
       },
       notion: {
-        input: 'border-notion-input-border dark:border-notion-input-borderDark bg-notion-input-background dark:bg-notion-dark-light text-neutral-900 dark:text-neutral-100'
+        input: ['border-notion-input-border dark:border-notion-input-borderDark bg-notion-input-background dark:bg-notion-dark-light text-neutral-900 dark:text-neutral-100', formControlFocus]
       },
       transparent: {
         input: [
@@ -63,4 +67,3 @@ export const mentionInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/option-selector-input.theme.js
+++ b/client/lib/forms/themes/option-selector-input.theme.js
@@ -1,14 +1,19 @@
+import { formControlFocusWithin, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * OptionSelectorInput tailwind-variants configuration
  */
 export const optionSelectorInputTheme = {
   slots: {
     option: [
-      'w-full border transition-colors shadow-xs',
-      'relative'
+      'w-full border shadow-xs',
+      'relative',
+      formControlTransition,
+      formControlFocusWithin
     ],
     button: [
-      'flex flex-col items-center justify-center transition-colors',
+      'flex flex-col items-center justify-center',
+      formControlTransition,
       'text-neutral-500 focus:outline-hidden w-full h-full'
     ],
     label: ''
@@ -53,4 +58,3 @@ export const optionSelectorInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/payment-input.theme.js
+++ b/client/lib/forms/themes/payment-input.theme.js
@@ -79,7 +79,7 @@ export const paymentInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         amountBar: [
           'border-0',
@@ -114,4 +114,3 @@ export const paymentInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/phone-input.theme.js
+++ b/client/lib/forms/themes/phone-input.theme.js
@@ -62,7 +62,7 @@ export const phoneInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ]
       }
     },

--- a/client/lib/forms/themes/phone-input.theme.js
+++ b/client/lib/forms/themes/phone-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * PhoneInput tailwind-variants configuration
  */
@@ -14,7 +16,8 @@ export const phoneInputTheme = {
       'bg-white dark:bg-notion-dark-light',
       'text-neutral-700 dark:text-neutral-300',
       'focus:outline-hidden',
-      'placeholder-neutral-400 dark:placeholder-neutral-500'
+      'placeholder-neutral-400 dark:placeholder-neutral-500',
+      formControlTransition
     ]
     ,
     separator: ''
@@ -25,13 +28,13 @@ export const phoneInputTheme = {
         input: [
           'border-neutral-300 dark:border-neutral-600',
           'shadow-xs',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       simple: {
         input: [
           'border-neutral-300 dark:border-neutral-600',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       notion: {
@@ -39,7 +42,7 @@ export const phoneInputTheme = {
           'border-notion-input-border dark:border-notion-input-borderDark',
           'bg-notion-input-background dark:bg-notion-dark-light',
           'text-neutral-900 dark:text-neutral-100',
-          'focus:ring-2 focus:ring-form/40 focus:border-transparent'
+          formControlFocus
         ]
       },
       minimal: {
@@ -47,7 +50,7 @@ export const phoneInputTheme = {
           'border-2 border-transparent',
           'bg-neutral-100 dark:bg-notion-dark-light',
           'text-neutral-700 dark:text-neutral-300',
-          'focus:ring-0 focus:border-form'
+          formControlFocus
         ],
         separator: 'ltr:border-l rtl:border-r border-neutral-200 dark:border-neutral-700'
       },

--- a/client/lib/forms/themes/rating-input.theme.js
+++ b/client/lib/forms/themes/rating-input.theme.js
@@ -1,15 +1,22 @@
+import { formControlFocusVisibleInset, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * RatingInput tailwind-variants configuration
  */
 export const ratingInputTheme = {
   slots: {
     icon: '',
-    star: 'cursor-pointer inline-block text-neutral-200 dark:text-neutral-700 focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:rounded-full focus-visible:outline-none'
+    star: [
+      'cursor-pointer inline-block text-neutral-200 dark:text-neutral-700',
+      'border-2 border-transparent rounded-full focus-visible:outline-none',
+      formControlTransition,
+      formControlFocusVisibleInset
+    ]
   },
   variants: {
     theme: {
       minimal: {
-        star: 'border-2 border-transparent focus-visible:ring-0 focus-visible:border-form rounded-full'
+        star: 'border-2 border-transparent rounded-full'
       }
     },
     size: {

--- a/client/lib/forms/themes/rich-text-area-input.theme.js
+++ b/client/lib/forms/themes/rich-text-area-input.theme.js
@@ -1,10 +1,13 @@
+import { formControlFocusWithin, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * RichTextAreaInput tailwind-variants configuration
  */
 export const richTextAreaInputTheme = {
   slots: {
     container: [
-      'rich-editor resize-y notranslate relative'
+      'rich-editor resize-y notranslate relative',
+      formControlTransition
     ],
     help: 'text-neutral-500'
   },
@@ -66,7 +69,7 @@ export const richTextAreaInputTheme = {
       true: { container: '!cursor-not-allowed !bg-neutral-200 dark:!bg-neutral-800' }
     },
     focused: {
-      true: { container: 'focus-within:ring-2 focus-within:ring-form/100 focus-within:border-transparent' }
+      true: { container: formControlFocusWithin }
     }
   },
   compoundVariants: [
@@ -85,4 +88,3 @@ export const richTextAreaInputTheme = {
     focused: false
   }
 }
-

--- a/client/lib/forms/themes/rich-text-area-input.theme.js
+++ b/client/lib/forms/themes/rich-text-area-input.theme.js
@@ -47,7 +47,7 @@ export const richTextAreaInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ]
       }
     },
@@ -76,7 +76,7 @@ export const richTextAreaInputTheme = {
     {
       theme: 'transparent',
       focused: true,
-      class: { container: 'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)] outline-none' }
+      class: { container: 'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)] outline-none' }
     }
   ],
   defaultVariants: {

--- a/client/lib/forms/themes/scale-input.theme.js
+++ b/client/lib/forms/themes/scale-input.theme.js
@@ -62,7 +62,7 @@ export const scaleInputTheme = {
           '!rounded-none',
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         buttonUnselected: [
           'bg-transparent'

--- a/client/lib/forms/themes/scale-input.theme.js
+++ b/client/lib/forms/themes/scale-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocusVisible, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * ScaleInput tailwind-variants configuration
  */
@@ -5,7 +7,10 @@ export const scaleInputTheme = {
   slots: {
     button: [
       'cursor-pointer inline-block grow text-center border',
-      'text-neutral-700 dark:text-neutral-300'
+      'text-neutral-700 dark:text-neutral-300',
+      'focus-visible:outline-none',
+      formControlTransition,
+      formControlFocusVisible
     ],
     buttonUnselected: [
       'bg-white dark:bg-notion-dark-light'

--- a/client/lib/forms/themes/signature-input.theme.js
+++ b/client/lib/forms/themes/signature-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * SignatureInput tailwind-variants configuration
  */
@@ -6,7 +8,9 @@ export const signatureInputTheme = {
     container: [
       'flex flex-wrap items-center justify-center gap-4',
       'border border-dashed',
-      'focus:outline-hidden'
+      'focus:outline-hidden',
+      formControlTransition,
+      formControlFocus
     ],
     help: 'text-neutral-500'
   },
@@ -68,4 +72,3 @@ export const signatureInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/slider-input.theme.js
+++ b/client/lib/forms/themes/slider-input.theme.js
@@ -1,26 +1,14 @@
+import { formControlFocusVisibleHalo, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * SliderInput tailwind-variants configuration
  */
 export const sliderInputTheme = {
   slots: {
     stepLabel: 'text-neutral-700 dark:text-neutral-300 text-center',
-    slider: 'w-full mt-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2'
+    slider: ['w-full mt-3', formControlTransition, formControlFocusVisibleHalo]
   },
   variants: {
-    theme: {
-      default: {
-        slider: 'focus-visible:ring-form/100'
-      },
-      simple: {
-        slider: 'focus-visible:ring-form/100'
-      },
-      notion: {
-        slider: 'focus-visible:ring-form/40'
-      },
-      minimal: {
-        slider: 'focus-visible:ring-2 focus-visible:ring-form/60'
-      }
-    },
     size: {
       xs: { stepLabel: 'text-xs' },
       sm: { stepLabel: 'text-sm' },

--- a/client/lib/forms/themes/text-area-input.theme.js
+++ b/client/lib/forms/themes/text-area-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * TextAreaInput tailwind-variants configuration
  */
@@ -11,6 +13,7 @@ export const textAreaInputTheme = {
       'placeholder-neutral-400 dark:placeholder-neutral-500',
       'focus:outline-hidden',
       'disabled:cursor-not-allowed disabled:opacity-75',
+      formControlTransition,
       'min-h-[100px] resize-y block'
     ],
     help: 'text-neutral-500'
@@ -21,13 +24,13 @@ export const textAreaInputTheme = {
         input: [
           'border-neutral-300 dark:border-neutral-600',
           'shadow-xs',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       simple: {
         input: [
           'border-neutral-300 dark:border-neutral-600',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       notion: {
@@ -35,7 +38,7 @@ export const textAreaInputTheme = {
           'border-notion-input-border dark:border-notion-input-borderDark',
           'bg-notion-input-background dark:bg-notion-dark-light',
           'text-neutral-900 dark:text-neutral-100',
-          'focus:ring-2 focus:ring-form/40 focus:border-transparent'
+          formControlFocus
         ]
       },
       minimal: {
@@ -43,7 +46,7 @@ export const textAreaInputTheme = {
           'border-2 border-transparent',
           'bg-neutral-100 dark:bg-notion-dark-light',
           'text-neutral-700 dark:text-neutral-300',
-          'focus:ring-0 focus:border-form'
+          formControlFocus
         ]
       },
       transparent: {
@@ -85,4 +88,3 @@ export const textAreaInputTheme = {
     disabled: false
   }
 }
-

--- a/client/lib/forms/themes/text-area-input.theme.js
+++ b/client/lib/forms/themes/text-area-input.theme.js
@@ -57,7 +57,7 @@ export const textAreaInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]',
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]',
           '!px-0'
         ]
       }

--- a/client/lib/forms/themes/text-input.theme.js
+++ b/client/lib/forms/themes/text-input.theme.js
@@ -58,7 +58,7 @@ export const textInputTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--color-form)]',
+          'focus:ring-0 focus:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]',
           '!px-0'
         ]
       }

--- a/client/lib/forms/themes/text-input.theme.js
+++ b/client/lib/forms/themes/text-input.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocus, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * TextInput tailwind-variants configuration
  * Proper TV structure: base classes + variant overrides (following Nuxt UI pattern)
@@ -12,6 +14,7 @@ export const textInputTheme = {
       'text-neutral-700 dark:text-neutral-300',
       'placeholder-neutral-400 dark:placeholder-neutral-500',
       'focus:outline-hidden',
+      formControlTransition,
       'disabled:cursor-not-allowed disabled:opacity-75'
     ],
     help: 'text-neutral-500'
@@ -22,13 +25,13 @@ export const textInputTheme = {
         input: [
           'border-neutral-300 dark:border-neutral-600',
           'shadow-xs',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       simple: {
         input: [
           'border-neutral-300 dark:border-neutral-600',
-          'focus:ring-2 focus:ring-form/100 focus:border-transparent'
+          formControlFocus
         ]
       },
       notion: {
@@ -36,7 +39,7 @@ export const textInputTheme = {
           'border-notion-input-border dark:border-notion-input-borderDark',
           'bg-notion-input-background dark:bg-notion-dark-light',
           'text-neutral-900 dark:text-neutral-100',
-          'focus:ring-2 focus:ring-form/40 focus:border-transparent'
+          formControlFocus
         ]
       },
       minimal: {
@@ -44,7 +47,7 @@ export const textInputTheme = {
           'border-2 border-transparent',
           'bg-neutral-100 dark:bg-notion-dark-light',
           'text-neutral-700 dark:text-neutral-300',
-          'focus:ring-0 focus:border-form'
+          formControlFocus
         ]
       },
       transparent: {

--- a/client/lib/forms/themes/v-checkbox.theme.js
+++ b/client/lib/forms/themes/v-checkbox.theme.js
@@ -1,3 +1,5 @@
+import { formControlFocusVisible, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * VCheckbox tailwind-variants configuration
  * Used for checkbox input components
@@ -8,7 +10,9 @@ export const vCheckboxTheme = {
     input: [
       'rounded border-neutral-500 checkbox',
       'size-5', // Default size, overridden by variants
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-form/100 focus-visible:border-transparent'
+      'focus-visible:outline-none',
+      formControlTransition,
+      formControlFocusVisible
     ],
     label: [
       'text-neutral-700 dark:text-neutral-300 ml-2'

--- a/client/lib/forms/themes/v-select.theme.js
+++ b/client/lib/forms/themes/v-select.theme.js
@@ -1,3 +1,5 @@
+import { formControlActive, formControlFocusWithin, formControlTransition } from './focus-ring.theme.js'
+
 /**
  * VSelect tailwind-variants configuration
  * Used for select dropdown components
@@ -5,7 +7,7 @@
 export const vSelectTheme = {
   slots: {
     container: 'v-select relative',
-    anchor: 'w-full flex overflow-hidden',
+    anchor: ['w-full flex overflow-hidden', formControlTransition],
     button: [
       'cursor-pointer w-full grow relative focus:outline-hidden min-w-0 truncate'
     ],
@@ -107,7 +109,7 @@ export const vSelectTheme = {
     // Open state styling for when popover is open (even if not focused)
     isOpen: {
       true: {
-        anchor: 'ring-2 ring-form/100 outline-none'
+        anchor: formControlActive
       }
     },
     size: {
@@ -169,7 +171,7 @@ export const vSelectTheme = {
     },
     focused: {
       true: {
-        anchor: 'focus-within:ring-2 focus-within:ring-form/100 focus-within:border-transparent'
+        anchor: formControlFocusWithin
       }
     },
     multiple: {

--- a/client/lib/forms/themes/v-select.theme.js
+++ b/client/lib/forms/themes/v-select.theme.js
@@ -99,7 +99,7 @@ export const vSelectTheme = {
           'shadow-[inset_0_-1px_0_0_rgb(212_212_212)] dark:shadow-[inset_0_-1px_0_0_rgb(82_82_82)]',
           '!rounded-none',
           'transition-shadow duration-200',
-          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)]'
+          'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)]'
         ],
         chevronGradient: 'bg-gradient-to-r from-transparent to-transparent',
         chevronContainer: 'bg-transparent',
@@ -193,12 +193,12 @@ export const vSelectTheme = {
     {
       theme: 'transparent',
       isOpen: true,
-      class: { anchor: 'ring-0 shadow-[inset_0_-2px_0_0_var(--color-form)] outline-none' }
+      class: { anchor: 'ring-0 shadow-[inset_0_-2px_0_0_var(--form-focus-color)] outline-none' }
     },
     {
       theme: 'transparent',
       focused: true,
-      class: { anchor: 'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--color-form)] outline-none' }
+      class: { anchor: 'focus-within:ring-0 focus-within:shadow-[inset_0_-2px_0_0_var(--form-focus-color)] outline-none' }
     }
   ],
   defaultVariants: {

--- a/client/test/unit/form-focus-themes.test.ts
+++ b/client/test/unit/form-focus-themes.test.ts
@@ -4,6 +4,7 @@ import { imageInputTheme } from '../../lib/forms/themes/image-input.theme.js'
 import { ratingInputTheme } from '../../lib/forms/themes/rating-input.theme.js'
 import { signatureInputTheme } from '../../lib/forms/themes/signature-input.theme.js'
 import { sliderInputTheme } from '../../lib/forms/themes/slider-input.theme.js'
+import { textInputTheme } from '../../lib/forms/themes/text-input.theme.js'
 
 describe('form focus themes', () => {
   it.each([
@@ -15,5 +16,12 @@ describe('form focus themes', () => {
     expect(classes).toContain('duration-200')
     expect(classes).toContain('var(--form-focus-color)')
     expect(classes).toMatch(/focus(?:-visible)?:shadow-/)
+  })
+
+  it('uses the validation-aware focus color for the transparent underline', () => {
+    const classes = tv(textInputTheme)({ theme: 'transparent' }).input()
+
+    expect(classes).toContain('var(--form-focus-color)')
+    expect(classes).not.toContain('var(--color-form)')
   })
 })

--- a/client/test/unit/form-focus-themes.test.ts
+++ b/client/test/unit/form-focus-themes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { tv } from 'tailwind-variants'
+import { imageInputTheme } from '../../lib/forms/themes/image-input.theme.js'
+import { ratingInputTheme } from '../../lib/forms/themes/rating-input.theme.js'
+import { signatureInputTheme } from '../../lib/forms/themes/signature-input.theme.js'
+import { sliderInputTheme } from '../../lib/forms/themes/slider-input.theme.js'
+
+describe('form focus themes', () => {
+  it.each([
+    ['image', tv(imageInputTheme)().button()],
+    ['rating', tv(ratingInputTheme)().star()],
+    ['signature', tv(signatureInputTheme)().container()],
+    ['slider', tv(sliderInputTheme)().slider()]
+  ])('adds the shared animated focus treatment to %s controls', (_name, classes) => {
+    expect(classes).toContain('duration-200')
+    expect(classes).toContain('var(--form-focus-color)')
+    expect(classes).toMatch(/focus(?:-visible)?:shadow-/)
+  })
+})

--- a/client/test/unit/useFormInput.test.ts
+++ b/client/test/unit/useFormInput.test.ts
@@ -209,6 +209,33 @@ describe('useFormInput', () => {
   })
 
   describe('Validation Error Handling', () => {
+    it('uses the accent color for focus when the field is valid', () => {
+      const props = {
+        name: 'simple_field',
+        form: mockForm,
+        modelValue: undefined,
+        color: '#f73be7'
+      }
+
+      const { inputStyle } = useFormInput(props, mockContext)
+
+      expect(inputStyle.value['--form-focus-color']).toBe('#f73be7')
+    })
+
+    it('uses the error color for focus when the field is invalid', () => {
+      mockForm.errors.has = vi.fn(() => true)
+      const props = {
+        name: 'simple_field',
+        form: mockForm,
+        modelValue: undefined,
+        color: '#f73be7'
+      }
+
+      const { inputStyle } = useFormInput(props, mockContext)
+
+      expect(inputStyle.value['--form-focus-color']).toBe('var(--color-red-500)')
+    })
+
     it('should clear validation errors when value is set', () => {
       mockForm.errors.has = vi.fn(() => true)
 
@@ -452,4 +479,3 @@ describe('useFormInput', () => {
     })
   })
 })
-


### PR DESCRIPTION
## What changed

- add shared animated focus, focus-visible, focus-within, and active-state theme primitives
- apply the focus treatment consistently across text, textarea, select, date, phone, file, code, checkbox, matrix, scale, and option controls
- propagate the configured form color to compound controls so custom form themes keep their expected focus color

## Why

Form controls previously switched to a solid Tailwind ring immediately. This ports the smoother Justiciel interaction: the border and a subtle color-matched halo animate in and out over 200ms.

## User impact

Public forms now have consistent, smoother focus and blur feedback while preserving keyboard focus visibility, error states, transparent themes, and custom form colors.

## Validation

- `npm run lint`
- `git diff --check`
- local isolated Laravel/Nuxt environment
- browser verification on seeded classic and transparent public forms, including computed custom color, border, box shadow, transition duration, and focus transfer between inputs
