### PR TITLE
Force live demo forms to use English labels

### DIFF
--- a/client/data/live-demo-scenarios.js
+++ b/client/data/live-demo-scenarios.js
@@ -94,6 +94,9 @@ function baseForm(key, overrides = {}) {
     computed_variables: [],
     presentation_style: "focused",
     language: "en",
+    translations: {
+      focused_next_button_text: "Next",
+    },
     font_family: null,
     theme: "default",
     width: "centered",

--- a/client/test/unit/live-demo-scenarios.test.ts
+++ b/client/test/unit/live-demo-scenarios.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { getLiveDemoScenario } from "../../data/live-demo-scenarios.js"
+
+const demoVariants = [
+  { variant: "home" },
+  { variant: "comparison", competitorName: "Typeform" },
+  { variant: "comparison", competitorName: "Google Forms" },
+  { variant: "comparison", competitorName: "Tally" },
+  { variant: "comparison", competitorName: "Jotform" },
+  { variant: "comparison", competitorName: "Fillout" },
+  { variant: "comparison", competitorName: "HeyForm" },
+  { variant: "comparison", competitorName: "Youform" },
+  { variant: "comparison", competitorName: "Formbricks" },
+  { variant: "comparison", competitorName: "Form.io" },
+  { variant: "comparison", competitorName: "123FormBuilder" },
+  { variant: "comparison", competitorName: "Another form builder" },
+]
+
+describe("live demo scenarios", () => {
+  it.each(demoVariants)(
+    "keeps the $variant demo for $competitorName in English",
+    (variant) => {
+      const scenario = getLiveDemoScenario(variant)
+
+      expect(scenario.form.language).toBe("en")
+      expect(scenario.form.translations.focused_next_button_text).toBe("Next")
+    },
+  )
+})


### PR DESCRIPTION
## What changed

- explicitly set the focused demo navigation label to `Next`
- keep every homepage and comparison demo scenario in English
- add a regression test covering the homepage demo, all known competitor demos, and the generic comparison fallback

## Why

The live demo renders the shared focused-form component directly. Although its form configuration already declared `language: "en"`, the focused next button fell back to the application's global i18n locale. A stale or browser-detected Arabic locale could therefore display `التالي` inside an otherwise English homepage.

## Impact

Live demo form controls now remain in English regardless of the visitor's global application locale. Regular public forms keep their existing locale behavior.

## Validation

- `npm run test -- --run test/unit/live-demo-scenarios.test.ts` (12 tests passed)
- `npm run lint`
- `git diff --check`