### PR TITLE
Display uploaded images directly in email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ client/.env.*
 !.env.example
 !api/.env.example
 !client/.env.example
+.help-center-docs/

--- a/api/app/Integrations/Handlers/EmailIntegration.php
+++ b/api/app/Integrations/Handlers/EmailIntegration.php
@@ -29,6 +29,7 @@ class EmailIntegration extends AbstractIntegrationHandler
             'email_content' => 'required',
             'include_submission_data' => 'boolean',
             'include_hidden_fields_submission_data' => ['nullable', 'boolean'],
+            'embed_uploaded_images' => ['nullable', 'boolean'],
             'reply_to' => 'nullable',
             'link_edit_submission' => ['nullable', 'boolean'],
             'logo_url' => ['nullable', 'url', 'starts_with:https://'],

--- a/api/app/Notifications/Forms/FormEmailNotification.php
+++ b/api/app/Notifications/Forms/FormEmailNotification.php
@@ -13,20 +13,31 @@ use App\Service\Forms\SubmissionUrlService;
 use App\Service\Formulas\ComputedVariableEvaluator;
 use App\Service\Pdf\PdfCacheService;
 use App\Service\Pdf\PdfGeneratorService;
+use App\Service\Storage\FileUploadPathService;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 
 class FormEmailNotification extends Notification
 {
     private const MAX_PDF_ATTACHMENTS = 3;
     private const MAX_TOTAL_ATTACHMENT_BYTES = 15 * 1024 * 1024;
+    private const MAX_INLINE_IMAGE_BYTES = 6 * 1024 * 1024;
+    private const INLINE_IMAGE_MIME_TYPES = [
+        'image/gif',
+        'image/jpeg',
+        'image/png',
+    ];
 
     public FormSubmitted $event;
     private ?array $computedValues = null;
+    private array $inlineImages = [];
+    private int $inlineImageBytes = 0;
+    private int $pdfAttachmentBytes = 0;
 
     /**
      * Create a new notification instance.
@@ -106,15 +117,17 @@ class FormEmailNotification extends Notification
             ->mailer($this->getMailer())
             ->replyTo($this->getReplyToEmail($this->event->form->creator->email))
             ->from($this->getFromEmail(), $this->getSenderName())
-            ->subject($this->getSubject())
-            ->withSymfonyMessage(function (Email $message) {
-                $this->addCustomHeaders($message);
-            })
-            ->markdown('mail.form.email-notification', $this->getMailData());
+            ->subject($this->getSubject());
 
+        // Explicitly selected PDF attachments take priority over optional inline images.
         $this->attachPdfTemplatesIfRequested($mail);
 
-        return $mail;
+        return $mail
+            ->withSymfonyMessage(function (Email $message) {
+                $this->addCustomHeaders($message);
+                $this->addInlineImages($message);
+            })
+            ->markdown('mail.form.email-notification', $this->getMailData());
     }
 
     /**
@@ -122,6 +135,7 @@ class FormEmailNotification extends Notification
      */
     private function attachPdfTemplatesIfRequested(MailMessage $mail): void
     {
+        $this->pdfAttachmentBytes = 0;
         $form = $this->event->form;
 
         $templateIds = $this->integrationData->pdf_template_ids ?? [];
@@ -167,6 +181,7 @@ class FormEmailNotification extends Notification
                     $filename = $template->resolveFilename($form, $submission);
                     $mail->attachData($content, $filename, ['mime' => 'application/pdf']);
                     $totalBytes += $nextSize;
+                    $this->pdfAttachmentBytes += $nextSize;
                 }
             } catch (\Throwable $e) {
                 report($e);
@@ -289,6 +304,7 @@ class FormEmailNotification extends Notification
     {
         $form = $this->event->form;
         $hasAdvancedEmailCustomization = $form->workspace?->hasFeature(Feature::EMAIL_ADVANCED) ?? false;
+        $fields = $this->prepareInlineImages($this->formatSubmissionData());
 
         $emailAppearance = $hasAdvancedEmailCustomization ? [
             'logoUrl' => $this->integrationData->logo_url ?? null,
@@ -300,13 +316,115 @@ class FormEmailNotification extends Notification
 
         return [
             'emailContent' => $this->getEmailContent(),
-            'fields' => $this->formatSubmissionData(),
+            'fields' => $fields,
             'form' => $form,
             'integrationData' => $this->integrationData,
             'noBranding' => app(BrandingPolicy::class)->canRemoveFormBranding($form),
             'submission_id' => $this->getEncodedSubmissionId(),
             'emailAppearance' => $emailAppearance,
         ];
+    }
+
+    private function prepareInlineImages(array $fields): array
+    {
+        $this->inlineImages = [];
+        $this->inlineImageBytes = 0;
+
+        if (
+            !($this->integrationData->include_submission_data ?? false)
+            || !($this->integrationData->embed_uploaded_images ?? false)
+        ) {
+            return $fields;
+        }
+
+        foreach ($fields as &$field) {
+            if (empty($field['email_data']) || !is_array($field['email_data'])) {
+                continue;
+            }
+
+            foreach ($field['email_data'] as &$file) {
+                $inlineImage = $this->prepareInlineImage($file);
+                if ($inlineImage) {
+                    $file['inline_cid'] = $inlineImage['cid'];
+                }
+            }
+            unset($file);
+        }
+        unset($field);
+
+        return $fields;
+    }
+
+    private function prepareInlineImage(array $file): ?array
+    {
+        if (!($file['is_image'] ?? false) || empty($file['file_name'])) {
+            return null;
+        }
+
+        try {
+            $path = FileUploadPathService::getFileUploadPath(
+                $this->event->form->id,
+                $file['file_name']
+            );
+
+            if (!Storage::exists($path)) {
+                return null;
+            }
+
+            $cid = hash('sha256', $this->event->form->id . '|' . $file['file_name']) . '@opnform';
+            if (isset($this->inlineImages[$cid])) {
+                return $this->inlineImages[$cid];
+            }
+
+            $size = Storage::size($path);
+            if (
+                $size <= 0
+                || $size > self::MAX_INLINE_IMAGE_BYTES
+                || ($this->pdfAttachmentBytes + $this->inlineImageBytes + $size) > self::MAX_TOTAL_ATTACHMENT_BYTES
+            ) {
+                return null;
+            }
+
+            $contents = Storage::get($path);
+            $actualSize = strlen($contents);
+            if (
+                $actualSize <= 0
+                || $actualSize > self::MAX_INLINE_IMAGE_BYTES
+                || ($this->pdfAttachmentBytes + $this->inlineImageBytes + $actualSize) > self::MAX_TOTAL_ATTACHMENT_BYTES
+            ) {
+                return null;
+            }
+
+            $mimeType = (new \finfo(FILEINFO_MIME_TYPE))->buffer($contents);
+            if (!is_string($mimeType) || !in_array(strtolower($mimeType), self::INLINE_IMAGE_MIME_TYPES, true)) {
+                return null;
+            }
+
+            $this->inlineImages[$cid] = [
+                'cid' => $cid,
+                'contents' => $contents,
+                'file_name' => $file['label'] ?? $file['file_name'],
+                'mime_type' => strtolower($mimeType),
+            ];
+            $this->inlineImageBytes += $actualSize;
+
+            return $this->inlineImages[$cid];
+        } catch (\Throwable $exception) {
+            report($exception);
+
+            return null;
+        }
+    }
+
+    private function addInlineImages(Email $message): void
+    {
+        foreach ($this->inlineImages as $image) {
+            $message->addPart(
+                (new DataPart($image['contents'], $image['file_name'], $image['mime_type']))
+                    ->asInline()
+                    ->setContentId($image['cid'])
+            );
+        }
     }
 
     private function getEmailContent(): string

--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -4,6 +4,7 @@ namespace App\Service\Forms;
 
 use App\Models\Forms\Form;
 use App\Service\Storage\FilenameUrlEncoder;
+use App\Service\Storage\StorageFileNameParser;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -255,27 +256,35 @@ class FormSubmissionFormatter
             } elseif (in_array($field['type'], ['files', 'signature'])) {
                 if ($this->outputStringsOnly) {
                     $formId = $this->form->id;
-                    $files = collect($data[$field['id']])->map(function ($file) use ($formId) {
-                        return $this->getFileUrl($formId, $file);
+                    $emailData = collect($data[$field['id']])->map(function ($file) use ($formId) {
+                        $displayName = $this->getFileDisplayName($file);
+
+                        return [
+                            'file_name' => $file,
+                            'unsigned_url' => route(
+                                'open.forms.submissions.file',
+                                [$formId, FilenameUrlEncoder::encode($file)]
+                            ),
+                            'signed_url' => $this->getFileUrl($formId, $file),
+                            'label' => $displayName,
+                            'is_image' => $this->isImageFile($displayName),
+                        ];
                     })->toArray();
+
                     if ($this->createLinks) {
-                        $field['value'] = implode(', ', collect($files)->map(function ($file) {
-                            return $this->buildSafeHtmlLink($file, $file);
+                        $field['value'] = implode('<br>', collect($emailData)->map(function ($file) {
+                            $icon = $file['is_image'] ? '🖼️' : '📎';
+
+                            return $this->buildSafeHtmlLink(
+                                $file['signed_url'],
+                                $icon . ' ' . $file['label']
+                            );
                         })->toArray());
                         $field['value_is_html'] = true;
                     } else {
-                        $field['value'] = implode(', ', $files);
+                        $field['value'] = implode(', ', collect($emailData)->pluck('signed_url')->toArray());
                     }
-                    $field['email_data'] = collect($data[$field['id']])->map(function ($file) use ($formId) {
-                        $splitText = explode('.', $file);
-                        $encodedFilename = FilenameUrlEncoder::encode($file);
-
-                        return [
-                            'unsigned_url' => route('open.forms.submissions.file', [$formId, $encodedFilename]),
-                            'signed_url' => $this->getFileUrl($formId, $file),
-                            'label' => Str::limit($file, 20, '[...].' . end($splitText)),
-                        ];
-                    })->toArray();
+                    $field['email_data'] = $emailData;
                 } else {
                     $formId = $this->form->id;
                     $field['value'] = collect($data[$field['id']])->map(function ($file) use ($formId) {
@@ -329,6 +338,32 @@ class FormSubmissionFormatter
     private function buildSafeHtmlLink(string $href, string $label): string
     {
         return '<a href="' . e($href) . '">' . e($label) . '</a>';
+    }
+
+    private function getFileDisplayName(string $fileName): string
+    {
+        $parser = StorageFileNameParser::parse($fileName);
+
+        if ($parser->fileName && $parser->extension) {
+            return $parser->fileName . '.' . $parser->extension;
+        }
+
+        return $fileName;
+    }
+
+    private function isImageFile(string $fileName): bool
+    {
+        return in_array(strtolower(pathinfo($fileName, PATHINFO_EXTENSION)), [
+            'bmp',
+            'gif',
+            'jpeg',
+            'jpg',
+            'png',
+            'svg',
+            'tif',
+            'tiff',
+            'webp',
+        ], true);
     }
 
     private function escapeHtmlValue(mixed $value): string

--- a/api/resources/views/mail/form/email-notification.blade.php
+++ b/api/resources/views/mail/form/email-notification.blade.php
@@ -14,14 +14,31 @@
 @if($integrationData->include_submission_data)
 @foreach($fields as $field)
 @if(isset($field['value']))
-<p style="white-space: pre-wrap; border-top: 1px solid #9ca3af;">
+<div style="white-space: pre-wrap; border-top: 1px solid #9ca3af; padding-top: 12px; margin-top: 12px;">
     <b>{{$field['name']}}</b>
-    @if(!empty($field['value_is_html']))
+    @if(!empty($field['email_data']))
+        @foreach($field['email_data'] as $file)
+        <div style="margin-top: 8px;">
+            @if(!empty($file['inline_cid']))
+            <a href="{{$file['signed_url']}}" style="text-decoration: none;">
+                <img
+                    src="cid:{{$file['inline_cid']}}"
+                    alt="{{$file['label']}}"
+                    style="display: block; max-width: 100%; height: auto; border: 0; border-radius: 6px;"
+                >
+            </a>
+            @endif
+            <a href="{{$file['signed_url']}}" style="display: inline-block; margin-top: 6px; text-decoration: none;">
+                {{$file['is_image'] ? '🖼️' : '📎'}} {{$file['label']}}
+            </a>
+        </div>
+        @endforeach
+    @elseif(!empty($field['value_is_html']))
     {!! $field['value'] !!}
     @else
     {{ is_array($field['value']) ? implode(',', $field['value']) : $field['value'] }}
     @endif
-</p>
+</div>
 @endif
 @endforeach
 @endif

--- a/api/tests/Feature/Forms/EmailNotificationTest.php
+++ b/api/tests/Feature/Forms/EmailNotificationTest.php
@@ -1,8 +1,14 @@
 <?php
 
 use App\Notifications\Forms\FormEmailNotification;
+use App\Models\PdfTemplate;
+use App\Service\Pdf\PdfCacheService;
+use App\Service\Storage\FileUploadPathService;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\Mime\Email;
 
 it('send email with the submitted data', function () {
     $user = $this->actingAsUser();
@@ -80,6 +86,229 @@ it('uses the workspace policy for file links in email notifications', function (
 
     expect((int) ($queryParameters['expires'] ?? 0))->toBe($now->copy()->addHours(168)->timestamp);
     expect($queryParameters['signature'] ?? null)->not->toBeEmpty();
+});
+
+it('shows readable file labels instead of raw api urls', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            [
+                'id' => 'attachment',
+                'name' => 'Attachment',
+                'type' => 'files',
+                'required' => false,
+            ],
+        ],
+    ]);
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'New submission',
+        'include_submission_data' => true,
+    ]);
+    $storedFileName = 'company-logo_' . Str::uuid() . '.png';
+    $documentFileName = 'brief_' . Str::uuid() . '.pdf';
+
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, [
+            'attachment' => [$storedFileName, $documentFileName],
+        ]),
+        $integrationData
+    );
+
+    $html = html_entity_decode($notification->toMail(new AnonymousNotifiable())->render());
+
+    expect($html)
+        ->toContain('🖼️ company-logo.png')
+        ->toContain('📎 brief.pdf');
+    expect($html)
+        ->not->toMatch('/<a href="([^"]*submissions\/file[^"]*)">\1<\/a>/')
+        ->not->toMatch('/>https?:\/\/[^<]*api[^<]*<\/a>/');
+});
+
+it('embeds multiple uploaded images and signatures vertically', function () {
+    Storage::fake('local');
+
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            [
+                'id' => 'images',
+                'name' => 'Images',
+                'type' => 'files',
+                'required' => false,
+            ],
+            [
+                'id' => 'signature',
+                'name' => 'Signature',
+                'type' => 'signature',
+                'required' => false,
+            ],
+        ],
+    ]);
+    $imageFileName = 'company-logo_' . Str::uuid() . '.png';
+    $signatureFileName = 'sign_' . Str::uuid() . '.png';
+    Storage::put(FileUploadPathService::getFileUploadPath($form->id, $imageFileName), emailTinyPngBytes());
+    $sixMegabyteImage = emailTinyPngBytes();
+    $sixMegabyteImage .= str_repeat("\0", (6 * 1024 * 1024) - strlen($sixMegabyteImage));
+    Storage::put(FileUploadPathService::getFileUploadPath($form->id, $signatureFileName), $sixMegabyteImage);
+
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'New submission',
+        'include_submission_data' => true,
+        'embed_uploaded_images' => true,
+    ]);
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, [
+            'images' => [$imageFileName],
+            'signature' => $signatureFileName,
+        ]),
+        $integrationData
+    );
+
+    $mailMessage = $notification->toMail(new AnonymousNotifiable());
+    $html = html_entity_decode($mailMessage->render());
+    $symfonyMessage = (new Email())->from('sender@example.com')->to('recipient@example.com')->html($html);
+    foreach ($mailMessage->callbacks as $callback) {
+        $callback($symfonyMessage);
+    }
+
+    expect(substr_count($html, 'src="cid:'))->toBe(2)
+        ->and($html)->toContain('company-logo.png')
+        ->and($html)->toContain('sign.png')
+        ->and(strpos($html, 'company-logo.png'))->toBeLessThan(strpos($html, 'sign.png'))
+        ->and($symfonyMessage->getAttachments())->toHaveCount(2);
+
+    foreach ($symfonyMessage->getAttachments() as $attachment) {
+        expect($attachment->getDisposition())->toBe('inline')
+            ->and($attachment->getContentType())->toBe('image/png')
+            ->and($attachment->getContentId())->toEndWith('@opnform')
+            ->and($html)->toContain('cid:' . $attachment->getContentId());
+    }
+});
+
+it('falls back to a readable link for each image that is too large', function () {
+    Storage::fake('local');
+
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            [
+                'id' => 'images',
+                'name' => 'Images',
+                'type' => 'files',
+                'required' => false,
+            ],
+        ],
+    ]);
+    $inlineFileName = 'small-image_' . Str::uuid() . '.png';
+    $largeFileName = 'large-image_' . Str::uuid() . '.png';
+    Storage::put(FileUploadPathService::getFileUploadPath($form->id, $inlineFileName), emailTinyPngBytes());
+    $largeImageContents = emailTinyPngBytes();
+    $largeImageContents .= str_repeat("\0", ((6 * 1024 * 1024) + 1) - strlen($largeImageContents));
+    Storage::put(
+        FileUploadPathService::getFileUploadPath($form->id, $largeFileName),
+        $largeImageContents
+    );
+
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'New submission',
+        'include_submission_data' => true,
+        'embed_uploaded_images' => true,
+    ]);
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, ['images' => [$inlineFileName, $largeFileName]]),
+        $integrationData
+    );
+
+    $mailMessage = $notification->toMail(new AnonymousNotifiable());
+    $html = html_entity_decode($mailMessage->render());
+    $symfonyMessage = (new Email())->from('sender@example.com')->to('recipient@example.com')->html($html);
+    foreach ($mailMessage->callbacks as $callback) {
+        $callback($symfonyMessage);
+    }
+
+    expect(substr_count($html, 'src="cid:'))->toBe(1)
+        ->and($html)->toContain('🖼️ small-image.png')
+        ->and($html)->toContain('🖼️ large-image.png')
+        ->and($symfonyMessage->getAttachments())->toHaveCount(1);
+});
+
+it('keeps selected pdf attachments ahead of optional inline images in the email size budget', function () {
+    Storage::fake('local');
+
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            [
+                'id' => 'image',
+                'name' => 'Image',
+                'type' => 'files',
+                'required' => false,
+            ],
+        ],
+    ]);
+    $submission = $form->submissions()->create(['data' => []]);
+    $template = PdfTemplate::create([
+        'form_id' => $form->id,
+        'name' => 'Selected PDF',
+        'filename' => 'selected.pdf',
+        'original_filename' => 'Selected.pdf',
+        'file_path' => "pdf-templates/{$form->id}/selected.pdf",
+        'file_size' => 11 * 1024 * 1024,
+        'page_count' => 1,
+    ]);
+    $pdfPath = 'tmp/pdf-output/selected.pdf';
+    Storage::put($pdfPath, str_repeat('p', 11 * 1024 * 1024));
+    $cacheService = Mockery::mock(PdfCacheService::class);
+    $cacheService->shouldReceive('getOrGenerateFromTemplate')->once()->andReturn($pdfPath);
+    app()->instance(PdfCacheService::class, $cacheService);
+
+    $imageFileName = 'budget-image_' . Str::uuid() . '.png';
+    $imageContents = emailTinyPngBytes();
+    $imageContents .= str_repeat("\0", (5 * 1024 * 1024) - strlen($imageContents));
+    Storage::put(FileUploadPathService::getFileUploadPath($form->id, $imageFileName), $imageContents);
+
+    $integrationData = $this->createFormIntegration('email', $form->id, [
+        'send_to' => $user->email,
+        'sender_name' => 'OpnForm',
+        'subject' => 'New form submission',
+        'email_content' => 'New submission',
+        'include_submission_data' => true,
+        'embed_uploaded_images' => true,
+        'pdf_template_ids' => [$template->id],
+    ]);
+    $notification = new FormEmailNotification(
+        new \App\Events\Forms\FormSubmitted($form, [
+            'submission_id' => $submission->id,
+            'image' => [$imageFileName],
+        ]),
+        $integrationData
+    );
+
+    $mailMessage = $notification->toMail(new AnonymousNotifiable());
+    $html = html_entity_decode($mailMessage->render());
+    $symfonyMessage = (new Email())->from('sender@example.com')->to('recipient@example.com')->html($html);
+    foreach ($mailMessage->callbacks as $callback) {
+        $callback($symfonyMessage);
+    }
+
+    expect($mailMessage->rawAttachments)->toHaveCount(1)
+        ->and($mailMessage->rawAttachments[0]['name'])->toEndWith('.pdf')
+        ->and($html)->not->toContain('src="cid:')
+        ->and($html)->toContain('🖼️ budget-image.png')
+        ->and($symfonyMessage->getAttachments())->toHaveCount(0);
 });
 
 it('sends a email if needed', function () {
@@ -518,3 +747,11 @@ it('renders rich text field values as html in submission data', function () {
     expect($html)->toContain('Sample </em>');
     expect($html)->not->toContain('&lt;p&gt;Test &lt;em&gt;Sample');
 });
+
+function emailTinyPngBytes(): string
+{
+    return base64_decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMBAQEAAP8AAAAASUVORK5CYII=',
+        true
+    ) ?: '';
+}

--- a/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
+++ b/api/tests/Feature/Integrations/Email/EmailIntegrationTest.php
@@ -487,3 +487,27 @@ test('email notification renders plain submission values once in the submission 
     expect($html)->not->toContain('&amp;lt;b&amp;gt;test&amp;lt;/b&amp;gt;');
     expect($html)->not->toContain("Café d'Art & <b>test</b>");
 });
