### PR TITLE
MCP 1/9: Add server foundation and canonical form schema

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -128,6 +128,11 @@ TELEGRAM_BOT_TOKEN=
 
 ZAPIER_ENABLED=false
 
+# MCP is always enabled on OpnForm Cloud. Self-hosted instances can opt in.
+MCP_ENABLED=false
+MCP_RATE_LIMIT_PER_MINUTE=120
+MCP_RATE_LIMIT_PER_HOUR=3000
+
 STRIPE_CLIENT_ID=
 STRIPE_CLIENT_SECRET=
 

--- a/api/app/Http/Requests/UserFormRequest.php
+++ b/api/app/Http/Requests/UserFormRequest.php
@@ -13,8 +13,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Http\Request;
 use App\Rules\CssOnlyRule;
-use Illuminate\Support\Str;
-use Stevebauman\Purify\Facades\Purify;
+use App\Service\Forms\FormDataNormalizer;
 
 /**
  * Abstract class to validate create/update forms
@@ -33,64 +32,7 @@ abstract class UserFormRequest extends \Illuminate\Foundation\Http\FormRequest
 
     protected function prepareForValidation()
     {
-        $data = $this->all();
-
-        if (isset($data['title']) && is_string($data['title'])) {
-            $data['title'] = Str::substr(trim($data['title']), 0, 255);
-        }
-
-        if (isset($data['properties']) && is_array($data['properties'])) {
-            $data['properties'] = array_map(function ($property) {
-                if (!is_array($property)) {
-                    return $property;
-                }
-
-                if (isset($property['name']) && is_string($property['name'])) {
-                    $property['name'] = trim(strip_tags($property['name']));
-                }
-
-                if (isset($property['help']) && is_string($property['help'])) {
-                    $property['help'] = Purify::clean($property['help']);
-                    if (strip_tags($property['help']) === '') {
-                        $property['help'] = null;
-                    }
-                }
-                $property = $this->normalizeSelectOptionIds($property);
-                return $property;
-            }, $data['properties']);
-        }
-
-        $this->merge($data);
-    }
-
-    /**
-     * Backfill option ids for legacy select fields before strict property validation runs.
-     */
-    private function normalizeSelectOptionIds(array $property): array
-    {
-        $type = $property['type'] ?? null;
-
-        if (!in_array($type, ['select', 'multi_select'], true)) {
-            return $property;
-        }
-
-        if (!isset($property[$type]['options']) || !is_array($property[$type]['options'])) {
-            return $property;
-        }
-
-        $property[$type]['options'] = array_map(function ($option) {
-            if (!is_array($option) || !empty($option['id'] ?? null)) {
-                return $option;
-            }
-
-            if (!empty($option['name'] ?? null) && is_string($option['name'])) {
-                $option['id'] = $option['name'];
-            }
-
-            return $option;
-        }, $property[$type]['options']);
-
-        return $property;
+        $this->merge(app(FormDataNormalizer::class)->normalize($this->all()));
     }
 
     /**

--- a/api/app/Mcp/Resources/FormDefinitionSchemaResource.php
+++ b/api/app/Mcp/Resources/FormDefinitionSchemaResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Mcp\Resources;
+
+use App\Service\Forms\AgentFormDefinition;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\MimeType;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Name('form_definition_schema')]
+#[Description('Versioned JSON Schema for OpnForm agent form definitions.')]
+#[Uri('opnform://schemas/agent-form-definition/v1')]
+#[MimeType('application/schema+json')]
+class FormDefinitionSchemaResource extends Resource
+{
+    public function handle(Request $request, AgentFormDefinition $definition): Response
+    {
+        return Response::json($definition->jsonSchema());
+    }
+}

--- a/api/app/Mcp/Resources/FormFieldCatalogResource.php
+++ b/api/app/Mcp/Resources/FormFieldCatalogResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Mcp\Resources;
+
+use App\Service\Forms\AgentFormFieldCatalog;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\MimeType;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Resource;
+
+#[Name('form_field_catalog')]
+#[Description('Canonical field and layout block catalog for OpnForm agent definitions, including aliases and plan behavior.')]
+#[Uri('opnform://reference/form-fields/v1')]
+#[MimeType('application/json')]
+class FormFieldCatalogResource extends Resource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::json(AgentFormFieldCatalog::reference());
+    }
+}

--- a/api/app/Mcp/Servers/OpnFormServer.php
+++ b/api/app/Mcp/Servers/OpnFormServer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mcp\Servers;
+
+use App\Mcp\Resources\FormDefinitionSchemaResource;
+use App\Mcp\Resources\FormFieldCatalogResource;
+use App\Mcp\Tools\ValidateFormDefinitionTool;
+use Laravel\Mcp\Server;
+use Laravel\Mcp\Server\Attributes\Instructions;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Version;
+
+#[Name('OpnForm')]
+#[Version('1.0.0')]
+#[Instructions('Build and manage OpnForm forms. Guest-safe draft tools are available without authentication; account, form, and submission tools require OAuth. Read the schema and field catalog before generating a form definition, and validate definitions before saving them.')]
+class OpnFormServer extends Server
+{
+    protected array $tools = [
+        ValidateFormDefinitionTool::class,
+    ];
+
+    protected array $resources = [
+        FormDefinitionSchemaResource::class,
+        FormFieldCatalogResource::class,
+    ];
+}

--- a/api/app/Mcp/Tools/ValidateFormDefinitionTool.php
+++ b/api/app/Mcp/Tools/ValidateFormDefinitionTool.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\AgentFormDefinition;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('validate_form_definition')]
+#[Description('Normalize and validate an OpnForm agent form definition without storing it. Returns the canonical definition with defaults, stable block IDs, sanitized content, and normalized aliases.')]
+#[IsReadOnly]
+#[IsIdempotent]
+#[IsOpenWorld(false)]
+class ValidateFormDefinitionTool extends Tool
+{
+    public function handle(Request $request, AgentFormDefinition $formDefinition): ResponseFactory
+    {
+        $validated = $request->validate([
+            'definition' => ['required', 'array'],
+        ]);
+
+        $definition = $formDefinition->normalizeAndValidate($validated['definition']);
+
+        return Response::structured([
+            'valid' => true,
+            'schema_version' => AgentFormDefinition::SCHEMA_VERSION,
+            'definition' => $definition,
+        ]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'definition' => $schema->object()
+                ->description('Form definition following opnform://schemas/agent-form-definition/v1. IDs and optional defaults may be omitted.')
+                ->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'valid' => $schema->boolean()->required(),
+            'schema_version' => $schema->integer()->required(),
+            'definition' => $schema->object()->required(),
+        ];
+    }
+}

--- a/api/app/Providers/RouteServiceProvider.php
+++ b/api/app/Providers/RouteServiceProvider.php
@@ -109,6 +109,19 @@ class RouteServiceProvider extends ServiceProvider
                     ->by('public-uploads:hour:' . $key),
             ];
         });
+
+        RateLimiter::for('mcp', function (Request $request) {
+            $identifier = $request->user()
+                ? 'user:'.$request->user()->getAuthIdentifier()
+                : 'ip:'.$request->ip();
+
+            return [
+                Limit::perMinute(max(1, config('opnform.mcp.rate_limit.per_minute', 120)))
+                    ->by('mcp:minute:'.$identifier),
+                Limit::perHour(max(1, config('opnform.mcp.rate_limit.per_hour', 3000)))
+                    ->by('mcp:hour:'.$identifier),
+            ];
+        });
     }
 
     protected function registerGlobalRouteParamConstraints()

--- a/api/app/Rules/PropertyValidators/PaymentPropertyValidator.php
+++ b/api/app/Rules/PropertyValidators/PaymentPropertyValidator.php
@@ -87,6 +87,13 @@ class PaymentPropertyValidator implements PropertyValidatorInterface
             return $errors;
         }
 
+        // Guest form definitions have no workspace security boundary yet. Defer
+        // provider lookup until the draft is claimed so validation cannot be
+        // used to enumerate OAuth provider IDs from other accounts.
+        if ($this->workspace === null) {
+            return $errors;
+        }
+
         try {
             $provider = OAuthProvider::find($property['stripe_account_id']);
             if ($provider === null) {
@@ -94,8 +101,7 @@ class PaymentPropertyValidator implements PropertyValidatorInterface
                 return $errors;
             }
 
-            // Check if the provider is associated with the workspace (if workspace is provided)
-            if ($this->workspace && !$this->workspace->hasProvider($provider->id)) {
+            if (!$this->workspace->hasProvider($provider->id)) {
                 Log::error('Attempted to use Stripe account not associated with the workspace', [
                     'stripe_account_id' => $property['stripe_account_id'],
                     'provider_id' => $provider->id,

--- a/api/app/Rules/PublicMediaUrlRule.php
+++ b/api/app/Rules/PublicMediaUrlRule.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class PublicMediaUrlRule implements ValidationRule
+{
+    private const PRIVATE_HOST_SUFFIXES = [
+        'home',
+        'internal',
+        'lan',
+        'local',
+        'localhost',
+        'test',
+    ];
+
+    private const TEMPORARY_HOST_SUFFIXES = [
+        'loca.lt',
+        'localtunnel.me',
+        'ngrok-free.app',
+        'ngrok.io',
+        'trycloudflare.com',
+    ];
+
+    private const TEMPORARY_QUERY_PARAMETERS = [
+        'expires',
+        'signature',
+        'x-amz-expires',
+        'x-amz-signature',
+        'x-goog-expires',
+        'x-goog-signature',
+    ];
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || filter_var($value, FILTER_VALIDATE_URL) === false) {
+            $fail('The :attribute must be a valid public HTTPS URL.');
+
+            return;
+        }
+
+        if (strtolower((string) parse_url($value, PHP_URL_SCHEME)) !== 'https') {
+            $fail('The :attribute must use HTTPS.');
+
+            return;
+        }
+
+        if (parse_url($value, PHP_URL_USER) !== null || parse_url($value, PHP_URL_PASS) !== null) {
+            $fail('The :attribute cannot contain embedded credentials.');
+
+            return;
+        }
+
+        $host = strtolower(rtrim(trim((string) parse_url($value, PHP_URL_HOST), '[]'), '.'));
+        if ($host === '' || $this->isPrivateHost($host)) {
+            $fail('The :attribute must use a public host.');
+
+            return;
+        }
+
+        if ($this->hasSuffix($host, self::TEMPORARY_HOST_SUFFIXES)) {
+            $fail('The :attribute cannot use a temporary tunnel host.');
+
+            return;
+        }
+
+        parse_str((string) parse_url($value, PHP_URL_QUERY), $query);
+        $queryKeys = array_map(
+            fn (string|int $key): string => strtolower((string) $key),
+            array_keys($query),
+        );
+        if (array_intersect($queryKeys, self::TEMPORARY_QUERY_PARAMETERS) !== []) {
+            $fail('The :attribute cannot use an expiring or signed URL.');
+        }
+    }
+
+    private function isPrivateHost(string $host): bool
+    {
+        if ($host === 'localhost' || $this->hasSuffix($host, self::PRIVATE_HOST_SUFFIXES)) {
+            return true;
+        }
+
+        if (! filter_var($host, FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        return filter_var(
+            $host,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) === false;
+    }
+
+    /**
+     * @param  array<int, string>  $suffixes
+     */
+    private function hasSuffix(string $host, array $suffixes): bool
+    {
+        foreach ($suffixes as $suffix) {
+            if ($host === $suffix || str_ends_with($host, '.'.$suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Models\Forms\Form;
+use App\Rules\ComputedVariablesRule;
+use App\Rules\FormPropertiesRule;
+use App\Service\Forms\AgentFormFieldCatalog as FieldCatalog;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class AgentFormDefinition
+{
+    public const SCHEMA_VERSION = 1;
+
+    private const ALLOWED_TOP_LEVEL_KEYS = [
+        'schema_version',
+        'title',
+        'visibility',
+        'properties',
+        'computed_variables',
+        'language',
+        'font_family',
+        'theme',
+        'presentation_style',
+        'width',
+        'size',
+        'layout_rtl',
+        'border_radius',
+        'dark_mode',
+        'color',
+        'uppercase_labels',
+        'no_branding',
+        'transparent_background',
+        'translations',
+        'cover_picture',
+        'cover_settings',
+        'logo_picture',
+        'custom_code',
+        'custom_css',
+        'submit_button_text',
+        're_fillable',
+        're_fill_button_text',
+        'submitted_text',
+        'redirect_url',
+        'max_submissions_count',
+        'max_submissions_reached_text',
+        'editable_submissions',
+        'editable_submissions_button_text',
+        'confetti_on_submission',
+        'show_progress_bar',
+        'auto_save',
+        'auto_focus',
+        'enable_partial_submissions',
+        'enable_ip_tracking',
+        'can_be_indexed',
+        'use_captcha',
+        'captcha_provider',
+        'seo_meta',
+        'settings',
+        'analytics',
+    ];
+
+    public function __construct(private readonly FormDataNormalizer $normalizer)
+    {
+    }
+
+    public function normalizeAndValidate(array $definition): array
+    {
+        $definition = $this->migrate($definition);
+        $definition = array_replace($this->defaults(), $definition);
+        $definition = $this->normalizeAliases($definition);
+        $definition = $this->normalizer->normalize($definition, backfillPropertyIds: true);
+        $definition['properties'] = collect($definition['properties'])->map(fn ($property) => is_array($property)
+            ? array_replace([
+                'help' => null,
+                'hidden' => false,
+                'required' => false,
+                'placeholder' => null,
+                'width' => 'full',
+            ], $property)
+            : $property)->values()->all();
+
+        $this->validate($definition);
+
+        return Arr::only($definition, self::ALLOWED_TOP_LEVEL_KEYS);
+    }
+
+    public function validate(array $definition): void
+    {
+        $unknownKeys = array_values(array_diff(array_keys($definition), self::ALLOWED_TOP_LEVEL_KEYS));
+
+        if ($unknownKeys !== []) {
+            throw ValidationException::withMessages([
+                'definition' => ['Unknown top-level keys: '.implode(', ', $unknownKeys).'.'],
+            ]);
+        }
+
+        Validator::make($definition, [
+            'schema_version' => ['required', 'integer', Rule::in([self::SCHEMA_VERSION])],
+            'title' => ['required', 'string', 'max:255'],
+            'visibility' => ['required', Rule::in(Form::VISIBILITY)],
+            'properties' => ['required', 'array', 'min:1', 'max:500', new FormPropertiesRule()],
+            'properties.*.type' => ['required', Rule::in(FieldCatalog::types())],
+            'computed_variables' => ['nullable', 'array', new ComputedVariablesRule()],
+            'language' => ['required', Rule::in(Form::LANGUAGES)],
+            'theme' => ['required', Rule::in(Form::THEMES)],
+            'presentation_style' => ['required', Rule::in(Form::PRESENTATION_STYLES)],
+            'width' => ['required', Rule::in(Form::WIDTHS)],
+            'size' => ['required', Rule::in(Form::SIZES)],
+            'layout_rtl' => ['required', 'boolean'],
+            'border_radius' => ['required', Rule::in(Form::BORDER_RADIUS)],
+            'dark_mode' => ['required', Rule::in(Form::DARK_MODE_VALUES)],
+            'color' => ['required', 'string'],
+            'uppercase_labels' => ['required', 'boolean'],
+            'no_branding' => ['required', 'boolean'],
+            'transparent_background' => ['required', 'boolean'],
+            're_fillable' => ['required', 'boolean'],
+            'confetti_on_submission' => ['required', 'boolean'],
+            'show_progress_bar' => ['required', 'boolean'],
+            'auto_save' => ['required', 'boolean'],
+            'auto_focus' => ['required', 'boolean'],
+            'enable_partial_submissions' => ['required', 'boolean'],
+            'enable_ip_tracking' => ['required', 'boolean'],
+            'can_be_indexed' => ['required', 'boolean'],
+            'use_captcha' => ['required', 'boolean'],
+            'captcha_provider' => ['required', Rule::in(['recaptcha', 'hcaptcha'])],
+            'settings' => ['present', 'array'],
+        ])->validate();
+    }
+
+    public function defaults(): array
+    {
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'title' => 'Untitled Form',
+            'visibility' => 'draft',
+            'properties' => [],
+            'computed_variables' => [],
+            'language' => 'en',
+            'font_family' => null,
+            'theme' => 'default',
+            'presentation_style' => 'classic',
+            'width' => 'centered',
+            'size' => 'md',
+            'layout_rtl' => false,
+            'border_radius' => 'small',
+            'dark_mode' => 'auto',
+            'color' => '#3B82F6',
+            'uppercase_labels' => false,
+            'no_branding' => false,
+            'transparent_background' => false,
+            'translations' => [],
+            'cover_picture' => null,
+            'cover_settings' => [],
+            'logo_picture' => null,
+            'custom_code' => null,
+            'custom_css' => null,
+            'submit_button_text' => null,
+            're_fillable' => false,
+            're_fill_button_text' => null,
+            'submitted_text' => 'Amazing, we saved your answers. Thank you for your time and have a great day!',
+            'redirect_url' => null,
+            'max_submissions_count' => null,
+            'max_submissions_reached_text' => 'This form has now reached the maximum number of allowed submissions and is now closed.',
+            'editable_submissions' => false,
+            'editable_submissions_button_text' => 'Edit submission',
+            'confetti_on_submission' => false,
+            'show_progress_bar' => false,
+            'auto_save' => true,
+            'auto_focus' => true,
+            'enable_partial_submissions' => false,
+            'enable_ip_tracking' => false,
+            'can_be_indexed' => true,
+            'use_captcha' => false,
+            'captcha_provider' => 'recaptcha',
+            'seo_meta' => [],
+            'settings' => [],
+            'analytics' => [],
+        ];
+    }
+
+    public function jsonSchema(): array
+    {
+        return [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+            '$id' => 'https://opnform.com/schemas/agent-form-definition/v1.json',
+            'title' => 'OpnForm Agent Form Definition v1',
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['schema_version', 'title', 'properties'],
+            'properties' => [
+                'schema_version' => ['const' => self::SCHEMA_VERSION],
+                'title' => ['type' => 'string', 'minLength' => 1, 'maxLength' => 255],
+                'visibility' => ['type' => 'string', 'enum' => Form::VISIBILITY, 'default' => 'draft'],
+                'properties' => [
+                    'type' => 'array',
+                    'minItems' => 1,
+                    'maxItems' => 500,
+                    'items' => ['$ref' => '#/$defs/block'],
+                ],
+                'computed_variables' => ['type' => 'array', 'default' => []],
+                'language' => ['type' => 'string', 'enum' => Form::LANGUAGES, 'default' => 'en'],
+                'font_family' => ['type' => ['string', 'null']],
+                'theme' => ['type' => 'string', 'enum' => Form::THEMES, 'default' => 'default'],
+                'presentation_style' => ['type' => 'string', 'enum' => Form::PRESENTATION_STYLES, 'default' => 'classic'],
+                'width' => ['type' => 'string', 'enum' => Form::WIDTHS, 'default' => 'centered'],
+                'size' => ['type' => 'string', 'enum' => Form::SIZES, 'default' => 'md'],
+                'layout_rtl' => ['type' => 'boolean', 'default' => false],
+                'border_radius' => ['type' => 'string', 'enum' => Form::BORDER_RADIUS, 'default' => 'small'],
+                'dark_mode' => ['type' => 'string', 'enum' => Form::DARK_MODE_VALUES, 'default' => 'auto'],
+                'color' => ['type' => 'string', 'default' => '#3B82F6'],
+                'uppercase_labels' => ['type' => 'boolean', 'default' => false],
+                'no_branding' => ['type' => 'boolean', 'default' => false],
+                'transparent_background' => ['type' => 'boolean', 'default' => false],
+                'translations' => ['type' => ['object', 'array'], 'default' => (object) []],
+                'cover_picture' => ['type' => ['string', 'null'], 'format' => 'uri'],
+                'cover_settings' => ['type' => ['object', 'array'], 'default' => (object) []],
+                'logo_picture' => ['type' => ['string', 'null'], 'format' => 'uri'],
+                'custom_code' => ['type' => ['string', 'null']],
+                'custom_css' => ['type' => ['string', 'null']],
+                'submit_button_text' => ['type' => ['string', 'null'], 'maxLength' => 50],
+                're_fillable' => ['type' => 'boolean', 'default' => false],
+                're_fill_button_text' => ['type' => ['string', 'null'], 'maxLength' => 50],
+                'submitted_text' => ['type' => 'string', 'maxLength' => 10000],
+                'redirect_url' => ['type' => ['string', 'null']],
+                'max_submissions_count' => ['type' => ['integer', 'null'], 'minimum' => 1],
+                'max_submissions_reached_text' => ['type' => ['string', 'null']],
+                'editable_submissions' => ['type' => 'boolean', 'default' => false],
+                'editable_submissions_button_text' => ['type' => 'string', 'minLength' => 1, 'maxLength' => 50],
+                'confetti_on_submission' => ['type' => 'boolean', 'default' => false],
+                'show_progress_bar' => ['type' => 'boolean', 'default' => false],
+                'auto_save' => ['type' => 'boolean', 'default' => true],
+                'auto_focus' => ['type' => 'boolean', 'default' => true],
+                'enable_partial_submissions' => ['type' => 'boolean', 'default' => false],
+                'enable_ip_tracking' => ['type' => 'boolean', 'default' => false],
+                'can_be_indexed' => ['type' => 'boolean', 'default' => true],
+                'use_captcha' => ['type' => 'boolean', 'default' => false],
+                'captcha_provider' => ['type' => 'string', 'enum' => ['recaptcha', 'hcaptcha'], 'default' => 'recaptcha'],
+                'seo_meta' => ['type' => ['object', 'array'], 'default' => (object) []],
+                'settings' => ['type' => ['object', 'array'], 'default' => (object) []],
+                'analytics' => ['type' => ['object', 'array'], 'default' => (object) []],
+            ],
+            '$defs' => [
+                'block' => [
+                    'type' => 'object',
+                    'required' => ['name', 'type'],
+                    'additionalProperties' => true,
+                    'properties' => [
+                        'id' => ['type' => 'string'],
+                        'name' => ['type' => 'string', 'minLength' => 1],
+                        'type' => ['type' => 'string', 'enum' => FieldCatalog::types()],
+                        'help' => ['type' => ['string', 'null']],
+                        'hidden' => ['type' => 'boolean', 'default' => false],
+                        'required' => ['type' => 'boolean', 'default' => false],
+                        'placeholder' => ['type' => ['string', 'null']],
+                        'width' => ['type' => 'string', 'enum' => ['full', '1/2', '1/3', '2/3', '1/4', '3/4'], 'default' => 'full'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function migrate(array $definition): array
+    {
+        $version = $definition['schema_version'] ?? self::SCHEMA_VERSION;
+
+        if ($version !== self::SCHEMA_VERSION) {
+            throw ValidationException::withMessages([
+                'schema_version' => ["Unsupported schema version [{$version}]. Current version is ".self::SCHEMA_VERSION.'.'],
+            ]);
+        }
+
+        $definition['schema_version'] = self::SCHEMA_VERSION;
+
+        return $definition;
+    }
+
+    private function normalizeAliases(array $definition): array
+    {
+        $definition['properties'] = collect($definition['properties'] ?? [])->map(function ($property) {
+            if (! is_array($property) || ! isset(FieldCatalog::ALIASES[$property['type'] ?? ''])) {
+                return $property;
+            }
+
+            return array_replace($property, FieldCatalog::ALIASES[$property['type']]);
+        })->values()->all();
+
+        return $definition;
+    }
+}

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -3,6 +3,7 @@
 namespace App\Service\Forms;
 
 use App\Models\Forms\Form;
+use App\Models\Workspace;
 use App\Rules\ComputedVariablesRule;
 use App\Rules\FormPropertiesRule;
 use App\Service\Forms\AgentFormFieldCatalog as FieldCatalog;
@@ -67,7 +68,7 @@ class AgentFormDefinition
     {
     }
 
-    public function normalizeAndValidate(array $definition): array
+    public function normalizeAndValidate(array $definition, ?Workspace $workspace = null): array
     {
         $definition = $this->migrate($definition);
         $definition = array_replace($this->defaults(), $definition);
@@ -83,12 +84,12 @@ class AgentFormDefinition
             ], $property)
             : $property)->values()->all();
 
-        $this->validate($definition);
+        $this->validate($definition, $workspace);
 
         return Arr::only($definition, self::ALLOWED_TOP_LEVEL_KEYS);
     }
 
-    public function validate(array $definition): void
+    public function validate(array $definition, ?Workspace $workspace = null): void
     {
         $unknownKeys = array_values(array_diff(array_keys($definition), self::ALLOWED_TOP_LEVEL_KEYS));
 
@@ -102,7 +103,7 @@ class AgentFormDefinition
             'schema_version' => ['required', 'integer', Rule::in([self::SCHEMA_VERSION])],
             'title' => ['required', 'string', 'max:255'],
             'visibility' => ['required', Rule::in(Form::VISIBILITY)],
-            'properties' => ['required', 'array', 'min:1', 'max:500', new FormPropertiesRule()],
+            'properties' => ['required', 'array', 'min:1', 'max:500', new FormPropertiesRule($workspace)],
             'properties.*.type' => ['required', Rule::in(FieldCatalog::types())],
             'computed_variables' => ['nullable', 'array', new ComputedVariablesRule()],
             'language' => ['required', Rule::in(Form::LANGUAGES)],

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -5,6 +5,7 @@ namespace App\Service\Forms;
 use App\Models\Forms\Form;
 use App\Models\Workspace;
 use App\Rules\ComputedVariablesRule;
+use App\Rules\CssOnlyRule;
 use App\Rules\FormPropertiesRule;
 use App\Service\Forms\AgentFormFieldCatalog as FieldCatalog;
 use Illuminate\Support\Arr;
@@ -107,6 +108,7 @@ class AgentFormDefinition
             'properties.*.type' => ['required', Rule::in(FieldCatalog::types())],
             'computed_variables' => ['nullable', 'array', new ComputedVariablesRule()],
             'language' => ['required', Rule::in(Form::LANGUAGES)],
+            'font_family' => ['nullable', 'string'],
             'theme' => ['required', Rule::in(Form::THEMES)],
             'presentation_style' => ['required', Rule::in(Form::PRESENTATION_STYLES)],
             'width' => ['required', Rule::in(Form::WIDTHS)],
@@ -118,7 +120,25 @@ class AgentFormDefinition
             'uppercase_labels' => ['required', 'boolean'],
             'no_branding' => ['required', 'boolean'],
             'transparent_background' => ['required', 'boolean'],
+            'translations' => ['nullable', 'array'],
+            'cover_picture' => ['nullable', 'url'],
+            'cover_settings' => ['nullable', 'array'],
+            'cover_settings.focal_point' => ['sometimes', 'nullable', 'array'],
+            'cover_settings.focal_point.x' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:100'],
+            'cover_settings.focal_point.y' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:100'],
+            'cover_settings.brightness' => ['sometimes', 'nullable', 'integer', 'min:-100', 'max:100'],
+            'logo_picture' => ['nullable', 'url'],
+            'custom_code' => ['nullable', 'string'],
+            'custom_css' => ['nullable', 'string', new CssOnlyRule()],
+            'submit_button_text' => ['nullable', 'string', 'max:50'],
             're_fillable' => ['required', 'boolean'],
+            're_fill_button_text' => ['nullable', 'string', 'max:50'],
+            'submitted_text' => ['required', 'string', 'max:10000'],
+            'redirect_url' => ['nullable', 'string'],
+            'max_submissions_count' => ['nullable', 'integer', 'min:1'],
+            'max_submissions_reached_text' => ['nullable', 'string'],
+            'editable_submissions' => ['required', 'boolean'],
+            'editable_submissions_button_text' => ['required', 'string', 'min:1', 'max:50'],
             'confetti_on_submission' => ['required', 'boolean'],
             'show_progress_bar' => ['required', 'boolean'],
             'auto_save' => ['required', 'boolean'],
@@ -128,7 +148,19 @@ class AgentFormDefinition
             'can_be_indexed' => ['required', 'boolean'],
             'use_captcha' => ['required', 'boolean'],
             'captcha_provider' => ['required', Rule::in(['recaptcha', 'hcaptcha'])],
+            'seo_meta' => ['nullable', 'array'],
             'settings' => ['present', 'array'],
+            'settings.navigation_arrows' => ['sometimes', 'boolean'],
+            'settings.auto_next' => ['sometimes', 'boolean'],
+            'analytics' => ['nullable', 'array'],
+            'analytics.provider' => ['nullable', Rule::in(['meta_pixel', 'google_analytics', 'gtm'])],
+            'analytics.tracking_id' => [
+                'nullable',
+                'string',
+                'max:50',
+                'regex:/^[A-Za-z0-9\-_\.]+$/',
+                'required_if:analytics.provider,meta_pixel,google_analytics,gtm',
+            ],
         ])->validate();
     }
 

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -7,6 +7,7 @@ use App\Models\Workspace;
 use App\Rules\ComputedVariablesRule;
 use App\Rules\CssOnlyRule;
 use App\Rules\FormPropertiesRule;
+use App\Rules\PublicMediaUrlRule;
 use App\Service\Forms\AgentFormFieldCatalog as FieldCatalog;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
@@ -121,13 +122,13 @@ class AgentFormDefinition
             'no_branding' => ['required', 'boolean'],
             'transparent_background' => ['required', 'boolean'],
             'translations' => ['nullable', 'array'],
-            'cover_picture' => ['nullable', 'url'],
+            'cover_picture' => ['nullable', new PublicMediaUrlRule()],
             'cover_settings' => ['nullable', 'array'],
             'cover_settings.focal_point' => ['sometimes', 'nullable', 'array'],
             'cover_settings.focal_point.x' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:100'],
             'cover_settings.focal_point.y' => ['sometimes', 'nullable', 'numeric', 'min:0', 'max:100'],
             'cover_settings.brightness' => ['sometimes', 'nullable', 'integer', 'min:-100', 'max:100'],
-            'logo_picture' => ['nullable', 'url'],
+            'logo_picture' => ['nullable', new PublicMediaUrlRule()],
             'custom_code' => ['nullable', 'string'],
             'custom_css' => ['nullable', 'string', new CssOnlyRule()],
             'submit_button_text' => ['nullable', 'string', 'max:50'],
@@ -249,9 +250,9 @@ class AgentFormDefinition
                 'no_branding' => ['type' => 'boolean', 'default' => false],
                 'transparent_background' => ['type' => 'boolean', 'default' => false],
                 'translations' => ['type' => ['object', 'array'], 'default' => (object) []],
-                'cover_picture' => ['type' => ['string', 'null'], 'format' => 'uri'],
+                'cover_picture' => ['type' => ['string', 'null'], 'format' => 'uri', 'pattern' => '^https://'],
                 'cover_settings' => ['type' => ['object', 'array'], 'default' => (object) []],
-                'logo_picture' => ['type' => ['string', 'null'], 'format' => 'uri'],
+                'logo_picture' => ['type' => ['string', 'null'], 'format' => 'uri', 'pattern' => '^https://'],
                 'custom_code' => ['type' => ['string', 'null']],
                 'custom_css' => ['type' => ['string', 'null']],
                 'submit_button_text' => ['type' => ['string', 'null'], 'maxLength' => 50],

--- a/api/app/Service/Forms/AgentFormFieldCatalog.php
+++ b/api/app/Service/Forms/AgentFormFieldCatalog.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Service\Forms;
+
+class AgentFormFieldCatalog
+{
+    public const INPUT_TYPES = [
+        'text',
+        'rich_text',
+        'date',
+        'url',
+        'phone_number',
+        'email',
+        'checkbox',
+        'select',
+        'multi_select',
+        'matrix',
+        'number',
+        'rating',
+        'scale',
+        'slider',
+        'files',
+        'signature',
+        'barcode',
+        'payment',
+    ];
+
+    public const LAYOUT_TYPES = [
+        'nf-text',
+        'nf-page-break',
+        'nf-divider',
+        'nf-image',
+        'nf-video',
+        'nf-audio',
+        'nf-code',
+    ];
+
+    public const ALIASES = [
+        'radio' => ['type' => 'select', 'without_dropdown' => true],
+        'qrcode' => ['type' => 'barcode', 'decoders' => ['qr_reader']],
+        'password' => ['type' => 'text', 'secret_input' => true, 'multi_lines' => false],
+        'toggle_switch' => ['type' => 'checkbox', 'use_toggle_switch' => true],
+    ];
+
+    public static function types(): array
+    {
+        return [...self::INPUT_TYPES, ...self::LAYOUT_TYPES];
+    }
+
+    public static function reference(): array
+    {
+        return [
+            'input_types' => self::INPUT_TYPES,
+            'layout_types' => self::LAYOUT_TYPES,
+            'aliases' => self::ALIASES,
+            'common_properties' => [
+                'id' => 'Stable UUID. It is generated when omitted.',
+                'name' => 'Required user-facing block label.',
+                'type' => 'One canonical type or alias from this catalog.',
+                'help' => 'Optional sanitized HTML help text.',
+                'hidden' => 'Boolean, defaults to false.',
+                'required' => 'Boolean, defaults to false.',
+                'placeholder' => 'Optional placeholder.',
+                'width' => 'One of full, 1/2, 1/3, 2/3, 1/4, 3/4. Defaults to full.',
+            ],
+            'type_properties' => [
+                'text' => ['multi_lines', 'max_char_limit', 'show_char_limit', 'secret_input', 'input_mask'],
+                'date' => ['with_time', 'date_range', 'prefill_today', 'disable_past_dates', 'disable_future_dates'],
+                'select' => ['select.options[{name,id,image?}]', 'without_dropdown', 'allow_creation'],
+                'multi_select' => ['multi_select.options[{name,id,image?}]', 'without_dropdown', 'min_selection', 'max_selection'],
+                'checkbox' => ['use_toggle_switch'],
+                'rating' => ['rating_max_value'],
+                'scale' => ['scale_min_value', 'scale_max_value', 'scale_step_value'],
+                'slider' => ['slider_min_value', 'slider_max_value', 'slider_step_value'],
+                'files' => ['max_file_size', 'allowed_file_types'],
+                'barcode' => ['decoders'],
+                'matrix' => ['rows', 'columns'],
+                'payment' => ['amount', 'currency', 'stripe_account_id'],
+                'nf-text' => ['content'],
+                'nf-page-break' => ['next_btn_text', 'previous_btn_text'],
+                'nf-image' => ['image_block'],
+                'nf-video' => ['video_block'],
+                'nf-audio' => ['audio_block'],
+                'nf-code' => ['content'],
+            ],
+            'availability' => [
+                'preview' => 'All field types may be rendered in a draft preview.',
+                'save' => 'Workspace plan and hosting rules are applied when a draft is claimed or a form is saved; disabled features are returned as warnings.',
+            ],
+        ];
+    }
+}

--- a/api/app/Service/Forms/FormCleaner.php
+++ b/api/app/Service/Forms/FormCleaner.php
@@ -106,6 +106,19 @@ class FormCleaner
     }
 
     /**
+     * Ingest raw form data from non-HTTP clients such as MCP tools.
+     */
+    public function processData(array $data, ?Form $form = null): FormCleaner
+    {
+        $customDomain = $data['custom_domain'] ?? $form?->custom_domain ?? null;
+        $allowOnSelfHosted = config('app.self_hosted', true) && (bool) config('opnform.custom_code.enable_self_hosted', false);
+        $this->allowCustomCode = ! empty($customDomain) || $allowOnSelfHosted;
+        $this->data = $this->commonCleaning($data);
+
+        return $this;
+    }
+
+    /**
      * Create form cleaner instance from existing form
      */
     public function processForm(Request $request, Form $form): FormCleaner

--- a/api/app/Service/Forms/FormDataNormalizer.php
+++ b/api/app/Service/Forms/FormDataNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service\Forms;
+
+use Illuminate\Support\Str;
+use Stevebauman\Purify\Facades\Purify;
+
+class FormDataNormalizer
+{
+    /**
+     * Normalize data shared by HTTP requests, MCP tools, and draft claims.
+     */
+    public function normalize(array $data, bool $backfillPropertyIds = false): array
+    {
+        if (isset($data['title']) && is_string($data['title'])) {
+            $data['title'] = Str::substr(trim($data['title']), 0, 255);
+        }
+
+        if (isset($data['properties']) && is_array($data['properties'])) {
+            $data['properties'] = $this->normalizeProperties($data['properties'], $backfillPropertyIds);
+        }
+
+        return $data;
+    }
+
+    public function normalizeProperties(array $properties, bool $backfillIds = false): array
+    {
+        return collect($properties)->map(function ($property) use ($backfillIds) {
+            if (! is_array($property)) {
+                return $property;
+            }
+
+            if ($backfillIds && empty($property['id'])) {
+                $property['id'] = Str::uuid()->toString();
+            }
+
+            if (isset($property['name']) && is_string($property['name'])) {
+                $property['name'] = trim(strip_tags($property['name']));
+            }
+
+            if (isset($property['help']) && is_string($property['help'])) {
+                $property['help'] = Purify::clean($property['help']);
+
+                if (strip_tags($property['help']) === '') {
+                    $property['help'] = null;
+                }
+            }
+
+            return $this->normalizeSelectOptionIds($property);
+        })->values()->all();
+    }
+
+    private function normalizeSelectOptionIds(array $property): array
+    {
+        $type = $property['type'] ?? null;
+
+        if (! in_array($type, ['select', 'multi_select'], true)) {
+            return $property;
+        }
+
+        if (! isset($property[$type]['options']) || ! is_array($property[$type]['options'])) {
+            return $property;
+        }
+
+        $property[$type]['options'] = array_map(function ($option) {
+            if (! is_array($option) || ! empty($option['id'] ?? null)) {
+                return $option;
+            }
+
+            if (! empty($option['name'] ?? null) && is_string($option['name'])) {
+                $option['id'] = $option['name'];
+            }
+
+            return $option;
+        }, $property[$type]['options']);
+
+        return $property;
+    }
+}

--- a/api/app/Support/Mcp/McpAvailability.php
+++ b/api/app/Support/Mcp/McpAvailability.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Support\Mcp;
+
+final class McpAvailability
+{
+    public function enabled(): bool
+    {
+        return ! config('app.self_hosted')
+            || (bool) config('opnform.mcp.enabled', false);
+    }
+}

--- a/api/composer.json
+++ b/api/composer.json
@@ -26,6 +26,7 @@
         "laravel/cashier": "*",
         "laravel/framework": "^11.9",
         "laravel/horizon": "*",
+        "laravel/mcp": "^0.8.2",
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "*",
         "laravel/tinker": "^2.9",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "961af48ddfce7334fd40697a96d42b50",
+    "content-hash": "f8e3bf9d56c6816dc39d17008ae46c1c",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2413,6 +2413,53 @@
             "time": "2021-12-07T10:10:20+00:00"
         },
         {
+            "name": "illuminate/json-schema",
+            "version": "v12.66.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/json-schema.git",
+                "reference": "543aab5a872b6b08f3b8c907064b009b84a56e07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/json-schema/zipball/543aab5a872b6b08f3b8c907064b009b84a56e07",
+                "reference": "543aab5a872b6b08f3b8c907064b009b84a56e07",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.50.0|^11.47.0|^12.40.2",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\JsonSchema\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Json Schema package.",
+            "homepage": "https://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2026-06-16T14:57:46+00:00"
+        },
+        {
             "name": "jane-php/json-schema-runtime",
             "version": "v7.10.4",
             "source": {
@@ -3256,6 +3303,80 @@
                 "source": "https://github.com/laravel/horizon/tree/v5.44.0"
             },
             "time": "2026-02-10T18:18:08+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "0c32bf369c6432cab21458f9f4479da33a49ba37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/0c32bf369c6432cab21458f9f4479da33a49ba37",
+                "reference": "0c32bf369c6432cab21458f9f4479da33a49ba37",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "illuminate/console": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/container": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/http": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/json-schema": "^12.41.1|^13.0",
+                "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/support": "^11.45.3|^12.41.1|^13.0",
+                "illuminate/validation": "^11.45.3|^12.41.1|^13.0",
+                "php": "^8.2",
+                "symfony/process": "^7.4.5|^8.0.5"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "pestphp/pest": "^3.8.5|^4.3.2",
+                "phpstan/phpstan": "^2.1.27",
+                "rector/rector": "^2.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Rapidly build MCP servers for your Laravel applications.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2026-06-25T14:00:45+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -16862,5 +16983,5 @@
         "ext-pcntl": "8.0",
         "ext-posix": "8.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/api/config/opnform.php
+++ b/api/config/opnform.php
@@ -16,6 +16,14 @@ return [
             'per_hour' => (int) env('PUBLIC_UPLOADS_RATE_LIMIT_PER_HOUR', 300),
         ],
     ],
+    'mcp' => [
+        // Cloud instances expose MCP by default. Self-hosted instances must opt in.
+        'enabled' => env('MCP_ENABLED', false),
+        'rate_limit' => [
+            'per_minute' => (int) env('MCP_RATE_LIMIT_PER_MINUTE', 120),
+            'per_hour' => (int) env('MCP_RATE_LIMIT_PER_HOUR', 3000),
+        ],
+    ],
     'webhooks' => [
         'allow_private_urls' => env('WEBHOOKS_ALLOW_PRIVATE_URLS', false),
     ],

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -3,5 +3,9 @@
 use App\Mcp\Servers\OpnFormServer;
 use Laravel\Mcp\Facades\Mcp;
 
-Mcp::web('/mcp', OpnFormServer::class);
-Mcp::local('opnform', OpnFormServer::class);
+$mcpEnabled = ! config('app.self_hosted') || config('opnform.mcp.enabled', false);
+
+if ($mcpEnabled) {
+    Mcp::web('/mcp', OpnFormServer::class)->middleware('throttle:mcp');
+    Mcp::local('opnform', OpnFormServer::class);
+}

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -1,11 +1,10 @@
 <?php
 
 use App\Mcp\Servers\OpnFormServer;
+use App\Support\Mcp\McpAvailability;
 use Laravel\Mcp\Facades\Mcp;
 
-$mcpEnabled = ! config('app.self_hosted') || config('opnform.mcp.enabled', false);
-
-if ($mcpEnabled) {
+if (app(McpAvailability::class)->enabled()) {
     Mcp::web('/mcp', OpnFormServer::class)->middleware('throttle:mcp');
     Mcp::local('opnform', OpnFormServer::class);
 }

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Mcp\Servers\OpnFormServer;
+use Laravel\Mcp\Facades\Mcp;
+
+Mcp::web('/mcp', OpnFormServer::class);
+Mcp::local('opnform', OpnFormServer::class);

--- a/api/tests/Feature/Mcp/AgentFormFieldCatalogParityTest.php
+++ b/api/tests/Feature/Mcp/AgentFormFieldCatalogParityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Service\Forms\AgentFormFieldCatalog;
+
+it('keeps the MCP field catalog aligned with the client block registry', function () {
+    $registryPath = base_path('../client/data/blocks_types.json');
+
+    expect($registryPath)->toBeFile();
+
+    $registry = json_decode(file_get_contents($registryPath), true, flags: JSON_THROW_ON_ERROR);
+
+    $clientInputTypes = collect($registry)
+        ->filter(fn (array $block): bool => (bool) ($block['is_input'] ?? false))
+        ->keys()
+        ->sort()
+        ->values()
+        ->all();
+    $mcpInputTypes = collect(AgentFormFieldCatalog::INPUT_TYPES)
+        ->merge(array_keys(AgentFormFieldCatalog::ALIASES))
+        ->sort()
+        ->values()
+        ->all();
+
+    $clientLayoutTypes = collect($registry)
+        ->reject(fn (array $block): bool => (bool) ($block['is_input'] ?? false))
+        ->keys()
+        ->sort()
+        ->values()
+        ->all();
+    $mcpLayoutTypes = collect(AgentFormFieldCatalog::LAYOUT_TYPES)
+        ->sort()
+        ->values()
+        ->all();
+
+    expect($mcpInputTypes)->toBe($clientInputTypes)
+        ->and($mcpLayoutTypes)->toBe($clientLayoutTypes)
+        ->and(AgentFormFieldCatalog::INPUT_TYPES)->toHaveCount(count(array_unique(AgentFormFieldCatalog::INPUT_TYPES)))
+        ->and(AgentFormFieldCatalog::LAYOUT_TYPES)->toHaveCount(count(array_unique(AgentFormFieldCatalog::LAYOUT_TYPES)));
+
+    foreach (AgentFormFieldCatalog::ALIASES as $alias => $definition) {
+        expect(AgentFormFieldCatalog::INPUT_TYPES)->not->toContain($alias)
+            ->and(AgentFormFieldCatalog::INPUT_TYPES)->toContain($definition['type']);
+    }
+});

--- a/api/tests/Feature/Mcp/McpAvailabilityTest.php
+++ b/api/tests/Feature/Mcp/McpAvailabilityTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Support\Mcp\McpAvailability;
+
+it('enables MCP on cloud instances regardless of the self-hosted opt-in flag', function (bool $configured) {
+    config()->set('app.self_hosted', false);
+    config()->set('opnform.mcp.enabled', $configured);
+
+    expect(app(McpAvailability::class)->enabled())->toBeTrue();
+})->with([false, true]);
+
+it('requires self-hosted instances to opt in to MCP', function (bool $configured, bool $expected) {
+    config()->set('app.self_hosted', true);
+    config()->set('opnform.mcp.enabled', $configured);
+
+    expect(app(McpAvailability::class)->enabled())->toBe($expected);
+})->with([
+    'disabled' => [false, false],
+    'enabled' => [true, true],
+]);

--- a/api/tests/Feature/Mcp/McpFoundationTest.php
+++ b/api/tests/Feature/Mcp/McpFoundationTest.php
@@ -6,6 +6,7 @@ use App\Mcp\Servers\OpnFormServer;
 use App\Mcp\Tools\ValidateFormDefinitionTool;
 use App\Service\Forms\AgentFormDefinition;
 use Illuminate\Testing\Fluent\AssertableJson;
+use Illuminate\Support\Facades\RateLimiter;
 
 it('exposes the OpnForm MCP endpoint and initializes the protocol', function () {
     $response = $this->postJson('/mcp', [
@@ -28,6 +29,14 @@ it('exposes the OpnForm MCP endpoint and initializes the protocol', function () 
         ->assertJsonPath('result.serverInfo.name', 'OpnForm')
         ->assertJsonPath('result.serverInfo.version', '1.0.0')
         ->assertJsonPath('result.protocolVersion', '2025-06-18');
+});
+
+it('registers a permissive dedicated rate limiter for MCP traffic', function () {
+    $limits = RateLimiter::limiter('mcp')(request());
+
+    expect($limits)->toHaveCount(2)
+        ->and($limits[0]->maxAttempts)->toBe(120)
+        ->and($limits[1]->maxAttempts)->toBe(3000);
 });
 
 it('publishes the versioned form definition schema', function () {

--- a/api/tests/Feature/Mcp/McpFoundationTest.php
+++ b/api/tests/Feature/Mcp/McpFoundationTest.php
@@ -120,6 +120,34 @@ it('rejects unknown field types and top-level keys', function () {
     ])->assertHasErrors();
 });
 
+it('applies the same custom CSS and settings validation as the form API', function () {
+    $definition = [
+        'title' => 'Unsafe customization',
+        'properties' => [
+            ['name' => 'Name', 'type' => 'text'],
+        ],
+    ];
+
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => array_merge($definition, [
+            'custom_css' => '</style><script>alert(1)</script>',
+        ]),
+    ])->assertHasErrors(['valid CSS']);
+
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => array_merge($definition, [
+            'settings' => ['auto_next' => 'yes'],
+        ]),
+    ])->assertHasErrors(['true or false']);
+
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => array_merge($definition, [
+            'custom_css' => '.form-root { color: #2563eb; }',
+            'settings' => ['auto_next' => true],
+        ]),
+    ])->assertOk();
+});
+
 it('rejects unsupported schema versions', function () {
     OpnFormServer::tool(ValidateFormDefinitionTool::class, [
         'definition' => [

--- a/api/tests/Feature/Mcp/McpFoundationTest.php
+++ b/api/tests/Feature/Mcp/McpFoundationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Mcp\Resources\FormDefinitionSchemaResource;
+use App\Mcp\Resources\FormFieldCatalogResource;
+use App\Mcp\Servers\OpnFormServer;
+use App\Mcp\Tools\ValidateFormDefinitionTool;
+use App\Service\Forms\AgentFormDefinition;
+use Illuminate\Testing\Fluent\AssertableJson;
+
+it('exposes the OpnForm MCP endpoint and initializes the protocol', function () {
+    $response = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'initialize',
+        'params' => [
+            'protocolVersion' => '2025-06-18',
+            'capabilities' => [],
+            'clientInfo' => [
+                'name' => 'OpnForm test client',
+                'version' => '1.0.0',
+            ],
+        ],
+    ], [
+        'Accept' => 'application/json, text/event-stream',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('result.serverInfo.name', 'OpnForm')
+        ->assertJsonPath('result.serverInfo.version', '1.0.0')
+        ->assertJsonPath('result.protocolVersion', '2025-06-18');
+});
+
+it('publishes the versioned form definition schema', function () {
+    OpnFormServer::resource(FormDefinitionSchemaResource::class)
+        ->assertOk()
+        ->assertSee('agent-form-definition/v1.json')
+        ->assertSee('schema_version')
+        ->assertSee('properties');
+});
+
+it('keeps every normalized top-level key represented in the published schema', function () {
+    $definition = app(AgentFormDefinition::class);
+    $normalized = $definition->normalizeAndValidate([
+        'title' => 'Schema coverage',
+        'properties' => [
+            ['name' => 'Name', 'type' => 'text'],
+        ],
+    ]);
+
+    expect(array_diff(array_keys($normalized), array_keys($definition->jsonSchema()['properties'])))->toBe([]);
+});
+
+it('publishes the canonical form field catalog', function () {
+    OpnFormServer::resource(FormFieldCatalogResource::class)
+        ->assertOk()
+        ->assertSee('input_types')
+        ->assertSee('nf-page-break')
+        ->assertSee('payment')
+        ->assertSee('save');
+});
+
+it('normalizes and validates a form definition without persistence', function () {
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => [
+            'title' => '  Customer intake  ',
+            'properties' => [
+                [
+                    'name' => '<b>Full name</b>',
+                    'type' => 'text',
+                    'help' => '<script>alert(1)</script><p>Legal name</p>',
+                ],
+                [
+                    'name' => 'Plan',
+                    'type' => 'radio',
+                    'select' => [
+                        'options' => [
+                            ['name' => 'Basic'],
+                            ['name' => 'Pro'],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ])->assertOk()
+        ->assertStructuredContent(function (AssertableJson $json) {
+            $json->where('valid', true)
+                ->where('schema_version', 1)
+                ->where('definition.title', 'Customer intake')
+                ->where('definition.visibility', 'draft')
+                ->where('definition.properties.0.name', 'Full name')
+                ->where('definition.properties.0.hidden', false)
+                ->where('definition.properties.1.type', 'select')
+                ->where('definition.properties.1.without_dropdown', true)
+                ->where('definition.properties.1.select.options.0.id', 'Basic')
+                ->has('definition.properties.0.id')
+                ->etc();
+        });
+
+    $this->assertDatabaseCount('forms', 0);
+});
+
+it('rejects unknown field types and top-level keys', function () {
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => [
+            'title' => 'Invalid form',
+            'surprise' => true,
+            'properties' => [
+                ['name' => 'Unknown', 'type' => 'not-a-field'],
+            ],
+        ],
+    ])->assertHasErrors();
+});
+
+it('rejects unsupported schema versions', function () {
+    OpnFormServer::tool(ValidateFormDefinitionTool::class, [
+        'definition' => [
+            'schema_version' => 99,
+            'title' => 'Future form',
+            'properties' => [
+                ['name' => 'Name', 'type' => 'text'],
+            ],
+        ],
+    ])->assertHasErrors(['Unsupported schema version']);
+});

--- a/api/tests/Feature/Mcp/McpFoundationTest.php
+++ b/api/tests/Feature/Mcp/McpFoundationTest.php
@@ -68,6 +68,29 @@ it('publishes the canonical form field catalog', function () {
         ->assertSee('save');
 });
 
+it('requires public durable HTTPS URLs for agent-provided media', function () {
+    $definition = app(AgentFormDefinition::class);
+
+    expect(fn () => $definition->normalizeAndValidate([
+        'title' => 'Unsafe media',
+        'cover_picture' => 'http://127.0.0.1/cover.png',
+        'properties' => [
+            ['name' => 'Name', 'type' => 'text'],
+        ],
+    ]))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    $validated = $definition->normalizeAndValidate([
+        'title' => 'Safe media',
+        'cover_picture' => 'https://cdn.example.com/cover.png',
+        'logo_picture' => 'https://cdn.example.com/logo.png',
+        'properties' => [
+            ['name' => 'Name', 'type' => 'text'],
+        ],
+    ]);
+
+    expect($validated['cover_picture'])->toBe('https://cdn.example.com/cover.png')
+        ->and($validated['logo_picture'])->toBe('https://cdn.example.com/logo.png');
+});
 it('normalizes and validates a form definition without persistence', function () {
     OpnFormServer::tool(ValidateFormDefinitionTool::class, [
         'definition' => [

--- a/api/tests/Unit/Rules/PaymentPropertyValidatorTest.php
+++ b/api/tests/Unit/Rules/PaymentPropertyValidatorTest.php
@@ -128,3 +128,19 @@ describe('non-payment blocks', function () {
         expect($errors)->toBeEmpty();
     });
 });
+
+describe('guest validation', function () {
+    it('defers provider lookup when no workspace security boundary exists', function () {
+        $validator = new PaymentPropertyValidator();
+        $property = [
+            'type' => 'payment',
+            'amount' => 10,
+            'currency' => 'USD',
+            'stripe_account_id' => 999999,
+        ];
+
+        $errors = $validator->validate($property, 0, ['properties' => [$property]]);
+
+        expect($errors)->toBeEmpty();
+    });
+});

--- a/api/tests/Unit/Rules/PublicMediaUrlRuleTest.php
+++ b/api/tests/Unit/Rules/PublicMediaUrlRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Rules\PublicMediaUrlRule;
+use Illuminate\Support\Facades\Validator;
+
+it('accepts durable public HTTPS media URLs', function () {
+    $validator = Validator::make([
+        'media_url' => 'https://cdn.example.com/forms/header.png',
+    ], [
+        'media_url' => [new PublicMediaUrlRule()],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('rejects unsafe or temporary media URLs', function (string $url, string $message) {
+    $validator = Validator::make([
+        'media_url' => $url,
+    ], [
+        'media_url' => [new PublicMediaUrlRule()],
+    ]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('media_url'))->toContain($message);
+})->with([
+    'plain HTTP' => ['http://cdn.example.com/header.png', 'HTTPS'],
+    'embedded credentials' => ['https://cdn.example.com@attacker.example/header.png', 'embedded credentials'],
+    'localhost' => ['https://localhost/header.png', 'public host'],
+    'private IPv4' => ['https://192.168.1.12/header.png', 'public host'],
+    'loopback IPv6' => ['https://[::1]/header.png', 'public host'],
+    'private hostname' => ['https://assets.internal/header.png', 'public host'],
+    'temporary tunnel' => ['https://draft.trycloudflare.com/header.png', 'temporary tunnel'],
+    'expiring signature' => ['https://cdn.example.com/header.png?expires=123&signature=secret', 'expiring or signed'],
+]);

--- a/api/tests/Unit/Service/Forms/FormCleanerDataTest.php
+++ b/api/tests/Unit/Service/Forms/FormCleanerDataTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Service\Forms\FormCleaner;
+
+uses(Tests\TestCase::class);
+
+it('sanitizes raw MCP form data with the same common cleaner', function () {
+    $cleaned = app(FormCleaner::class)->processData([
+        'title' => 'MCP draft',
+        'properties' => [
+            [
+                'id' => 'intro',
+                'name' => 'Introduction',
+                'type' => 'nf-text',
+                'content' => '<script>alert(1)</script><p>Safe introduction</p>',
+            ],
+            [
+                'id' => 'custom-code',
+                'name' => 'Custom code',
+                'type' => 'nf-code',
+                'content' => '<script>window.example = true</script>',
+            ],
+        ],
+    ])->getData();
+
+    expect($cleaned['properties'])->toHaveCount(1)
+        ->and($cleaned['properties'][0]['content'])->not->toContain('<script>')
+        ->and($cleaned['properties'][0]['content'])->toContain('Safe introduction');
+});
+
+it('keeps custom code when the target form has a custom domain', function () {
+    $form = new Form(['custom_domain' => 'forms.example.test']);
+
+    $cleaned = app(FormCleaner::class)->processData([
+        'properties' => [
+            [
+                'id' => 'custom-code',
+                'name' => 'Custom code',
+                'type' => 'nf-code',
+                'content' => '<script>window.example = true</script>',
+            ],
+        ],
+    ], $form)->getData();
+
+    expect($cleaned['properties'])->toHaveCount(1)
+        ->and($cleaned['properties'][0]['type'])->toBe('nf-code');
+});

--- a/api/tests/Unit/Service/Forms/FormDataNormalizerTest.php
+++ b/api/tests/Unit/Service/Forms/FormDataNormalizerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Service\Forms\FormDataNormalizer;
+
+uses(Tests\TestCase::class);
+
+it('uses one normalization path for form titles, properties, and select options', function () {
+    $normalized = app(FormDataNormalizer::class)->normalize([
+        'title' => '  My form  ',
+        'properties' => [
+            [
+                'name' => '  <strong>Choice</strong>  ',
+                'type' => 'select',
+                'help' => '<script>alert(1)</script><p>Pick one</p>',
+                'select' => [
+                    'options' => [
+                        ['name' => 'First'],
+                    ],
+                ],
+            ],
+        ],
+    ], backfillPropertyIds: true);
+
+    expect($normalized['title'])->toBe('My form')
+        ->and($normalized['properties'][0]['name'])->toBe('Choice')
+        ->and($normalized['properties'][0]['help'])->not->toContain('<script>')
+        ->and($normalized['properties'][0]['select']['options'][0]['id'])->toBe('First')
+        ->and($normalized['properties'][0]['id'])->toBeString()->not->toBeEmpty();
+});


### PR DESCRIPTION
## Summary

- install the official Laravel MCP package and expose one OpnForm MCP endpoint
- add a versioned canonical agent form definition, field catalog, normalization, and validation tool
- share form normalization and raw-data cleaning with the existing HTTP form path
- add protocol, resource, validation, sanitizer, and regression coverage

## Stack

1. **Foundation and canonical schema (this PR)**
2. Guest persisted drafts
3. Preview, editor handoff, and claim
4. Official OAuth and optional authentication
5. Authenticated form management
6. Submission read/search/stats/export
7. Agent Plugin package, docs, telemetry, and release validation

## Validation

- `cd api && vendor/bin/pest tests/Feature/Mcp/McpFoundationTest.php tests/Unit/Service/Forms/FormDataNormalizerTest.php tests/Unit/Service/Forms/FormCleanerDataTest.php`
- `cd api && vendor/bin/pest tests/Feature/Forms/FormTest.php tests/Feature/Forms/FormValidationTest.php tests/Feature/Forms/FormUpdateTest.php tests/Unit/Service/FormCleanerTest.php tests/Unit/Rules/FormPropertiesRuleTest.php`
- `cd api && vendor/bin/phpstan analyse app/Mcp app/Service/Forms/AgentFormDefinition.php app/Service/Forms/AgentFormFieldCatalog.php app/Service/Forms/FormDataNormalizer.php app/Service/Forms/FormCleaner.php --memory-limit=1G`
- `cd api && vendor/bin/pint --dirty`
- `cd api && composer validate --no-check-publish`

## Review loop

A complete code-review pass was performed. Findings fixed before opening: JSON Schema top-level coverage and missing raw-cleaner regression tests. No unresolved findings remain.