### PR TITLE
fix(pdf-editor): resolve template download URL against the page origin

### DIFF
--- a/client/api/forms.js
+++ b/client/api/forms.js
@@ -93,8 +93,13 @@ export const formsApi = {
     getDownloadRequest: (formId, templateId) => {
       const endpoint = `/open/forms/${formId}/pdf-templates/${templateId}/download`
       const requestOptions = getOpnRequestsOptions(endpoint, {})
+      // baseURL is relative on self-hosted installs (NUXT_PUBLIC_API_BASE=/api), and
+      // the URL constructor rejects a relative base. Resolve against the page origin
+      // so both relative and absolute API bases work.
+      const base = (requestOptions.baseURL || '').replace(/\/$/, '')
+      const origin = import.meta.client ? window.location.origin : undefined
       return {
-        url: new URL(endpoint, requestOptions.baseURL).toString(),
+        url: new URL(base + endpoint, origin).toString(),
         httpHeaders: requestOptions.headers,
       }
     },

--- a/client/components/open/pdf-editor/PdfZoneEditor.vue
+++ b/client/components/open/pdf-editor/PdfZoneEditor.vue
@@ -145,6 +145,9 @@ const renderPassId = ref(0)
 const zoomRenderTimeout = ref(null)
 const pendingRenderAfterInteraction = ref(false)
 const INITIAL_FIT_HORIZONTAL_PADDING = 48
+// US Letter at 72dpi, used to size templates that contain only blank pages.
+const BLANK_PAGE_WIDTH = 612
+const BLANK_PAGE_HEIGHT = 792
 const SNAP_THRESHOLD_PX = 6
 const MIN_ZONE_WIDTH_PERCENT = 5
 const MIN_ZONE_HEIGHT_PERCENT = 2
@@ -489,7 +492,14 @@ const renderAllPages = async (options = {}) => {
   const { zoomOnlyVisible = false } = options
   const thisPassId = ++renderPassId.value
   const targetPages = zoomOnlyVisible ? getPriorityZoomPages() : pageList.value.filter((p) => !isNewPage(p))
-  if (!targetPages.length) return
+  if (!targetPages.length) {
+    // Templates built entirely from blank pages have no source page to measure, so the
+    // canvas would stay at 0x0 and every zone would collapse to the top-left corner.
+    // Fall back to US Letter, matching the blank page placeholder in the sidebar.
+    canvasWidth.value = BLANK_PAGE_WIDTH * zoomScale.value
+    canvasHeight.value = BLANK_PAGE_HEIGHT * zoomScale.value
+    return
+  }
 
   // Get dimensions from first physical page (for new pages and initial layout)
   const firstPhysical = targetPages[0]


### PR DESCRIPTION
## Problem

The PDF template editor is completely non-functional on self-hosted installs. Pages never render, thumbnails spin forever, and any zone you add collapses into an undraggable sliver at the top-left of page 1.

All of it comes from one line in `client/api/forms.js`:

```js
url: new URL(endpoint, requestOptions.baseURL).toString(),
```

On the client, `baseURL` resolves to `config.public.apiBase`. The Docker setup ships `NUXT_PUBLIC_API_BASE=/api` — a **relative** path — and the URL constructor rejects a relative base:

```
Failed to load PDF for thumbnails: TypeError: URL constructor: /api is not a valid URL.
Failed to load PDF: TypeError: URL constructor: /api is not a valid URL.
```

opnform.com is unaffected because its API base is absolute, so this only bites self-hosters.

The throw happens *synchronously inside* `getDownloadRequest`, before `getDocument()` can issue anything. Ingress logs from a session spent in the editor confirm the request is never attempted:

```
0  requests to  /open/forms/{id}/pdf-templates/{id}/download
13 GET  /api/open/forms/4/pdf-templates
1  POST /api/open/forms/4/pdf-templates      ← upload, succeeded
1  GET  /api/open/forms/4/pdf-templates/3
```

## Why one bug looks like three

**Spinners vs. blank pages.** `PdfZoneEditor.vue` and `PdfLeftSidebar.vue` share the helper but differ in cleanup. The editor clears its flag in a `finally` and renders empty pages; the sidebar has no `finally`, so `thumbnailsLoaded[pageNum]` is never set and the overlay spins indefinitely.

**Zones pinned to the corner.** `canvasWidth`/`canvasHeight` start at `0` and are only assigned once the document loads. Zone geometry is a percentage of them:

```js
left:  `${(zone.x / 100) * canvasWidth.value}px`   // → 0px
width: `${(zone.width / 100) * canvasWidth.value}px`   // → 0px
```

Every zone becomes a 0×0 box at the origin, and dragging fails because the drag math reads the same zeros.

## Fix

Resolve the endpoint against `window.location.origin`, which handles a relative base and leaves an absolute one untouched:

| API base | Result |
| --- | --- |
| `/api` (self-hosted) | `https://host/api/open/forms/4/pdf-templates/3/download` |
| `https://api.opnform.com` (SaaS) | `https://api.opnform.com/open/forms/4/pdf-templates/3/download` |
| empty | `https://host/open/forms/4/pdf-templates/3/download` |

## Second, independent fix

`renderAllPages()` derives canvas dimensions from the first *physical* page and returned early via `if (!targetPages.length) return`. A template built entirely from blank pages therefore never sized its canvas and collapsed zones exactly the same way, with no PDF involved at all. It now falls back to US Letter at 72dpi (612×792), matching the `aspect-[8.5/11]` blank placeholder already used in the sidebar.

## Not addressed here

`PdfLeftSidebar.vue` still spins forever on *any* thumbnail load failure, since nothing resets the loading state in its `catch`. With this fix the failure no longer occurs, but the missing error state is worth a follow-up — happy to add one if you'd like it in scope.

## Verification

Built the client image from this branch and deployed it to a self-hosted instance running `NUXT_PUBLIC_API_BASE=/api`.

The patched builder is present in the shipped bundle:

```js
getDownloadRequest:(e,s)=>{const o=`/open/forms/${e}/pdf-templates/${s}/download`,
r=i(o,{}),n=(r.baseURL||"").replace(/\/$/,""),p=window.location.origin;…
```

The URL it now produces resolves to the correct route — the real path returns `401` (auth required) while a bogus sibling path returns `404`, so the request reaches the endpoint instead of throwing client-side:

```
/api/open/forms/4/pdf-templates/3/download    -> 401 {"message":"Origin User Agent is invalid"}
/api/open/forms/4/pdf-templates/3/nonexistent -> 404
```

(The 401 is that instance's JWT IP/UA binding rejecting a server-minted token from curl, not an authorization problem with the route.)

The URL construction itself was checked against all three base shapes — relative, absolute, and empty — as tabulated above. In-browser confirmation of rendering and zone dragging is with the reporter.