+
+test('email integration stores the inline uploaded images preference', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $response = $this->postJson(route('open.forms.integrations.create', $form), [
+        'integration_id' => 'email',
+        'status' => 'active',
+        'data' => [
+            'send_to' => $user->email,
+            'sender_name' => 'Test Sender',
+            'subject' => 'Test Subject',
+            'email_content' => 'Test Content',
+            'include_submission_data' => true,
+            'embed_uploaded_images' => true,
+        ],
+    ]);
+
+    $response->assertSuccessful();
+
+    $integration = FormIntegration::where('form_id', $form->id)->firstOrFail();
+    expect($integration->data->embed_uploaded_images)->toBeTrue();
+});

--- a/client/components/open/integrations/EmailIntegration.vue
+++ b/client/components/open/integrations/EmailIntegration.vue
@@ -204,6 +204,14 @@
       help="If enabled the email will contain hidden fields"
     />
     <toggle-switch-input
+      v-if="integrationData.data.include_submission_data"
+      :form="integrationData"
+      name="data.embed_uploaded_images"
+      class="mt-4"
+      label="Display uploaded images inline"
+      help="Show GIF, JPEG, and PNG uploads up to 6 MB directly in the email. Other images remain secure links. Embedded images remain available in the recipient's email."
+    />
+    <toggle-switch-input
       v-if="form.editable_submissions"
       :form="integrationData"
       name="data.link_edit_submission"
