### PR TITLE
Restore legal links in footer

### DIFF
--- a/client/components/pages/OpenFormFooter.vue
+++ b/client/components/pages/OpenFormFooter.vue
@@ -331,8 +331,8 @@ const linkGroups = computed(() => [
     links: [
       { label: "Feedback", href: "https://feedback.opnform.com/" },
       { label: "Changelog", href: "https://feedback.opnform.com/changelog" },
-      // { label: "Privacy Policy", to: { name: "privacy-policy" } },
-      // { label: "Terms & Conditions", to: { name: "terms-conditions" } },
+      { label: "Privacy Policy", to: { name: "privacy-policy" } },
+      { label: "Terms & Conditions", to: { name: "terms-conditions" } },
     ],
   },
 ])


### PR DESCRIPTION
## Summary

- restore the Privacy Policy link in the redesigned footer
- restore the Terms & Conditions link in the redesigned footer
- reuse the existing Nuxt routes so navigation remains internal

## Why

The footer redesign left both legal links commented out, removing access to the public legal pages from site-wide footer navigation.

## Impact

Visitors can once again reach `/privacy-policy` and `/terms-conditions` from every page that renders the shared footer.

## Validation

- `npm run lint`
- `git diff --check`