### PR TITLE
Fix self-hosted PDF template rendering

### DIFF
--- a/client/api/forms.js
+++ b/client/api/forms.js
@@ -1,5 +1,6 @@
 import { apiService } from './base'
 import { getOpnRequestsOptions } from '~/composables/useOpnApi'
+import { resolvePdfDownloadUrl } from '~/lib/pdf-editor'
 
 export const formsApi = {
   // Form views
@@ -93,8 +94,9 @@ export const formsApi = {
     getDownloadRequest: (formId, templateId) => {
       const endpoint = `/open/forms/${formId}/pdf-templates/${templateId}/download`
       const requestOptions = getOpnRequestsOptions(endpoint, {})
+      const origin = import.meta.client ? window.location.origin : undefined
       return {
-        url: new URL(endpoint, requestOptions.baseURL).toString(),
+        url: resolvePdfDownloadUrl(endpoint, requestOptions.baseURL, origin),
         httpHeaders: requestOptions.headers,
       }
     },

--- a/client/components/open/pdf-editor/PdfZoneEditor.vue
+++ b/client/components/open/pdf-editor/PdfZoneEditor.vue
@@ -113,6 +113,7 @@
 
 <script setup>
 import { formsApi } from '~/api/forms'
+import { getPdfRenderPages } from '~/lib/pdf-editor'
 
 const pdfStore = useWorkingPdfStore()
 const {
@@ -398,12 +399,6 @@ const cancelAllRenderTasks = () => {
   activeRenderTasks.clear()
 }
 
-const getPriorityZoomPages = () => {
-  const current = Number(currentPage.value)
-  const candidatePages = [current - 1, current, current + 1]
-  return candidatePages.filter((pageNum) => pageList.value.includes(pageNum) && !isNewPage(pageNum))
-}
-
 const getEditorScrollRoot = () => {
   return pagesContainer.value?.closest?.('.pdf-editor-scroll-container')
 }
@@ -418,9 +413,9 @@ const fitZoomToPageWidth = async () => {
   if (!pdfDoc.value) return
 
   const firstPhysicalPage = pageList.value.find((pageNum) => !isNewPage(pageNum))
-  if (!firstPhysicalPage) return
-
-  const sourcePageNumber = pdfStore.getSourcePageNumber(firstPhysicalPage)
+  const sourcePageNumber = firstPhysicalPage
+    ? pdfStore.getSourcePageNumber(firstPhysicalPage)
+    : 1
   if (sourcePageNumber == null) return
 
   const availablePageWidth = getAvailablePageWidth()
@@ -488,7 +483,24 @@ const renderAllPages = async (options = {}) => {
   if (!pdfDoc.value) return
   const { zoomOnlyVisible = false } = options
   const thisPassId = ++renderPassId.value
-  const targetPages = zoomOnlyVisible ? getPriorityZoomPages() : pageList.value.filter((p) => !isNewPage(p))
+  const { physicalPages, targetPages } = getPdfRenderPages(
+    pageList.value,
+    currentPage.value,
+    isNewPage,
+    zoomOnlyVisible
+  )
+
+  if (!physicalPages.length) {
+    const page = await pdfDoc.value.getPage(1)
+    if (thisPassId !== renderPassId.value) return
+    const viewport = page.getViewport({ scale: zoomScale.value })
+    canvasWidth.value = viewport.width
+    canvasHeight.value = viewport.height
+    return
+  }
+
+  // A visible-only zoom pass can contain only blank pages. Preserve the
+  // dimensions established by the last physical-page render in that case.
   if (!targetPages.length) return
 
   // Get dimensions from first physical page (for new pages and initial layout)

--- a/client/lib/pdf-editor.js
+++ b/client/lib/pdf-editor.js
@@ -1,0 +1,17 @@
+export function resolvePdfDownloadUrl(endpoint, baseUrl, origin) {
+  const normalizedBaseUrl = (baseUrl || '').replace(/\/+$/, '')
+  return new URL(normalizedBaseUrl + endpoint, origin).toString()
+}
+
+export function getPdfRenderPages(pageList, currentPage, isNewPage, zoomOnlyVisible = false) {
+  const physicalPages = pageList.filter((pageNum) => !isNewPage(pageNum))
+  if (!zoomOnlyVisible) {
+    return { physicalPages, targetPages: physicalPages }
+  }
+
+  const current = Number(currentPage)
+  const priorityPages = [current - 1, current, current + 1]
+  const targetPages = priorityPages.filter((pageNum) => physicalPages.includes(pageNum))
+
+  return { physicalPages, targetPages }
+}

--- a/client/test/unit/pdf-editor.test.ts
+++ b/client/test/unit/pdf-editor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { getPdfRenderPages, resolvePdfDownloadUrl } from '../../lib/pdf-editor'
+
+describe('PDF editor helpers', () => {
+  describe('resolvePdfDownloadUrl', () => {
+    const endpoint = '/open/forms/4/pdf-templates/3/download'
+    const origin = 'https://forms.example.com'
+
+    it.each([
+      ['/api', 'https://forms.example.com/api/open/forms/4/pdf-templates/3/download'],
+      ['/api/', 'https://forms.example.com/api/open/forms/4/pdf-templates/3/download'],
+      ['', 'https://forms.example.com/open/forms/4/pdf-templates/3/download'],
+      ['https://api.opnform.com', 'https://api.opnform.com/open/forms/4/pdf-templates/3/download'],
+    ])('resolves the %s API base', (baseUrl, expectedUrl) => {
+      expect(resolvePdfDownloadUrl(endpoint, baseUrl, origin)).toBe(expectedUrl)
+    })
+  })
+
+  describe('getPdfRenderPages', () => {
+    const blankPages = new Set([2, 3, 4])
+    const isNewPage = (pageNum: number) => blankPages.has(pageNum)
+
+    it('keeps physical and visible render pages distinct', () => {
+      expect(getPdfRenderPages([1, 2, 3, 4, 5], 3, isNewPage, true)).toEqual({
+        physicalPages: [1, 5],
+        targetPages: [],
+      })
+    })
+
+    it('selects adjacent physical pages during a visible-only render', () => {
+      expect(getPdfRenderPages([1, 2, 3, 4, 5], 2, isNewPage, true)).toEqual({
+        physicalPages: [1, 5],
+        targetPages: [1],
+      })
+    })
+
+    it('returns no physical pages for an all-blank template', () => {
+      expect(getPdfRenderPages([2, 3, 4], 3, isNewPage)).toEqual({
+        physicalPages: [],
+        targetPages: [],
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This replaces #1239 with the valid self-hosted URL fix plus regression coverage and corrected blank-page rendering behavior.

- resolve PDF download URLs for relative, empty, trailing-slash, and absolute API bases
- keep physical PDF pages separate from the visible-page render window
- derive an all-blank template's canvas dimensions from the actual source PDF instead of a hardcoded paper size
- preserve dimensions when a visible-only zoom pass contains only inserted blank pages

## Why

`new URL(endpoint, baseURL)` throws when self-hosted deployments configure a relative API base such as `/api`.

The earlier implementation also conflated the full set of physical pages with the currently visible render targets. On a blank page between physical pages, the visible target list may legitimately be empty even though the document still has physical pages. A completely blank manifest additionally needs dimensions derived from the loaded PDF.

## Validation

- `npm run test -- --run test/unit/pdf-editor.test.ts` — 7 passed
- `npm run test -- --run` — 702 passed
- `npm run lint` — passed
- `npm run build` — passed
- `env APP_ENV=testing OPEN_AI_API_KEY=dummy ./vendor/bin/pest -p` — 1,844 passed
- `./vendor/bin/pint --test` — passed
- browser QA on the isolated seeded stack: removed the only source page, rendered a blank A4 page from the PDF's dimensions, added and dragged a zone, saved, and reopened successfully

## Known repository-level check

`./vendor/bin/phpstan analyse --memory-limit=1G` reaches completion but reports two pre-existing errors in `BackfillLifetimeLicenseWorkspaceEntitlements.php` for the `owners` relation. This PR does not change backend code.

## Scope

The generic sidebar error-state improvement mentioned during #1239's review remains a separate UX follow-up; it is not required for the URL/rendering regression fixed here.