@@ -303,6 +311,7 @@ onBeforeMount(() => {
     email_content: "Hello there 👋 <br>This is a confirmation that your submission was successfully saved.",
     include_submission_data: true,
     include_hidden_fields_submission_data: false,
+    embed_uploaded_images: false,
     logo_url: null,
     font_family: null,
     font_color: null,

--- a/docs/configuration/external-file-links.mdx
+++ b/docs/configuration/external-file-links.mdx
@@ -29,6 +29,28 @@ The selected period is used for new uploaded-file links included in:
 Existing links keep their original expiration. Internal dashboard file previews
 and form assets are not changed by this workspace setting.
 
+## Show uploaded images in notification emails
+
+Each email integration can display uploaded images and signatures directly in
+the message:
+
+1. Open the form editor and select **Integrations**.
+2. Create or edit an email integration.
+3. Enable **Include submission data**.
+4. Enable **Display uploaded images inline**.
+
+The setting is disabled by default. GIF, JPEG, and PNG files up to 6 MB each
+appear vertically in the email and remain clickable through their secure file
+links. Images that are too large or incompatible stay available as readable
+file links without blocking the notification. Other uploaded file types also
+appear with their filename instead of exposing the raw API URL.
+
+<Warning>
+    An image embedded in an email remains available in the recipient's mailbox.
+    The external file link can expire, but the embedded copy cannot be revoked
+    from a message that has already been sent.
+</Warning>
+
 <Warning>
     Choose the shortest period that still fits the recipient's workflow. For
     example, a team that processes weekend submissions on Monday can select


### PR DESCRIPTION
## Summary

- add a per-email integration option to display uploaded images and signatures inline
- show multiple images vertically while keeping secure, readable filename links
- fall back to links without blocking delivery for unsupported, unavailable, oversized, or over-budget images
- preserve selected PDF attachments by giving them priority in the email attachment budget
- document supported formats, the 6 MB per-image limit, and the mailbox retention consideration

## Why

Uploaded files were previously rendered as long OpnForm API URLs in email notifications. This was confusing for recipients and forced them to open each image separately.

The new opt-in setting makes visual submissions immediately reviewable while preserving secure links and safe delivery fallbacks.

## Validation

- 40 backend tests, 231 assertions across email notifications, email integrations, and external submission file links
- 693 frontend tests
- frontend ESLint
- Laravel Pint on changed PHP files
- Larastan on all changed backend files
- `git diff --check`

The full repository Larastan run still reports two pre-existing relation errors in `BackfillLifetimeLicenseWorkspaceEntitlements.php`, which is not changed by this PR.

## Documentation

- update the external file link documentation
- prepare the Customer Update and Help Center drafts in Notion