### PR TITLE
Align workspace actions with member roles

### DIFF
--- a/api/app/Policies/WorkspacePolicy.php
+++ b/api/app/Policies/WorkspacePolicy.php
@@ -77,11 +77,15 @@ class WorkspacePolicy
      */
     public function update(User $user, Workspace $workspace)
     {
-        if ($token = $user->currentAccessToken()) {
-            return $token->can('workspaces-write') && $user->ownsWorkspace($workspace);
+        if (!$user->ownsWorkspace($workspace) || $workspace->isReadonlyUser($user)) {
+            return Response::deny('You cannot update this workspace.');
         }
 
-        return $user->ownsWorkspace($workspace);
+        if ($token = $user->currentAccessToken()) {
+            return $token->can('workspaces-write');
+        }
+
+        return true;
     }
 
     /**
@@ -91,16 +95,12 @@ class WorkspacePolicy
      */
     public function delete(User $user, Workspace $workspace)
     {
-        if (!$user->ownsWorkspace($workspace)) {
-            return Response::deny('You cannot delete this workspace.');
+        if (!$this->adminAction($user, $workspace)) {
+            return Response::deny('You need to be an admin of this workspace to do this.');
         }
 
         if ($user->workspaces()->count() <= 1) {
             return Response::deny('You cannot delete your last workspace. Delete your account instead.');
-        }
-
-        if ($token = $user->currentAccessToken()) {
-            return $token->can('workspaces-write');
         }
 
         return true;

--- a/api/tests/Feature/Workspaces/WorkspaceTest.php
+++ b/api/tests/Feature/Workspaces/WorkspaceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 it('can not create more than 1 workspace for free user', function () {
     $user = $this->actingAsUser();
 
@@ -460,5 +462,139 @@ describe('SMTP settings redaction', function () {
         $ws = collect($response->json())->firstWhere('id', $workspace->id);
         expect($ws['settings']['custom_code'])->toBe('<script>tracking</script>');
         expect($ws['settings']['email_settings'] ?? null)->toBeNull();
+    });
+});
+
+
+describe('Workspace member authorization', function () {
+    it('prevents a readonly member from deleting a workspace they were invited to', function () {
+        $admin = $this->createProUser();
+        $workspace = $this->createUserWorkspace($admin);
+        $form = $this->createForm($admin, $workspace);
+
+        $readonly = $this->createUser();
+        $this->createUserWorkspace($readonly);
+        $workspace->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
+
+        expect($readonly->workspaces()->count())->toBeGreaterThan(1);
+
+        $this->actingAsUser($readonly);
+
+        $this->deleteJson(route('open.workspaces.delete', $workspace))
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'You need to be an admin of this workspace to do this.',
+            ]);
+
+        expect($workspace->fresh())->not->toBeNull();
+        expect($form->fresh())->not->toBeNull();
+        expect($form->fresh()->workspace_id)->toBe($workspace->id);
+    });
+
+    it('prevents a regular member from deleting a workspace they were invited to', function () {
+        $admin = $this->createProUser();
+        $workspace = $this->createUserWorkspace($admin);
+
+        $member = $this->createUser();
+        $this->createUserWorkspace($member);
+        $workspace->users()->attach($member, ['role' => User::ROLE_USER]);
+
+        expect($member->workspaces()->count())->toBeGreaterThan(1);
+
+        $this->actingAsUser($member);
+
+        $this->deleteJson(route('open.workspaces.delete', $workspace))
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'You need to be an admin of this workspace to do this.',
+            ]);
+
+        expect($workspace->fresh())->not->toBeNull();
+    });
+
+    it('prevents a non-member from deleting a workspace', function () {
+        $admin = $this->createProUser();
+        $workspace = $this->createUserWorkspace($admin);
+
+        $outsider = $this->createProUser();
+        $this->createUserWorkspace($outsider);
+        $this->actingAsUser($outsider);
+
+        $this->deleteJson(route('open.workspaces.delete', $workspace))
+            ->assertForbidden();
+
+        expect($workspace->fresh())->not->toBeNull();
+    });
+
+    it('allows an admin to delete a workspace they own when they have another workspace', function () {
+        $admin = $this->actingAsProUser();
+        $workspace = $this->createUserWorkspace($admin);
+        $this->createUserWorkspace($admin);
+
+        $this->deleteJson(route('open.workspaces.delete', $workspace))
+            ->assertSuccessful()
+            ->assertJson([
+                'message' => 'Workspace successfully deleted.',
+                'workspace_id' => $workspace->id,
+            ]);
+
+        expect($workspace->fresh())->toBeNull();
+    });
+
+    it('still prevents an admin from deleting their last workspace', function () {
+        $admin = $this->actingAsUser();
+        $workspace = $this->createUserWorkspace($admin);
+
+        expect($admin->workspaces()->count())->toBe(1);
+
+        $this->deleteJson(route('open.workspaces.delete', $workspace))
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'You cannot delete your last workspace. Delete your account instead.',
+            ]);
+
+        expect($workspace->fresh())->not->toBeNull();
+    });
+
+    it('prevents a readonly member from renaming a workspace', function () {
+        $admin = $this->createProUser();
+        $workspace = $this->createUserWorkspace($admin);
+        $originalName = $workspace->name;
+
+        $readonly = $this->createUser();
+        $workspace->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
+        $this->actingAsUser($readonly);
+
+        $this->putJson(route('open.workspaces.update', $workspace), [
+            'name' => 'Hijacked Workspace',
+            'icon' => '💀',
+        ])
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'You cannot update this workspace.',
+            ]);
+
+        expect($workspace->fresh()->name)->toBe($originalName);
+    });
+
+    it('allows a regular member to update workspace information', function () {
+        $admin = $this->createProUser();
+        $workspace = $this->createUserWorkspace($admin);
+
+        $member = $this->createUser();
+        $workspace->users()->attach($member, ['role' => User::ROLE_USER]);
+        $this->actingAsUser($member);
+
+        $this->putJson(route('open.workspaces.update', $workspace), [
+            'name' => 'Shared Workspace',
+            'emoji' => '✏️',
+        ])
+            ->assertSuccessful()
+            ->assertJson([
+                'message' => 'Workspace updated.',
+            ]);
+
+        expect($workspace->fresh()->name)->toBe('Shared Workspace');
+        expect($workspace->fresh()->icon)->toBe('✏️');
     });
 });


### PR DESCRIPTION
## Summary

- require workspace admins for workspace deletion
- prevent readonly members from updating workspace information
- add regression coverage for admin, member, readonly, and non-member access

This aligns API authorization with the permissions already presented in the workspace settings UI. Admin behavior and the existing last-workspace safeguard remain unchanged, while regular members can still update shared workspace information.

The underlying issue was that workspace deletion relied on broad membership rather than the existing admin-role check. Workspace updates also did not exclude readonly members.

Thanks to @harshilnayi for responsibly sharing this permissions inconsistency with us.

## Validation

- `./vendor/bin/pest tests/Feature/Workspaces/WorkspaceTest.php tests/Feature/TokenPermissionsTest.php tests/Feature/Webhook/UserInviteSecurityTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=2G app/Policies/WorkspacePolicy.php`
- `./vendor/bin/pint --test app/Policies/WorkspacePolicy.php tests/Feature/Workspaces/WorkspaceTest.php`
- `git diff --check`