### PR TITLE
MCP 3/9: Preview, edit, and claim guest drafts

### DIFF
--- a/api/app/Http/Controllers/AgentFormDraftController.php
+++ b/api/app/Http/Controllers/AgentFormDraftController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\FormResource;
+use App\Models\Forms\AgentFormDraft;
+use App\Models\Workspace;
+use App\Service\Forms\AgentFormDraftService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AgentFormDraftController extends Controller
+{
+    public const SESSION_HEADER = 'x-agent-draft-session';
+
+    public function preview(AgentFormDraft $draft, AgentFormDraftService $drafts): JsonResponse
+    {
+        abort_unless($draft->isAvailable(), Response::HTTP_NOT_FOUND);
+
+        return response()->json([
+            'draft' => $drafts->serialize($draft),
+        ])->header('Cache-Control', 'private, no-store, max-age=0');
+    }
+
+    public function consume(Request $request, AgentFormDraftService $drafts): JsonResponse
+    {
+        $this->assertTrustedFrontend($request);
+        $validated = $request->validate([
+            'handoff_token' => ['required', 'string', 'size:43'],
+        ]);
+        $result = $drafts->consumeEditorHandoff($validated['handoff_token']);
+
+        return response()->json([
+            'editor_session' => $result['editor_session'],
+            'draft' => $drafts->serialize($result['draft']),
+        ])->header('Cache-Control', 'private, no-store, max-age=0');
+    }
+
+    public function current(Request $request, AgentFormDraftService $drafts): JsonResponse
+    {
+        $this->assertTrustedFrontend($request);
+
+        return response()->json([
+            'draft' => $drafts->serialize($drafts->getForEditor($this->editorSession($request))),
+        ])->header('Cache-Control', 'private, no-store, max-age=0');
+    }
+
+    public function replace(Request $request, AgentFormDraftService $drafts): JsonResponse
+    {
+        $this->assertTrustedFrontend($request);
+        $validated = $request->validate([
+            'expected_version' => ['required', 'integer', 'min:1'],
+            'definition' => ['required', 'array'],
+        ]);
+
+        $draft = $drafts->replaceFromEditor(
+            $this->editorSession($request),
+            $validated['expected_version'],
+            $validated['definition'],
+        );
+
+        return response()->json(['draft' => $drafts->serialize($draft)]);
+    }
+
+    public function claim(Request $request, AgentFormDraftService $drafts): JsonResponse
+    {
+        $this->assertTrustedFrontend($request);
+        $validated = $request->validate([
+            'expected_version' => ['required', 'integer', 'min:1'],
+            'workspace_id' => ['required', 'integer', 'exists:workspaces,id'],
+        ]);
+        $workspace = Workspace::query()->findOrFail($validated['workspace_id']);
+        $claimed = $drafts->claim(
+            $this->editorSession($request),
+            $validated['expected_version'],
+            $workspace,
+            $request->user(),
+        );
+
+        return response()->json([
+            'form' => (new FormResource($claimed['form']))->setCleanings($claimed['cleanings']),
+            'cleanings' => $claimed['cleanings'],
+            'already_claimed' => $claimed['already_claimed'],
+            'editor_url' => front_url('/forms/'.$claimed['form']->slug.'/edit'),
+        ]);
+    }
+
+    private function assertTrustedFrontend(Request $request): void
+    {
+        $configuredSecret = (string) config('app.front_api_secret');
+        $providedSecret = (string) $request->header('x-api-secret');
+
+        abort_unless(
+            $configuredSecret !== '' && hash_equals($configuredSecret, $providedSecret),
+            Response::HTTP_FORBIDDEN,
+        );
+    }
+
+    private function editorSession(Request $request): string
+    {
+        return (string) $request->header(self::SESSION_HEADER);
+    }
+}

--- a/api/app/Http/Controllers/Forms/FormController.php
+++ b/api/app/Http/Controllers/Forms/FormController.php
@@ -15,6 +15,7 @@ use App\Models\Workspace;
 use App\Notifications\Forms\MobileEditorEmail;
 use App\Service\Billing\Feature;
 use App\Service\Forms\FormCleaner;
+use App\Service\Forms\FormCreationService;
 use App\Service\Storage\FileUploadPathService;
 use App\Service\Storage\StorageFileNameParser;
 use App\Service\Storage\UploadSecurityService;
@@ -30,7 +31,7 @@ class FormController extends Controller
 
     private FormCleaner $formCleaner;
 
-    public function __construct()
+    public function __construct(private readonly FormCreationService $formCreation)
     {
         $this->middleware('auth', ['except' => ['uploadAsset']]);
         $this->formCleaner = new FormCleaner();
@@ -133,21 +134,10 @@ class FormController extends Controller
         $this->authorize('ownsWorkspace', $workspace);
         $this->authorize('create', [Form::class, $workspace]);
 
-        $formData = $this->formCleaner
-            ->processRequest($request)
-            ->simulateCleaning($workspace)
-            ->getData();
+        $created = $this->formCreation->create($request->validated(), $request->user(), $workspace);
+        $form = $created['form'];
 
-        $form = Form::create(array_merge($formData, [
-            'creator_id' => $request->user()->id,
-        ]));
-
-        if (config('app.self_hosted') && !empty($formData['slug'])) {
-            $form->slug = $formData['slug'];
-            $form->save();
-        }
-
-        if ($this->formCleaner->hasCleaned()) {
+        if ($created['has_cleaned']) {
             $formStatus = $form->workspace->is_trialing ? 'Non-trial' : 'Pro';
             $message =  'Form successfully created, but the ' . $formStatus . ' features you used will be disabled when sharing your form:';
         } else {
@@ -156,7 +146,7 @@ class FormController extends Controller
 
         return $this->success([
             'message' => $message . ($form->visibility == 'draft' ? ' But other people won\'t be able to see the form since it\'s currently in draft mode' : ''),
-            'form' => (new FormResource($form))->setCleanings($this->formCleaner->getPerformedCleanings()),
+            'form' => (new FormResource($form))->setCleanings($created['cleanings']),
             'users_first_form' => $request->user()->forms()->count() == 1,
         ]);
     }

--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mcp\Apps;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\AppResource;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\Uri;
+use Laravel\Mcp\Server\Ui\AppMeta;
+use Laravel\Mcp\Server\Ui\Csp;
+
+#[Name('form_draft_preview')]
+#[Description('Interactive preview of a guest OpnForm draft with a secure editor handoff.')]
+#[Uri('ui://opnform/form-draft-preview')]
+class FormDraftPreviewApp extends AppResource
+{
+    public function handle(Request $request): Response
+    {
+        return Response::view('mcp.form-draft-preview-app');
+    }
+
+    public function appMeta(): AppMeta
+    {
+        $frontUrl = parse_url(front_url());
+        if (! is_array($frontUrl) || ! isset($frontUrl['scheme'], $frontUrl['host'])) {
+            return AppMeta::make();
+        }
+
+        $origin = $frontUrl['scheme'].'://'.$frontUrl['host'];
+        if (isset($frontUrl['port'])) {
+            $origin .= ':'.$frontUrl['port'];
+        }
+
+        return AppMeta::make()->csp(
+            Csp::make()->frameDomains([$origin]),
+        );
+    }
+}

--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -13,28 +13,48 @@ use Laravel\Mcp\Server\Ui\Csp;
 
 #[Name('form_draft_preview')]
 #[Description('Interactive preview of a guest OpnForm draft with a secure editor handoff.')]
-#[Uri('ui://opnform/form-draft-preview')]
+#[Uri('ui://opnform/form-draft-preview-v3')]
 class FormDraftPreviewApp extends AppResource
 {
     public function handle(Request $request): Response
     {
-        return Response::view('mcp.form-draft-preview-app');
+        $response = Response::view('mcp.form-draft-preview-app');
+        $origin = $this->frontOrigin();
+
+        if ($origin !== null) {
+            $response->withMeta('openai/widgetCSP', [
+                'connect_domains' => [],
+                'resource_domains' => [],
+                'frame_domains' => [$origin],
+                'redirect_domains' => [$origin],
+            ]);
+        }
+
+        return $response;
     }
 
     public function appMeta(): AppMeta
     {
-        $frontUrl = parse_url(front_url());
-        if (! is_array($frontUrl) || ! isset($frontUrl['scheme'], $frontUrl['host'])) {
+        $origin = $this->frontOrigin();
+        if ($origin === null) {
             return AppMeta::make();
-        }
-
-        $origin = $frontUrl['scheme'].'://'.$frontUrl['host'];
-        if (isset($frontUrl['port'])) {
-            $origin .= ':'.$frontUrl['port'];
         }
 
         return AppMeta::make()->csp(
             Csp::make()->frameDomains([$origin]),
         );
     }
+
+    private function frontOrigin(): ?string
+    {
+        $frontUrl = parse_url(front_url());
+        if (! is_array($frontUrl) || ! isset($frontUrl['scheme'], $frontUrl['host'])) {
+            return null;
+        }
+
+        $origin = $frontUrl['scheme'].'://'.$frontUrl['host'];
+
+        return isset($frontUrl['port']) ? $origin.':'.$frontUrl['port'] : $origin;
+    }
+
 }

--- a/api/app/Mcp/Servers/OpnFormServer.php
+++ b/api/app/Mcp/Servers/OpnFormServer.php
@@ -4,9 +4,12 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Resources\FormDefinitionSchemaResource;
 use App\Mcp\Resources\FormFieldCatalogResource;
+use App\Mcp\Apps\FormDraftPreviewApp;
 use App\Mcp\Tools\CreateFormDraftTool;
 use App\Mcp\Tools\GetFormDraftTool;
 use App\Mcp\Tools\PatchFormDraftTool;
+use App\Mcp\Tools\PreviewFormDraftTool;
+use App\Mcp\Tools\OpenFormDraftInEditorTool;
 use App\Mcp\Tools\ValidateFormDefinitionTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -23,10 +26,13 @@ class OpnFormServer extends Server
         CreateFormDraftTool::class,
         GetFormDraftTool::class,
         PatchFormDraftTool::class,
+        PreviewFormDraftTool::class,
+        OpenFormDraftInEditorTool::class,
     ];
 
     protected array $resources = [
         FormDefinitionSchemaResource::class,
         FormFieldCatalogResource::class,
+        FormDraftPreviewApp::class,
     ];
 }

--- a/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
+++ b/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('open_form_draft_in_editor')]
-#[Description('Create a fresh one-time OpnForm editor link for a guest draft. Use when the previous editor link expired or was consumed.')]
+#[Description('Create a reusable OpnForm editor link that remains valid until the guest draft expires.')]
 #[IsOpenWorld]
 class OpenFormDraftInEditorTool extends Tool
 {

--- a/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
+++ b/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\AgentFormDraftService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('open_form_draft_in_editor')]
+#[Description('Create a fresh one-time OpnForm editor link for a guest draft. Use when the previous editor link expired or was consumed.')]
+#[IsOpenWorld]
+class OpenFormDraftInEditorTool extends Tool
+{
+    public function handle(Request $request, AgentFormDraftService $drafts): ResponseFactory
+    {
+        $validated = $request->validate([
+            'draft_token' => ['required', 'string', 'size:43'],
+        ]);
+
+        return Response::structured($drafts->issueEditorHandoff($validated['draft_token']));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'draft_token' => $schema->string()->min(43)->max(43)->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Mcp\Apps\FormDraftPreviewApp;
+use App\Service\Forms\AgentFormDraftService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Attributes\RendersApp;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('preview_form_draft')]
+#[Description('Render the current guest draft, return a short-lived browser preview, and create a one-time link for opening it in the OpnForm editor.')]
+#[RendersApp(resource: FormDraftPreviewApp::class)]
+#[IsOpenWorld]
+class PreviewFormDraftTool extends Tool
+{
+    public function handle(Request $request, AgentFormDraftService $drafts): ResponseFactory
+    {
+        $validated = $request->validate([
+            'draft_token' => ['required', 'string', 'size:43'],
+        ]);
+        $draft = $drafts->get($validated['draft_token']);
+        $handoff = $drafts->issueEditorHandoff($validated['draft_token']);
+
+        return Response::structured([
+            'draft' => $drafts->serialize($draft),
+            'preview_url' => $drafts->previewUrl($draft),
+            'editor_url' => $handoff['editor_url'],
+            'editor_link_expires_at' => $handoff['expires_at'],
+        ]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'draft_token' => $schema->string()
+                ->description('Private capability token returned by create_form_draft.')
+                ->min(43)
+                ->max(43)
+                ->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -15,7 +15,7 @@ use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('preview_form_draft')]
-#[Description('Render the current guest draft, return a short-lived browser preview, and create a one-time link for opening it in the OpnForm editor.')]
+#[Description('Render the current guest draft, return a short-lived browser preview, and create a reusable editor link that remains valid for the guest draft lifetime.')]
 #[RendersApp(resource: FormDraftPreviewApp::class)]
 #[IsOpenWorld]
 class PreviewFormDraftTool extends Tool

--- a/api/app/Models/Forms/AgentFormDraft.php
+++ b/api/app/Models/Forms/AgentFormDraft.php
@@ -20,12 +20,19 @@ class AgentFormDraft extends Model
         'claimed_form_id',
         'claim_receipt_hash',
         'claimed_at',
+        'handoff_token_hash',
+        'handoff_expires_at',
+        'handoff_consumed_at',
+        'editor_session_hash',
+        'editor_session_expires_at',
         'expires_at',
     ];
 
     protected $hidden = [
         'token_hash',
         'claim_receipt_hash',
+        'handoff_token_hash',
+        'editor_session_hash',
     ];
 
     protected function casts(): array
@@ -36,6 +43,9 @@ class AgentFormDraft extends Model
             'version' => 'integer',
             'claimed_form_id' => 'integer',
             'claimed_at' => 'datetime',
+            'handoff_expires_at' => 'datetime',
+            'handoff_consumed_at' => 'datetime',
+            'editor_session_expires_at' => 'datetime',
             'expires_at' => 'datetime',
         ];
     }

--- a/api/app/Models/Forms/AgentFormDraft.php
+++ b/api/app/Models/Forms/AgentFormDraft.php
@@ -4,6 +4,7 @@ namespace App\Models\Forms;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class AgentFormDraft extends Model
 {
@@ -20,9 +21,6 @@ class AgentFormDraft extends Model
         'claimed_form_id',
         'claim_receipt_hash',
         'claimed_at',
-        'handoff_token_hash',
-        'handoff_expires_at',
-        'handoff_consumed_at',
         'editor_session_hash',
         'editor_session_expires_at',
         'expires_at',
@@ -31,7 +29,6 @@ class AgentFormDraft extends Model
     protected $hidden = [
         'token_hash',
         'claim_receipt_hash',
-        'handoff_token_hash',
         'editor_session_hash',
     ];
 
@@ -43,8 +40,6 @@ class AgentFormDraft extends Model
             'version' => 'integer',
             'claimed_form_id' => 'integer',
             'claimed_at' => 'datetime',
-            'handoff_expires_at' => 'datetime',
-            'handoff_consumed_at' => 'datetime',
             'editor_session_expires_at' => 'datetime',
             'expires_at' => 'datetime',
         ];
@@ -60,5 +55,10 @@ class AgentFormDraft extends Model
     public function isAvailable(): bool
     {
         return $this->status === self::STATUS_ACTIVE && $this->expires_at->isFuture();
+    }
+
+    public function editorHandoffs(): HasMany
+    {
+        return $this->hasMany(AgentFormDraftHandoff::class);
     }
 }

--- a/api/app/Models/Forms/AgentFormDraftHandoff.php
+++ b/api/app/Models/Forms/AgentFormDraftHandoff.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models\Forms;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AgentFormDraftHandoff extends Model
+{
+    protected $fillable = [
+        'agent_form_draft_id',
+        'token_hash',
+        'last_used_at',
+        'expires_at',
+    ];
+
+    protected $hidden = [
+        'token_hash',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    public function draft(): BelongsTo
+    {
+        return $this->belongsTo(AgentFormDraft::class, 'agent_form_draft_id');
+    }
+}

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use JsonException;
+use Stevebauman\Purify\Facades\Purify;
 
 class AgentFormDefinition
 {
@@ -79,15 +80,25 @@ class AgentFormDefinition
         $definition = array_replace($this->defaults(), $definition);
         $definition = $this->normalizeAliases($definition);
         $definition = $this->normalizer->normalize($definition, backfillPropertyIds: true);
-        $definition['properties'] = collect($definition['properties'])->map(fn ($property) => is_array($property)
-            ? array_replace([
+        $definition['properties'] = collect($definition['properties'])->map(function ($property) {
+            if (! is_array($property)) {
+                return $property;
+            }
+
+            $property = array_replace([
                 'help' => null,
                 'hidden' => false,
                 'required' => false,
                 'placeholder' => null,
                 'width' => 'full',
-            ], $property)
-            : $property)->values()->all();
+            ], $property);
+
+            if (($property['type'] ?? null) === 'nf-text' && isset($property['content'])) {
+                $property['content'] = Purify::clean((string) $property['content']);
+            }
+
+            return $property;
+        })->values()->all();
 
         $this->validate($definition, $workspace);
 

--- a/api/app/Service/Forms/AgentFormDraftService.php
+++ b/api/app/Service/Forms/AgentFormDraftService.php
@@ -3,6 +3,7 @@
 namespace App\Service\Forms;
 
 use App\Models\Forms\AgentFormDraft;
+use App\Models\Forms\AgentFormDraftHandoff;
 use App\Models\Forms\Form;
 use App\Models\User;
 use App\Models\Workspace;
@@ -92,13 +93,12 @@ class AgentFormDraftService
         return DB::transaction(function () use ($draftToken) {
             $draft = $this->resolveActive($draftToken, lock: true);
             $handoffToken = $this->generateToken();
-            $expiresAt = now()->addMinutes(10);
+            $expiresAt = $draft->expires_at->copy();
 
-            $draft->forceFill([
-                'handoff_token_hash' => $this->hashToken($handoffToken),
-                'handoff_expires_at' => $expiresAt,
-                'handoff_consumed_at' => null,
-            ])->save();
+            $draft->editorHandoffs()->create([
+                'token_hash' => $this->hashToken($handoffToken),
+                'expires_at' => $expiresAt,
+            ]);
 
             return [
                 'handoff_token' => $handoffToken,
@@ -116,24 +116,33 @@ class AgentFormDraftService
         return DB::transaction(function () use ($handoffToken) {
             $this->assertTokenShape($handoffToken, 'handoff_token');
 
+            $handoff = AgentFormDraftHandoff::query()
+                ->where('token_hash', $this->hashToken($handoffToken))
+                ->where('expires_at', '>', now())
+                ->lockForUpdate()
+                ->first();
+
+            if (! $handoff) {
+                throw ValidationException::withMessages([
+                    'handoff_token' => ['This editor link is invalid or expired.'],
+                ]);
+            }
+
             $draft = AgentFormDraft::query()
-                ->where('handoff_token_hash', $this->hashToken($handoffToken))
-                ->whereNull('handoff_consumed_at')
-                ->where('handoff_expires_at', '>', now())
+                ->whereKey($handoff->agent_form_draft_id)
                 ->active()
                 ->lockForUpdate()
                 ->first();
 
             if (! $draft) {
                 throw ValidationException::withMessages([
-                    'handoff_token' => ['This editor link is invalid, expired, or already used.'],
+                    'handoff_token' => ['This editor link is invalid or expired.'],
                 ]);
             }
 
-            $editorSession = $this->generateToken();
+            $editorSession = $this->editorSessionToken($draft);
+            $handoff->forceFill(['last_used_at' => now()])->save();
             $draft->forceFill([
-                'handoff_consumed_at' => now(),
-                'handoff_token_hash' => null,
                 'editor_session_hash' => $this->hashToken($editorSession),
                 'editor_session_expires_at' => $draft->expires_at,
             ])->save();
@@ -283,6 +292,18 @@ class AgentFormDraftService
     private function generateToken(): string
     {
         return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+
+    private function editorSessionToken(AgentFormDraft $draft): string
+    {
+        $token = hash_hmac(
+            'sha256',
+            'agent-form-draft-editor:'.$draft->getKey(),
+            (string) config('app.key'),
+            true,
+        );
+
+        return rtrim(strtr(base64_encode($token), '+/', '-_'), '=');
     }
 
     private function hashToken(string $token): string

--- a/api/app/Service/Forms/AgentFormDraftService.php
+++ b/api/app/Service/Forms/AgentFormDraftService.php
@@ -195,6 +195,7 @@ class AgentFormDraftService
 
             $definition = $draft->definition;
             $definition['visibility'] = 'draft';
+            $definition = $this->formDefinition->normalizeAndValidate($definition, $workspace);
             $created = $this->formCreation->create($definition, $user, $workspace);
 
             $draft->forceFill([

--- a/api/app/Service/Forms/AgentFormDraftService.php
+++ b/api/app/Service/Forms/AgentFormDraftService.php
@@ -3,7 +3,12 @@
 namespace App\Service\Forms;
 
 use App\Models\Forms\AgentFormDraft;
+use App\Models\Forms\Form;
+use App\Models\User;
+use App\Models\Workspace;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 
 class AgentFormDraftService
@@ -13,6 +18,7 @@ class AgentFormDraftService
     public function __construct(
         private readonly AgentFormDefinition $formDefinition,
         private readonly AgentFormDraftPatcher $patcher,
+        private readonly FormCreationService $formCreation,
     ) {
     }
 
@@ -78,11 +84,138 @@ class AgentFormDraftService
         ];
     }
 
+    /**
+     * @return array{handoff_token: string, editor_url: string, expires_at: string}
+     */
+    public function issueEditorHandoff(string $draftToken): array
+    {
+        return DB::transaction(function () use ($draftToken) {
+            $draft = $this->resolveActive($draftToken, lock: true);
+            $handoffToken = $this->generateToken();
+            $expiresAt = now()->addMinutes(10);
+
+            $draft->forceFill([
+                'handoff_token_hash' => $this->hashToken($handoffToken),
+                'handoff_expires_at' => $expiresAt,
+                'handoff_consumed_at' => null,
+            ])->save();
+
+            return [
+                'handoff_token' => $handoffToken,
+                'editor_url' => front_url('/agent-drafts/edit#handoff='.$handoffToken),
+                'expires_at' => $expiresAt->toIso8601String(),
+            ];
+        });
+    }
+
+    /**
+     * @return array{draft: AgentFormDraft, editor_session: string}
+     */
+    public function consumeEditorHandoff(string $handoffToken): array
+    {
+        return DB::transaction(function () use ($handoffToken) {
+            $this->assertTokenShape($handoffToken, 'handoff_token');
+
+            $draft = AgentFormDraft::query()
+                ->where('handoff_token_hash', $this->hashToken($handoffToken))
+                ->whereNull('handoff_consumed_at')
+                ->where('handoff_expires_at', '>', now())
+                ->active()
+                ->lockForUpdate()
+                ->first();
+
+            if (! $draft) {
+                throw ValidationException::withMessages([
+                    'handoff_token' => ['This editor link is invalid, expired, or already used.'],
+                ]);
+            }
+
+            $editorSession = $this->generateToken();
+            $draft->forceFill([
+                'handoff_consumed_at' => now(),
+                'handoff_token_hash' => null,
+                'editor_session_hash' => $this->hashToken($editorSession),
+                'editor_session_expires_at' => $draft->expires_at,
+            ])->save();
+
+            return ['draft' => $draft->refresh(), 'editor_session' => $editorSession];
+        });
+    }
+
+    public function getForEditor(string $editorSession): AgentFormDraft
+    {
+        return $this->resolveEditorSession($editorSession);
+    }
+
+    public function replaceFromEditor(string $editorSession, int $expectedVersion, array $definition): AgentFormDraft
+    {
+        return DB::transaction(function () use ($editorSession, $expectedVersion, $definition) {
+            $draft = $this->resolveEditorSession($editorSession, lock: true);
+            $this->assertActiveVersion($draft, $expectedVersion);
+
+            $definition['visibility'] = 'draft';
+            $definition = $this->formDefinition->normalizeAndValidate($definition);
+            $draft->forceFill([
+                'definition' => $definition,
+                'schema_version' => AgentFormDefinition::SCHEMA_VERSION,
+                'version' => $draft->version + 1,
+            ])->save();
+
+            return $draft->refresh();
+        });
+    }
+
+    /**
+     * @return array{form: Form, cleanings: array, already_claimed: bool}
+     */
+    public function claim(string $editorSession, int $expectedVersion, Workspace $workspace, User $user): array
+    {
+        return DB::transaction(function () use ($editorSession, $expectedVersion, $workspace, $user) {
+            $draft = $this->resolveEditorSession($editorSession, lock: true, activeOnly: false);
+
+            if ($draft->status === AgentFormDraft::STATUS_CLAIMED && $draft->claimed_form_id) {
+                $form = Form::query()->findOrFail($draft->claimed_form_id);
+                Gate::forUser($user)->authorize('view', $form);
+
+                return ['form' => $form, 'cleanings' => [], 'already_claimed' => true];
+            }
+
+            $this->assertActiveVersion($draft, $expectedVersion);
+            Gate::forUser($user)->authorize('ownsWorkspace', $workspace);
+            Gate::forUser($user)->authorize('create', [Form::class, $workspace]);
+
+            $definition = $draft->definition;
+            $definition['visibility'] = 'draft';
+            $created = $this->formCreation->create($definition, $user, $workspace);
+
+            $draft->forceFill([
+                'status' => AgentFormDraft::STATUS_CLAIMED,
+                'claimed_form_id' => $created['form']->id,
+                'claimed_at' => now(),
+            ])->save();
+
+            return [
+                'form' => $created['form'],
+                'cleanings' => $created['cleanings'],
+                'already_claimed' => false,
+            ];
+        });
+    }
+
+    public function previewUrl(AgentFormDraft $draft): string
+    {
+        $sourceUrl = URL::temporarySignedRoute(
+            'agent-drafts.preview',
+            now()->addMinutes(15),
+            ['draft' => $draft->id],
+        );
+
+        return front_url('/agent-drafts/preview?source='.rawurlencode($sourceUrl));
+    }
+
     private function resolveActive(string $token, bool $lock = false): AgentFormDraft
     {
-        if (! preg_match('/^[A-Za-z0-9_-]{43}$/', $token)) {
-            throw $this->unavailable();
-        }
+        $this->assertTokenShape($token, 'draft_token');
 
         $query = AgentFormDraft::query()
             ->where('token_hash', $this->hashToken($token))
@@ -99,6 +232,52 @@ class AgentFormDraftService
         }
 
         return $draft;
+    }
+
+    private function resolveEditorSession(string $token, bool $lock = false, bool $activeOnly = true): AgentFormDraft
+    {
+        $this->assertTokenShape($token, 'editor_session');
+        $query = AgentFormDraft::query()
+            ->where('editor_session_hash', $this->hashToken($token))
+            ->where('editor_session_expires_at', '>', now())
+            ->where('expires_at', '>', now());
+
+        if ($activeOnly) {
+            $query->where('status', AgentFormDraft::STATUS_ACTIVE);
+        }
+        if ($lock) {
+            $query->lockForUpdate();
+        }
+
+        $draft = $query->first();
+        if (! $draft) {
+            throw ValidationException::withMessages([
+                'editor_session' => ['Editor session not found or expired.'],
+            ]);
+        }
+
+        return $draft;
+    }
+
+    private function assertActiveVersion(AgentFormDraft $draft, int $expectedVersion): void
+    {
+        if (! $draft->isAvailable()) {
+            throw $this->unavailable();
+        }
+        if ($draft->version !== $expectedVersion) {
+            throw ValidationException::withMessages([
+                'expected_version' => ["Draft version conflict. Current version is {$draft->version}. Fetch the draft and retry."],
+            ]);
+        }
+    }
+
+    private function assertTokenShape(string $token, string $field): void
+    {
+        if (! preg_match('/^[A-Za-z0-9_-]{43}$/', $token)) {
+            throw ValidationException::withMessages([
+                $field => ['Invalid or unavailable capability token.'],
+            ]);
+        }
     }
 
     private function generateToken(): string

--- a/api/app/Service/Forms/FormCreationService.php
+++ b/api/app/Service/Forms/FormCreationService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Models\Forms\Form;
+use App\Models\User;
+use App\Models\Workspace;
+
+class FormCreationService
+{
+    /**
+     * @return array{form: Form, cleanings: array, has_cleaned: bool}
+     */
+    public function create(array $data, User $creator, Workspace $workspace): array
+    {
+        $cleaner = new FormCleaner();
+        $formData = $cleaner
+            ->processData($data)
+            ->simulateCleaning($workspace)
+            ->getData();
+
+        unset($formData['schema_version']);
+        $formData['workspace_id'] = $workspace->id;
+
+        $form = Form::create(array_merge($formData, [
+            'creator_id' => $creator->id,
+        ]));
+
+        if (config('app.self_hosted') && ! empty($formData['slug'])) {
+            $form->slug = $formData['slug'];
+            $form->save();
+        }
+
+        return [
+            'form' => $form,
+            'cleanings' => $cleaner->getPerformedCleanings(),
+            'has_cleaned' => $cleaner->hasCleaned(),
+        ];
+    }
+}

--- a/api/database/migrations/2026_08_14_010000_add_editor_handoff_to_agent_form_drafts_table.php
+++ b/api/database/migrations/2026_08_14_010000_add_editor_handoff_to_agent_form_drafts_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('agent_form_drafts', function (Blueprint $table) {
+            $table->char('handoff_token_hash', 64)->nullable()->unique();
+            $table->timestamp('handoff_expires_at')->nullable()->index();
+            $table->timestamp('handoff_consumed_at')->nullable();
+            $table->char('editor_session_hash', 64)->nullable()->unique();
+            $table->timestamp('editor_session_expires_at')->nullable()->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_form_drafts', function (Blueprint $table) {
+            $table->dropColumn([
+                'handoff_token_hash',
+                'handoff_expires_at',
+                'handoff_consumed_at',
+                'editor_session_hash',
+                'editor_session_expires_at',
+            ]);
+        });
+    }
+};

--- a/api/database/migrations/2026_08_14_020000_make_agent_form_draft_handoffs_reusable.php
+++ b/api/database/migrations/2026_08_14_020000_make_agent_form_draft_handoffs_reusable.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('agent_form_draft_handoffs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('agent_form_draft_id')->constrained()->cascadeOnDelete();
+            $table->char('token_hash', 64)->unique();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->index();
+            $table->timestamps();
+        });
+
+        Schema::table('agent_form_drafts', function (Blueprint $table) {
+            $table->dropUnique(['handoff_token_hash']);
+            $table->dropIndex(['handoff_expires_at']);
+            $table->dropColumn([
+                'handoff_token_hash',
+                'handoff_expires_at',
+                'handoff_consumed_at',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_form_drafts', function (Blueprint $table) {
+            $table->char('handoff_token_hash', 64)->nullable()->unique();
+            $table->timestamp('handoff_expires_at')->nullable()->index();
+            $table->timestamp('handoff_consumed_at')->nullable();
+        });
+
+        Schema::dropIfExists('agent_form_draft_handoffs');
+    }
+};

--- a/api/resources/views/mcp/form-draft-preview-app.blade.php
+++ b/api/resources/views/mcp/form-draft-preview-app.blade.php
@@ -5,14 +5,23 @@
             body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; color: var(--color-text-primary, #111827); }
             main { padding: 18px; }
             .card { border: 1px solid var(--color-border-primary, #d1d5db); border-radius: 14px; padding: 18px; background: var(--color-background-primary, transparent); }
+            .header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+            .heading { min-width: 0; }
             h1 { margin: 0 0 8px; font-size: 20px; }
-            .meta { color: var(--color-text-secondary, #6b7280); font-size: 13px; }
+            .meta { margin: 0; color: var(--color-text-secondary, #6b7280); font-size: 13px; }
             iframe { width: 100%; height: 620px; margin: 16px 0; border: 1px solid var(--color-border-primary, #d1d5db); border-radius: 10px; background: white; }
             ol { padding-left: 22px; margin: 18px 0; }
             li { margin: 10px 0; }
-            button { border: 0; border-radius: 9px; padding: 10px 14px; background: #2563eb; color: white; font-weight: 650; cursor: pointer; }
+            button { flex: none; border: 0; border-radius: 8px; padding: 7px 10px; background: #2563eb; color: white; font-size: 12px; font-weight: 650; cursor: pointer; }
             button:disabled { cursor: wait; opacity: .6; }
             .empty { color: var(--color-text-secondary, #6b7280); font-style: italic; }
+            @media (max-width: 520px) {
+                main { padding: 12px; }
+                .card { padding: 14px; }
+                .header { align-items: center; }
+                h1 { font-size: 17px; }
+                button { padding: 6px 8px; }
+            }
         </style>
         <script type="module">
             createMcpApp(async (app) => {
@@ -47,7 +56,13 @@
                     }
 
                     openButton.disabled = !payload.editor_url;
-                    openButton.onclick = () => app.openLink({ url: payload.editor_url });
+                    openButton.onclick = () => {
+                        if (window.openai?.openExternal) {
+                            return window.openai.openExternal({ href: payload.editor_url, redirectUrl: false });
+                        }
+
+                        return app.openLink({ url: payload.editor_url });
+                    };
                 });
 
                 app.autoResize();
@@ -57,11 +72,15 @@
 
     <main>
         <section class="card">
-            <h1 id="title">Loading preview…</h1>
-            <p id="meta" class="meta"></p>
+            <header class="header">
+                <div class="heading">
+                    <h1 id="title">Loading preview…</h1>
+                    <p id="meta" class="meta"></p>
+                </div>
+                <button id="open-editor" disabled>Open in OpnForm</button>
+            </header>
             <iframe id="preview" title="OpnForm draft preview" hidden></iframe>
             <ol id="fields"></ol>
-            <button id="open-editor" disabled>Open in OpnForm editor</button>
         </section>
     </main>
 </x-mcp::app>

--- a/api/resources/views/mcp/form-draft-preview-app.blade.php
+++ b/api/resources/views/mcp/form-draft-preview-app.blade.php
@@ -1,0 +1,67 @@
+<x-mcp::app title="OpnForm draft preview">
+    <x-slot:head>
+        <style>
+            :root { color-scheme: light dark; }
+            body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; color: var(--color-text-primary, #111827); }
+            main { padding: 18px; }
+            .card { border: 1px solid var(--color-border-primary, #d1d5db); border-radius: 14px; padding: 18px; background: var(--color-background-primary, transparent); }
+            h1 { margin: 0 0 8px; font-size: 20px; }
+            .meta { color: var(--color-text-secondary, #6b7280); font-size: 13px; }
+            iframe { width: 100%; height: 620px; margin: 16px 0; border: 1px solid var(--color-border-primary, #d1d5db); border-radius: 10px; background: white; }
+            ol { padding-left: 22px; margin: 18px 0; }
+            li { margin: 10px 0; }
+            button { border: 0; border-radius: 9px; padding: 10px 14px; background: #2563eb; color: white; font-weight: 650; cursor: pointer; }
+            button:disabled { cursor: wait; opacity: .6; }
+            .empty { color: var(--color-text-secondary, #6b7280); font-style: italic; }
+        </style>
+        <script type="module">
+            createMcpApp(async (app) => {
+                const title = document.getElementById('title');
+                const meta = document.getElementById('meta');
+                const fields = document.getElementById('fields');
+                const preview = document.getElementById('preview');
+                const openButton = document.getElementById('open-editor');
+
+                app.onToolResult((result) => {
+                    const payload = result?.structuredContent ?? result?.structured_content ?? {};
+                    const draft = payload.draft ?? {};
+                    const definition = draft.definition ?? {};
+                    title.textContent = definition.title ?? 'Untitled form';
+                    meta.textContent = `Draft v${draft.version ?? '?'} · ${definition.presentation_style ?? 'classic'} layout`;
+                    if (payload.preview_url) {
+                        preview.src = payload.preview_url;
+                        preview.hidden = false;
+                        fields.hidden = true;
+                    }
+                    fields.replaceChildren();
+
+                    const visibleFields = (definition.properties ?? []).filter((field) => !field.hidden);
+                    if (visibleFields.length === 0) {
+                        fields.innerHTML = '<li class="empty">No visible blocks yet.</li>';
+                    } else {
+                        for (const field of visibleFields) {
+                            const item = document.createElement('li');
+                            item.textContent = field.name ?? field.type ?? 'Untitled block';
+                            fields.appendChild(item);
+                        }
+                    }
+
+                    openButton.disabled = !payload.editor_url;
+                    openButton.onclick = () => app.openLink({ url: payload.editor_url });
+                });
+
+                app.autoResize();
+            });
+        </script>
+    </x-slot:head>
+
+    <main>
+        <section class="card">
+            <h1 id="title">Loading preview…</h1>
+            <p id="meta" class="meta"></p>
+            <iframe id="preview" title="OpnForm draft preview" hidden></iframe>
+            <ol id="fields"></ol>
+            <button id="open-editor" disabled>Open in OpnForm editor</button>
+        </section>
+    </main>
+</x-mcp::app>

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -35,6 +35,7 @@ use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HealthCheckController;
+use App\Http\Controllers\AgentFormDraftController;
 
 /*
 |--------------------------------------------------------------------------
@@ -50,6 +51,24 @@ use App\Http\Controllers\HealthCheckController;
 if (config('app.self_hosted')) {
     Route::get('/healthcheck', [HealthCheckController::class, 'apiCheck']);
 }
+
+Route::prefix('agent-drafts')->name('agent-drafts.')->group(function () {
+    Route::get('/preview/{draft}', [AgentFormDraftController::class, 'preview'])
+        ->middleware(['signed', 'throttle:60,1'])
+        ->name('preview');
+    Route::post('/handoff/consume', [AgentFormDraftController::class, 'consume'])
+        ->middleware('throttle:30,1')
+        ->name('handoff.consume');
+    Route::get('/editor/current', [AgentFormDraftController::class, 'current'])
+        ->middleware('throttle:120,1')
+        ->name('editor.current');
+    Route::put('/editor/current', [AgentFormDraftController::class, 'replace'])
+        ->middleware('throttle:120,1')
+        ->name('editor.replace');
+    Route::post('/editor/claim', [AgentFormDraftController::class, 'claim'])
+        ->middleware(['auth.multi', 'throttle:30,1'])
+        ->name('editor.claim');
+});
 
 Route::prefix('open')->name('open.')->group(function () {
     Route::prefix('forms')->name('forms.')->group(function () {

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AgentFormDraftController;
 use App\Mcp\Servers\OpnFormServer;
 use App\Mcp\Tools\PreviewFormDraftTool;
 use App\Models\Forms\AgentFormDraft;
+use App\Models\OAuthProvider;
 use App\Models\User;
 use App\Service\Forms\AgentFormDraftService;
 use Illuminate\Support\Facades\URL;
@@ -267,6 +268,43 @@ it('refuses claim into another users workspace', function () {
             'workspace_id' => $foreignWorkspace->id,
         ])
         ->assertForbidden();
+
+    $this->assertDatabaseCount('forms', 0);
+});
+
+it('refuses a guest payment account that does not belong to the claim workspace', function () {
+    $user = User::factory()->create();
+    $workspace = createUserWorkspace($user);
+    $foreignProvider = OAuthProvider::factory()->for(User::factory()->create())->create([
+        'provider' => 'stripe',
+        'provider_user_id' => 'acct_foreign',
+    ]);
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition([
+        'properties' => [[
+            'id' => 'payment-field',
+            'name' => 'Payment',
+            'type' => 'payment',
+            'amount' => 10,
+            'currency' => 'USD',
+            'stripe_account_id' => $foreignProvider->id,
+        ]],
+    ]));
+    $session = $drafts->consumeEditorHandoff(
+        $drafts->issueEditorHandoff($created['token'])['handoff_token'],
+    )['editor_session'];
+
+    $this->actingAs($user, 'api')
+        ->withHeaders([
+            'x-api-secret' => 'test-front-secret',
+            AgentFormDraftController::SESSION_HEADER => $session,
+        ])
+        ->postJson(route('agent-drafts.editor.claim'), [
+            'expected_version' => 1,
+            'workspace_id' => $workspace->id,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('properties.0.stripe_account_id');
 
     $this->assertDatabaseCount('forms', 0);
 });

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -24,7 +24,7 @@ beforeEach(function () {
     config()->set('app.front_url', 'https://opnform.test');
 });
 
-it('renders an MCP App preview with short-lived preview and editor links', function () {
+it('renders an MCP App preview with short-lived preview and reusable editor links', function () {
     $created = app(AgentFormDraftService::class)->create(editorDraftDefinition());
 
     OpnFormServer::tool(PreviewFormDraftTool::class, [
@@ -36,15 +36,48 @@ it('renders an MCP App preview with short-lived preview and editor links', funct
 
     OpnFormServer::resource(\App\Mcp\Apps\FormDraftPreviewApp::class)
         ->assertOk()
-        ->assertSee('Open in OpnForm editor')
+        ->assertSee('Open in OpnForm')
+        ->assertSee('window.openai?.openExternal')
         ->assertSee('<iframe');
 
     $draft = $created['draft']->refresh();
-    expect($draft->handoff_token_hash)->toMatch('/^[a-f0-9]{64}$/')
-        ->and($draft->handoff_expires_at->isFuture())->toBeTrue()
+    $handoff = $draft->editorHandoffs()->sole();
+    expect($handoff->token_hash)->toMatch('/^[a-f0-9]{64}$/')
+        ->and($handoff->expires_at->isSameSecond($draft->expires_at))->toBeTrue()
         ->and(app(AgentFormDraftService::class)->issueEditorHandoff($created['token'])['editor_url'])
         ->toStartWith('https://opnform.test/agent-drafts/edit#handoff=')
         ->and(app(\App\Mcp\Apps\FormDraftPreviewApp::class)->resolvedAppMeta()['csp']['frameDomains'])
+        ->toBe(['https://opnform.test']);
+});
+
+it('publishes standard and ChatGPT-compatible CSP metadata with the full frontend origin', function () {
+    config()->set('app.front_url', 'http://127.0.0.1:33676');
+    $previewApp = app(\App\Mcp\Apps\FormDraftPreviewApp::class);
+    $resource = $previewApp->handle(new \Laravel\Mcp\Request())
+        ->content()
+        ->toResource($previewApp);
+
+    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v3')
+        ->and($previewApp->resolvedAppMeta()['csp']['frameDomains'])
+        ->toBe(['http://127.0.0.1:33676'])
+        ->and($resource['text'])->not->toContain('native-preview')
+        ->and($resource['_meta']['openai/widgetCSP'])
+        ->toBe([
+            'connect_domains' => [],
+            'resource_domains' => [],
+            'frame_domains' => ['http://127.0.0.1:33676'],
+            'redirect_domains' => ['http://127.0.0.1:33676'],
+        ]);
+
+    config()->set('app.front_url', 'https://opnform.test');
+    $secureApp = app(\App\Mcp\Apps\FormDraftPreviewApp::class);
+    $secureResource = $secureApp->handle(new \Laravel\Mcp\Request())
+        ->content()
+        ->toResource($secureApp);
+
+    expect($secureApp->resolvedAppMeta()['csp']['frameDomains'])
+        ->toBe(['https://opnform.test'])
+        ->and($secureResource['_meta']['openai/widgetCSP']['frame_domains'])
         ->toBe(['https://opnform.test']);
 });
 
@@ -61,30 +94,62 @@ it('serves preview data only through a valid signed URL without exposing capabil
     $this->getJson(route('agent-drafts.preview', $draft))->assertForbidden();
 });
 
-it('consumes editor handoffs once and stores only a hashed editor session', function () {
+it('keeps every guest editor link reusable until the draft expires', function () {
+    $this->freezeTime();
     $drafts = app(AgentFormDraftService::class);
     $created = $drafts->create(editorDraftDefinition());
-    $handoff = $drafts->issueEditorHandoff($created['token']);
+    $firstHandoff = $drafts->issueEditorHandoff($created['token']);
+    $draft = $created['draft']->refresh();
+    $firstCapability = $draft->editorHandoffs()->sole();
+
+    expect($firstCapability->expires_at->isSameSecond($draft->expires_at))->toBeTrue();
 
     $response = $this->withHeader('x-api-secret', 'test-front-secret')
         ->postJson(route('agent-drafts.handoff.consume'), [
-            'handoff_token' => $handoff['handoff_token'],
+            'handoff_token' => $firstHandoff['handoff_token'],
         ])
         ->assertOk()
         ->assertJsonPath('draft.version', 1);
 
     $editorSession = $response->json('editor_session');
-    $draft = $created['draft']->refresh();
+    $draft->refresh();
     expect($editorSession)->toHaveLength(43)
         ->and($draft->editor_session_hash)->toBe(hash('sha256', $editorSession))
-        ->and($draft->handoff_token_hash)->toBeNull()
-        ->and($draft->handoff_consumed_at)->not->toBeNull();
+        ->and($firstCapability->refresh()->last_used_at)->not->toBeNull();
+
+    $this->travel(1)->day();
+    $secondHandoff = $drafts->issueEditorHandoff($created['token']);
+    $this->withHeader('x-api-secret', 'test-front-secret')
+        ->postJson(route('agent-drafts.handoff.consume'), [
+            'handoff_token' => $secondHandoff['handoff_token'],
+        ])
+        ->assertOk()
+        ->assertJsonPath('editor_session', $editorSession);
 
     $this->withHeader('x-api-secret', 'test-front-secret')
         ->postJson(route('agent-drafts.handoff.consume'), [
-            'handoff_token' => $handoff['handoff_token'],
+            'handoff_token' => $firstHandoff['handoff_token'],
         ])
-        ->assertUnprocessable();
+        ->assertOk()
+        ->assertJsonPath('editor_session', $editorSession);
+
+    $this->assertDatabaseCount('agent_form_draft_handoffs', 2);
+
+    $this->travel(5)->days();
+    $this->travel(23)->hours();
+    $this->withHeader('x-api-secret', 'test-front-secret')
+        ->postJson(route('agent-drafts.handoff.consume'), [
+            'handoff_token' => $firstHandoff['handoff_token'],
+        ])
+        ->assertOk();
+
+    $this->travel(2)->hours();
+    $this->withHeader('x-api-secret', 'test-front-secret')
+        ->postJson(route('agent-drafts.handoff.consume'), [
+            'handoff_token' => $firstHandoff['handoff_token'],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('handoff_token');
 });
 
 it('requires the trusted frontend secret for editor endpoints', function () {

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+use App\Http\Controllers\AgentFormDraftController;
+use App\Mcp\Servers\OpnFormServer;
+use App\Mcp\Tools\PreviewFormDraftTool;
+use App\Models\Forms\AgentFormDraft;
+use App\Models\User;
+use App\Service\Forms\AgentFormDraftService;
+use Illuminate\Support\Facades\URL;
+
+function editorDraftDefinition(array $overrides = []): array
+{
+    return array_replace([
+        'title' => 'Agent customer intake',
+        'properties' => [
+            ['id' => 'name-field', 'name' => 'Name', 'type' => 'text'],
+            ['id' => 'email-field', 'name' => 'Email', 'type' => 'email'],
+        ],
+    ], $overrides);
+}
+
+beforeEach(function () {
+    config()->set('app.front_api_secret', 'test-front-secret');
+    config()->set('app.front_url', 'https://opnform.test');
+});
+
+it('renders an MCP App preview with short-lived preview and editor links', function () {
+    $created = app(AgentFormDraftService::class)->create(editorDraftDefinition());
+
+    OpnFormServer::tool(PreviewFormDraftTool::class, [
+        'draft_token' => $created['token'],
+    ])->assertOk()
+        ->assertSee('preview_url')
+        ->assertSee('editor_url')
+        ->assertSee('Agent customer intake');
+
+    OpnFormServer::resource(\App\Mcp\Apps\FormDraftPreviewApp::class)
+        ->assertOk()
+        ->assertSee('Open in OpnForm editor')
+        ->assertSee('<iframe');
+
+    $draft = $created['draft']->refresh();
+    expect($draft->handoff_token_hash)->toMatch('/^[a-f0-9]{64}$/')
+        ->and($draft->handoff_expires_at->isFuture())->toBeTrue()
+        ->and(app(AgentFormDraftService::class)->issueEditorHandoff($created['token'])['editor_url'])
+        ->toStartWith('https://opnform.test/agent-drafts/edit#handoff=')
+        ->and(app(\App\Mcp\Apps\FormDraftPreviewApp::class)->resolvedAppMeta()['csp']['frameDomains'])
+        ->toBe(['https://opnform.test']);
+});
+
+it('serves preview data only through a valid signed URL without exposing capabilities', function () {
+    $draft = app(AgentFormDraftService::class)->create(editorDraftDefinition())['draft'];
+    $signedUrl = URL::temporarySignedRoute('agent-drafts.preview', now()->addMinute(), ['draft' => $draft->id]);
+
+    $this->getJson($signedUrl)
+        ->assertOk()
+        ->assertHeader('Cache-Control', 'max-age=0, no-store, private')
+        ->assertJsonPath('draft.definition.title', 'Agent customer intake')
+        ->assertJsonMissing(['token_hash' => $draft->token_hash]);
+
+    $this->getJson(route('agent-drafts.preview', $draft))->assertForbidden();
+});
+
+it('consumes editor handoffs once and stores only a hashed editor session', function () {
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition());
+    $handoff = $drafts->issueEditorHandoff($created['token']);
+
+    $response = $this->withHeader('x-api-secret', 'test-front-secret')
+        ->postJson(route('agent-drafts.handoff.consume'), [
+            'handoff_token' => $handoff['handoff_token'],
+        ])
+        ->assertOk()
+        ->assertJsonPath('draft.version', 1);
+
+    $editorSession = $response->json('editor_session');
+    $draft = $created['draft']->refresh();
+    expect($editorSession)->toHaveLength(43)
+        ->and($draft->editor_session_hash)->toBe(hash('sha256', $editorSession))
+        ->and($draft->handoff_token_hash)->toBeNull()
+        ->and($draft->handoff_consumed_at)->not->toBeNull();
+
+    $this->withHeader('x-api-secret', 'test-front-secret')
+        ->postJson(route('agent-drafts.handoff.consume'), [
+            'handoff_token' => $handoff['handoff_token'],
+        ])
+        ->assertUnprocessable();
+});
+
+it('requires the trusted frontend secret for editor endpoints', function () {
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition());
+    $session = $drafts->consumeEditorHandoff(
+        $drafts->issueEditorHandoff($created['token'])['handoff_token'],
+    )['editor_session'];
+
+    $this->withHeader(AgentFormDraftController::SESSION_HEADER, $session)
+        ->getJson(route('agent-drafts.editor.current'))
+        ->assertForbidden();
+});
+
+it('syncs editor replacements through the canonical optimistic version', function () {
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition());
+    $session = $drafts->consumeEditorHandoff(
+        $drafts->issueEditorHandoff($created['token'])['handoff_token'],
+    )['editor_session'];
+    $headers = [
+        'x-api-secret' => 'test-front-secret',
+        AgentFormDraftController::SESSION_HEADER => $session,
+    ];
+
+    $definition = $created['draft']->definition;
+    $definition['title'] = 'Edited in browser';
+
+    $this->withHeaders($headers)
+        ->putJson(route('agent-drafts.editor.replace'), [
+            'expected_version' => 1,
+            'definition' => $definition,
+        ])
+        ->assertOk()
+        ->assertJsonPath('draft.version', 2)
+        ->assertJsonPath('draft.definition.title', 'Edited in browser');
+
+    $this->withHeaders($headers)
+        ->putJson(route('agent-drafts.editor.replace'), [
+            'expected_version' => 1,
+            'definition' => $definition,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('expected_version');
+
+    expect($drafts->get($created['token'])->version)->toBe(2);
+});
+
+it('claims a draft explicitly into an owned workspace as an unpublished form', function () {
+    $user = User::factory()->create();
+    $workspace = createUserWorkspace($user);
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition(['no_branding' => true]));
+    $session = $drafts->consumeEditorHandoff(
+        $drafts->issueEditorHandoff($created['token'])['handoff_token'],
+    )['editor_session'];
+    $headers = [
+        'x-api-secret' => 'test-front-secret',
+        AgentFormDraftController::SESSION_HEADER => $session,
+    ];
+
+    $response = $this->actingAs($user, 'api')
+        ->withHeaders($headers)
+        ->postJson(route('agent-drafts.editor.claim'), [
+            'expected_version' => 1,
+            'workspace_id' => $workspace->id,
+        ])
+        ->assertOk()
+        ->assertJsonPath('form.visibility', 'draft')
+        ->assertJsonPath('already_claimed', false)
+        ->assertJsonStructure(['cleanings' => ['form']]);
+
+    $formId = $response->json('form.id');
+    $this->assertDatabaseHas('forms', [
+        'id' => $formId,
+        'workspace_id' => $workspace->id,
+        'creator_id' => $user->id,
+        'visibility' => 'draft',
+    ]);
+    $this->assertDatabaseHas('agent_form_drafts', [
+        'id' => $created['draft']->id,
+        'status' => AgentFormDraft::STATUS_CLAIMED,
+        'claimed_form_id' => $formId,
+    ]);
+
+    $this->actingAs($user, 'api')
+        ->withHeaders($headers)
+        ->postJson(route('agent-drafts.editor.claim'), [
+            'expected_version' => 1,
+            'workspace_id' => $workspace->id,
+        ])
+        ->assertOk()
+        ->assertJsonPath('form.id', $formId)
+        ->assertJsonPath('already_claimed', true);
+
+    $this->assertDatabaseCount('forms', 1);
+});
+
+it('refuses claim into another users workspace', function () {
+    $user = User::factory()->create();
+    $foreignWorkspace = createUserWorkspace(User::factory()->create());
+    $drafts = app(AgentFormDraftService::class);
+    $created = $drafts->create(editorDraftDefinition());
+    $session = $drafts->consumeEditorHandoff(
+        $drafts->issueEditorHandoff($created['token'])['handoff_token'],
+    )['editor_session'];
+
+    $this->actingAs($user, 'api')
+        ->withHeaders([
+            'x-api-secret' => 'test-front-secret',
+            AgentFormDraftController::SESSION_HEADER => $session,
+        ])
+        ->postJson(route('agent-drafts.editor.claim'), [
+            'expected_version' => 1,
+            'workspace_id' => $foreignWorkspace->id,
+        ])
+        ->assertForbidden();
+
+    $this->assertDatabaseCount('forms', 0);
+});

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -185,6 +185,22 @@ it('rejects oversized draft definitions before persistence', function () {
     $this->assertDatabaseCount('agent_form_drafts', 0);
 });
 
+it('sanitizes rich text html before an agent draft can be rendered', function () {
+    $created = app(AgentFormDraftService::class)->create(guestDraftDefinition([
+        'properties' => [[
+            'id' => 'rich-text',
+            'name' => 'Introduction',
+            'type' => 'nf-text',
+            'content' => '<p>Hello</p><img src=x onerror="alert(1)"><script>alert(2)</script>',
+        ]],
+    ]));
+
+    $content = $created['draft']->definition['properties'][0]['content'];
+    expect($content)->toContain('<p>Hello</p>')
+        ->not->toContain('onerror')
+        ->not->toContain('<script');
+});
+
 it('rate limits only excessive draft creation bursts', function () {
     config()->set('opnform.mcp.rate_limit.draft_creates_per_minute', 2);
     config()->set('opnform.mcp.rate_limit.draft_creates_per_hour', 10);

--- a/client/components/open/forms/BlockRenderer.vue
+++ b/client/components/open/forms/BlockRenderer.vue
@@ -36,8 +36,15 @@
       :id="block.id"
       :key="'code-' + block.id"
       class="nf-code w-full px-2 my-1.5"
-      v-html="block.content"
-    />
+    >
+      <div
+        v-if="disableCustomCodeExecution"
+        class="rounded-lg border border-dashed bg-neutral-50 p-4 text-sm text-neutral-500"
+      >
+        Custom code is preserved but does not execute in an agent draft preview.
+      </div>
+      <div v-else v-html="block.content" />
+    </div>
     <div
       v-else-if="block.type === 'nf-divider'"
       :id="block.id"
@@ -143,6 +150,7 @@ const dataForm = computed(() => props.formManager?.form || {})
 const darkMode = computed(() => props.formManager?.darkMode?.value || false)
 const strategy = computed(() => props.formManager?.strategy?.value || {})
 const isAdminPreview = computed(() => strategy.value?.admin?.showAdminControls || false)
+const disableCustomCodeExecution = inject('disableCustomCodeExecution', false)
 
 // Debounce form data changes to avoid excessive re-renders when user types
 const formDataForMentions = computed(() => dataForm.value?.data?.() || {})

--- a/client/components/open/forms/components/FormEditor.vue
+++ b/client/components/open/forms/components/FormEditor.vue
@@ -160,6 +160,11 @@ const props = defineProps({
     required: false,
     type: Boolean,
     default: false,
+  },
+  saveHandler: {
+    required: false,
+    type: Function,
+    default: null,
   }
 })
 
@@ -361,6 +366,11 @@ const proceedWithSave = () => {
     // Clean invalid logic before saving using the comprehensive validator
     const { validatePropertiesLogic } = useFormLogic()
     form.value.properties = validatePropertiesLogic(form.value.properties)
+  }
+
+  if (props.saveHandler) {
+    props.saveHandler(form.value.data())
+    return
   }
 
   if (props.isGuest) {

--- a/client/lib/forms/agent-draft-autosave.js
+++ b/client/lib/forms/agent-draft-autosave.js
@@ -1,0 +1,25 @@
+export function createAgentDraftAutosave(sync, delay = 900) {
+  let timer = null
+
+  function clear() {
+    if (timer === null) return
+    clearTimeout(timer)
+    timer = null
+  }
+
+  function schedule() {
+    clear()
+    timer = setTimeout(() => {
+      timer = null
+      sync({ keepalive: false }).catch(() => {})
+    }, delay)
+  }
+
+  function flush() {
+    if (timer === null) return Promise.resolve()
+    clear()
+    return sync({ keepalive: true })
+  }
+
+  return { schedule, flush }
+}

--- a/client/lib/forms/agent-draft-session.js
+++ b/client/lib/forms/agent-draft-session.js
@@ -1,0 +1,20 @@
+export function getAgentDraftSessionRequest(hash = '') {
+  const handoffToken = new URLSearchParams(hash.replace(/^#/, '')).get('handoff')
+
+  if (!handoffToken) {
+    return {
+      url: '/api/agent-drafts/current',
+      options: undefined,
+      consumesHandoff: false,
+    }
+  }
+
+  return {
+    url: '/api/agent-drafts/handoff',
+    options: {
+      method: 'POST',
+      body: { handoff_token: handoffToken },
+    },
+    consumesHandoff: true,
+  }
+}

--- a/client/pages/agent-drafts/edit.vue
+++ b/client/pages/agent-drafts/edit.vue
@@ -84,6 +84,7 @@ const workspaces = ref([])
 const selectedWorkspaceId = ref(null)
 const workspaceModalOpen = ref(false)
 const claimAfterLogin = ref(false)
+const hydratingEditor = ref(true)
 let syncTimer = null
 let syncPromise = null
 
@@ -164,7 +165,7 @@ const syncDraft = (data) => performSync(data).then(() => {
 })
 
 const scheduleSync = () => {
-  if (loading.value || claiming.value) return
+  if (loading.value || claiming.value || hydratingEditor.value) return
   clearTimeout(syncTimer)
   syncTimer = setTimeout(() => performSync().catch(() => {}), 900)
 }
@@ -238,6 +239,12 @@ onMounted(() => {
     fatalError.value = exception?.data?.message || 'This editor link is invalid, expired, or already used. Ask the agent for a fresh link.'
   }).finally(() => {
     loading.value = false
+    if (!fatalError.value) {
+      nextTick().then(() => {
+        lastSavedFingerprint.value = JSON.stringify(cleanDefinition(workingFormStore.content?.data()))
+        hydratingEditor.value = false
+      })
+    }
   })
 
   useWindowMessage(WindowMessageTypes.AFTER_LOGIN).listen(() => {

--- a/client/pages/agent-drafts/edit.vue
+++ b/client/pages/agent-drafts/edit.vue
@@ -64,6 +64,7 @@
 import FormEditor from '~/components/open/forms/components/FormEditor.vue'
 import { workspaceApi } from '~/api'
 import { WindowMessageTypes } from '~/composables/useWindowMessage'
+import { getAgentDraftSessionRequest } from '~/lib/forms/agent-draft-session'
 
 definePageMeta({ layout: 'empty' })
 useOpnSeoMeta({ title: 'Edit private form draft' })
@@ -228,12 +229,11 @@ const claimDraft = () => {
 }
 
 onMounted(() => {
-  const fragment = new URL(window.location.href).hash.replace(/^#handoff=/, '')
-  window.history.replaceState({}, '', '/agent-drafts/edit')
-  $fetch('/api/agent-drafts/handoff', {
-    method: 'POST',
-    body: { handoff_token: fragment },
-  }).then((response) => {
+  const sessionRequest = getAgentDraftSessionRequest(window.location.hash)
+  if (sessionRequest.consumesHandoff) {
+    window.history.replaceState({}, '', '/agent-drafts/edit')
+  }
+  $fetch(sessionRequest.url, sessionRequest.options).then((response) => {
     applyDraft(response.draft)
   }).catch((exception) => {
     fatalError.value = exception?.data?.message || 'This editor link is invalid or expired. Ask the agent for a fresh link.'

--- a/client/pages/agent-drafts/edit.vue
+++ b/client/pages/agent-drafts/edit.vue
@@ -1,0 +1,252 @@
+<template>
+  <div class="flex min-h-screen flex-col bg-white">
+    <div v-if="loading" class="flex grow items-center justify-center">
+      <div class="text-center">
+        <Loader class="mx-auto h-7 w-7 text-blue-500" />
+        <p class="mt-3 text-sm text-neutral-500">Opening your private draft…</p>
+      </div>
+    </div>
+
+    <div v-else-if="fatalError" class="mx-auto flex max-w-xl grow items-center p-6">
+      <UAlert color="error" title="Unable to open this draft" :description="fatalError" />
+    </div>
+
+    <FormEditor
+      v-else
+      class="w-full grow"
+      :loading="saving"
+      :save-handler="syncDraft"
+      :back-button="false"
+    >
+      <template #before-save>
+        <div class="mr-2 hidden items-center gap-2 sm:flex">
+          <span class="text-xs text-neutral-500">{{ syncLabel }}</span>
+          <UButton
+            size="sm"
+            color="neutral"
+            variant="outline"
+            :loading="claiming"
+            @click.stop="prepareClaim"
+          >
+            Save to my account
+          </UButton>
+        </div>
+      </template>
+    </FormEditor>
+
+    <UModal v-model:open="workspaceModalOpen" :ui="{ content: 'sm:max-w-md' }">
+      <template #header>
+        <div>
+          <h2 class="font-semibold">Choose a workspace</h2>
+          <p class="mt-1 text-sm font-normal text-neutral-500">The form will be saved as an unpublished draft.</p>
+        </div>
+      </template>
+      <template #body>
+        <SelectInput
+          v-model="selectedWorkspaceId"
+          name="workspace"
+          label="Workspace"
+          :options="workspaceOptions"
+          :required="true"
+        />
+      </template>
+      <template #footer>
+        <div class="flex w-full justify-end gap-2">
+          <UButton color="neutral" variant="outline" @click="workspaceModalOpen = false">Cancel</UButton>
+          <UButton :loading="claiming" @click="claimDraft">Save draft</UButton>
+        </div>
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup>
+import FormEditor from '~/components/open/forms/components/FormEditor.vue'
+import { workspaceApi } from '~/api'
+import { WindowMessageTypes } from '~/composables/useWindowMessage'
+
+definePageMeta({ layout: 'empty' })
+useOpnSeoMeta({ title: 'Edit private form draft' })
+
+const appStore = useAppStore()
+const workingFormStore = useWorkingFormStore()
+const { isAuthenticated } = useIsAuthenticated()
+provide('disableCustomCodeExecution', true)
+
+const loading = ref(true)
+const saving = ref(false)
+const claiming = ref(false)
+const fatalError = ref(null)
+const version = ref(null)
+const lastSavedFingerprint = ref(null)
+const syncState = ref('saved')
+const workspaces = ref([])
+const selectedWorkspaceId = ref(null)
+const workspaceModalOpen = ref(false)
+const claimAfterLogin = ref(false)
+let syncTimer = null
+let syncPromise = null
+
+const syncLabel = computed(() => ({
+  saving: 'Saving draft…',
+  error: 'Draft not saved',
+  saved: `Draft saved · v${version.value || '?'}`,
+}[syncState.value]))
+const workspaceOptions = computed(() => workspaces.value.map(workspace => ({
+  name: workspace.name,
+  value: workspace.id,
+})))
+
+const cleanDefinition = (data) => {
+  const definition = JSON.parse(JSON.stringify(data))
+  delete definition.id
+  delete definition.slug
+  delete definition.workspace_id
+  delete definition.workspace
+  delete definition.bypass_success_page
+  delete definition.share_url
+  delete definition.created_at
+  delete definition.updated_at
+  return definition
+}
+
+const applyDraft = (draft) => {
+  version.value = draft.version
+  const definition = cleanDefinition(draft.definition)
+  lastSavedFingerprint.value = JSON.stringify(definition)
+  workingFormStore.set(useForm(definition))
+  syncState.value = 'saved'
+}
+
+const refreshDraft = () => $fetch('/api/agent-drafts/current').then((response) => {
+  applyDraft(response.draft)
+  return response.draft
+})
+
+const performSync = (rawData) => {
+  const definition = cleanDefinition(rawData || workingFormStore.content?.data())
+  const fingerprint = JSON.stringify(definition)
+  if (!definition || fingerprint === lastSavedFingerprint.value) {
+    return Promise.resolve()
+  }
+  if (syncPromise) {
+    return syncPromise.then(() => performSync(definition))
+  }
+
+  saving.value = true
+  syncState.value = 'saving'
+  syncPromise = $fetch('/api/agent-drafts/current', {
+    method: 'PUT',
+    body: { expected_version: version.value, definition },
+  }).then((response) => {
+    version.value = response.draft.version
+    lastSavedFingerprint.value = JSON.stringify(cleanDefinition(response.draft.definition))
+    syncState.value = 'saved'
+  }).catch((exception) => {
+    syncState.value = 'error'
+    if (exception?.statusCode === 422 || exception?.status === 422) {
+      return refreshDraft().then(() => {
+        useAlert().warning('The draft changed in the conversation. The editor was refreshed with the latest version.')
+      })
+    }
+    useAlert().error(exception?.data?.message || 'Unable to save this draft right now.')
+    throw exception
+  }).finally(() => {
+    saving.value = false
+    syncPromise = null
+  })
+
+  return syncPromise
+}
+
+const syncDraft = (data) => performSync(data).then(() => {
+  useAlert().success('Draft saved.')
+})
+
+const scheduleSync = () => {
+  if (loading.value || claiming.value) return
+  clearTimeout(syncTimer)
+  syncTimer = setTimeout(() => performSync().catch(() => {}), 900)
+}
+
+watch(() => workingFormStore.content?.data?.(), scheduleSync, { deep: true })
+
+const prepareClaim = () => {
+  if (!isAuthenticated.value) {
+    claimAfterLogin.value = true
+    appStore.quickRegisterModal = true
+    return
+  }
+
+  claiming.value = true
+  performSync().then(() => workspaceApi.list()).then((availableWorkspaces) => {
+    workspaces.value = availableWorkspaces || []
+    if (workspaces.value.length === 1) {
+      selectedWorkspaceId.value = workspaces.value[0].id
+      return claimDraft()
+    }
+    if (workspaces.value.length === 0) {
+      throw new Error('Your account does not have a workspace yet.')
+    }
+    selectedWorkspaceId.value = null
+    claiming.value = false
+    workspaceModalOpen.value = true
+  }).catch((exception) => {
+    useAlert().error(exception?.data?.message || exception.message || 'Unable to prepare this draft for your account.')
+  }).finally(() => {
+    if (!workspaceModalOpen.value) claiming.value = false
+  })
+}
+
+const claimDraft = () => {
+  if (!selectedWorkspaceId.value) {
+    useAlert().error('Please select a workspace.')
+    return Promise.resolve()
+  }
+
+  claiming.value = true
+  return performSync().then(() => $fetch('/api/agent-drafts/claim', {
+    method: 'POST',
+    body: {
+      expected_version: version.value,
+      workspace_id: selectedWorkspaceId.value,
+    },
+  })).then((response) => {
+    workspaceModalOpen.value = false
+    if (response.cleanings && Object.keys(response.cleanings).length > 0) {
+      useAlert().warning('The form was saved. Some premium features will stay disabled when the form is shared.', 10000, { form: response.form })
+    } else {
+      useAlert().success('Form saved to your account as an unpublished draft.')
+    }
+    window.location.assign(response.editor_url)
+  }).catch((exception) => {
+    useAlert().error(exception?.data?.message || 'Unable to save this form to your account.')
+  }).finally(() => {
+    claiming.value = false
+  })
+}
+
+onMounted(() => {
+  const fragment = new URL(window.location.href).hash.replace(/^#handoff=/, '')
+  window.history.replaceState({}, '', '/agent-drafts/edit')
+  $fetch('/api/agent-drafts/handoff', {
+    method: 'POST',
+    body: { handoff_token: fragment },
+  }).then((response) => {
+    applyDraft(response.draft)
+  }).catch((exception) => {
+    fatalError.value = exception?.data?.message || 'This editor link is invalid, expired, or already used. Ask the agent for a fresh link.'
+  }).finally(() => {
+    loading.value = false
+  })
+
+  useWindowMessage(WindowMessageTypes.AFTER_LOGIN).listen(() => {
+    if (claimAfterLogin.value) {
+      claimAfterLogin.value = false
+      prepareClaim()
+    }
+  }, { useMessageChannel: false })
+})
+
+onBeforeUnmount(() => clearTimeout(syncTimer))
+</script>

--- a/client/pages/agent-drafts/edit.vue
+++ b/client/pages/agent-drafts/edit.vue
@@ -64,6 +64,7 @@
 import FormEditor from '~/components/open/forms/components/FormEditor.vue'
 import { workspaceApi } from '~/api'
 import { WindowMessageTypes } from '~/composables/useWindowMessage'
+import { createAgentDraftAutosave } from '~/lib/forms/agent-draft-autosave'
 import { getAgentDraftSessionRequest } from '~/lib/forms/agent-draft-session'
 
 definePageMeta({ layout: 'empty' })
@@ -86,7 +87,6 @@ const selectedWorkspaceId = ref(null)
 const workspaceModalOpen = ref(false)
 const claimAfterLogin = ref(false)
 const hydratingEditor = ref(true)
-let syncTimer = null
 let syncPromise = null
 
 const syncLabel = computed(() => ({
@@ -125,14 +125,14 @@ const refreshDraft = () => $fetch('/api/agent-drafts/current').then((response) =
   return response.draft
 })
 
-const performSync = (rawData) => {
+const performSync = (rawData, keepalive = false) => {
   const definition = cleanDefinition(rawData || workingFormStore.content?.data())
   const fingerprint = JSON.stringify(definition)
   if (!definition || fingerprint === lastSavedFingerprint.value) {
     return Promise.resolve()
   }
   if (syncPromise) {
-    return syncPromise.then(() => performSync(definition))
+    return syncPromise.then(() => performSync(definition, keepalive))
   }
 
   saving.value = true
@@ -140,6 +140,7 @@ const performSync = (rawData) => {
   syncPromise = $fetch('/api/agent-drafts/current', {
     method: 'PUT',
     body: { expected_version: version.value, definition },
+    keepalive,
   }).then((response) => {
     version.value = response.draft.version
     lastSavedFingerprint.value = JSON.stringify(cleanDefinition(response.draft.definition))
@@ -165,11 +166,14 @@ const syncDraft = (data) => performSync(data).then(() => {
   useAlert().success('Draft saved.')
 })
 
+const draftAutosave = createAgentDraftAutosave(({ keepalive }) => performSync(undefined, keepalive))
+
 const scheduleSync = () => {
   if (loading.value || claiming.value || hydratingEditor.value) return
-  clearTimeout(syncTimer)
-  syncTimer = setTimeout(() => performSync().catch(() => {}), 900)
+  draftAutosave.schedule()
 }
+
+const flushPendingSync = () => draftAutosave.flush().catch(() => {})
 
 watch(() => workingFormStore.content?.data?.(), scheduleSync, { deep: true })
 
@@ -229,6 +233,8 @@ const claimDraft = () => {
 }
 
 onMounted(() => {
+  window.addEventListener('pagehide', flushPendingSync)
+
   const sessionRequest = getAgentDraftSessionRequest(window.location.hash)
   if (sessionRequest.consumesHandoff) {
     window.history.replaceState({}, '', '/agent-drafts/edit')
@@ -255,5 +261,8 @@ onMounted(() => {
   }, { useMessageChannel: false })
 })
 
-onBeforeUnmount(() => clearTimeout(syncTimer))
+onBeforeUnmount(() => {
+  window.removeEventListener('pagehide', flushPendingSync)
+  flushPendingSync()
+})
 </script>

--- a/client/pages/agent-drafts/edit.vue
+++ b/client/pages/agent-drafts/edit.vue
@@ -236,7 +236,7 @@ onMounted(() => {
   }).then((response) => {
     applyDraft(response.draft)
   }).catch((exception) => {
-    fatalError.value = exception?.data?.message || 'This editor link is invalid, expired, or already used. Ask the agent for a fresh link.'
+    fatalError.value = exception?.data?.message || 'This editor link is invalid or expired. Ask the agent for a fresh link.'
   }).finally(() => {
     loading.value = false
     if (!fatalError.value) {

--- a/client/pages/agent-drafts/preview.vue
+++ b/client/pages/agent-drafts/preview.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="min-h-screen bg-neutral-50 p-4 sm:p-8">
+    <div class="mx-auto max-w-5xl">
+      <div class="mb-4 flex items-center justify-between">
+        <div>
+          <p class="text-sm font-medium text-blue-600">Private draft preview</p>
+          <h1 class="text-xl font-semibold text-neutral-900">{{ form?.title || 'OpnForm draft' }}</h1>
+        </div>
+        <UBadge color="neutral" variant="subtle">Expires in 15 minutes</UBadge>
+      </div>
+
+      <div v-if="loading" class="rounded-xl border bg-white p-12 text-center">
+        <Loader class="mx-auto h-6 w-6 text-blue-500" />
+      </div>
+      <UAlert
+        v-else-if="error"
+        color="error"
+        title="This preview is unavailable"
+        :description="error"
+      />
+      <div v-else class="min-h-[650px] overflow-hidden rounded-xl border bg-white shadow-sm">
+        <OpenCompleteForm
+          :form="form"
+          :mode="FormMode.PREVIEW"
+          class="min-h-[650px] w-full"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import OpenCompleteForm from '~/components/open/forms/OpenCompleteForm.vue'
+import { FormMode } from '~/lib/forms/FormModeStrategy.js'
+
+definePageMeta({ layout: 'empty' })
+useOpnSeoMeta({ title: 'Private form draft preview' })
+
+const route = useRoute()
+const config = useRuntimeConfig()
+const loading = ref(true)
+const error = ref(null)
+const form = ref(null)
+provide('disableCustomCodeExecution', true)
+
+onMounted(() => {
+  try {
+    const source = new URL(String(route.query.source || ''))
+    const configuredApi = config.public.apiBase ? new URL(config.public.apiBase, window.location.origin) : null
+    const expectedOrigin = configuredApi?.origin || window.location.origin
+    if (source.origin !== expectedOrigin || !source.pathname.includes('/agent-drafts/preview/')) {
+      throw new Error('The preview link is invalid.')
+    }
+
+    $fetch(source.toString()).then((response) => {
+      form.value = {
+        ...response.draft.definition,
+        plan_tier: 'pro',
+        is_trialing: false,
+        max_file_size: 10,
+        workspace: { plan_tier: 'pro', features: [], limits: {} },
+      }
+    }).catch(() => {
+      error.value = 'The signed preview link has expired or is no longer valid.'
+    }).finally(() => {
+      loading.value = false
+    })
+  } catch (exception) {
+    error.value = exception.message || 'The preview link is invalid.'
+    loading.value = false
+  }
+})
+</script>

--- a/client/server/api/agent-drafts/claim.post.js
+++ b/client/server/api/agent-drafts/claim.post.js
@@ -1,0 +1,7 @@
+import { agentDraftApi } from '../../utils/agentDraftApi'
+
+export default defineEventHandler(async (event) => agentDraftApi(event, '/agent-drafts/editor/claim', {
+  method: 'POST',
+  body: await readBody(event),
+  includeAuth: true,
+}))

--- a/client/server/api/agent-drafts/current.get.js
+++ b/client/server/api/agent-drafts/current.get.js
@@ -1,0 +1,3 @@
+import { agentDraftApi } from '../../utils/agentDraftApi'
+
+export default defineEventHandler((event) => agentDraftApi(event, '/agent-drafts/editor/current'))

--- a/client/server/api/agent-drafts/current.put.js
+++ b/client/server/api/agent-drafts/current.put.js
@@ -1,0 +1,6 @@
+import { agentDraftApi } from '../../utils/agentDraftApi'
+
+export default defineEventHandler(async (event) => agentDraftApi(event, '/agent-drafts/editor/current', {
+  method: 'PUT',
+  body: await readBody(event),
+}))

--- a/client/server/api/agent-drafts/handoff.post.js
+++ b/client/server/api/agent-drafts/handoff.post.js
@@ -1,0 +1,13 @@
+import { agentDraftApi, setAgentDraftSession } from '../../utils/agentDraftApi'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const response = await agentDraftApi(event, '/agent-drafts/handoff/consume', {
+    method: 'POST',
+    body: { handoff_token: body?.handoff_token },
+  })
+
+  setAgentDraftSession(event, response.editor_session, response.draft.expires_at)
+
+  return { draft: response.draft }
+})

--- a/client/server/plugins/embeddable.js
+++ b/client/server/plugins/embeddable.js
@@ -17,7 +17,9 @@ export default defineNitroPlugin((nitroApp) => {
     delete response.headers["X-Frame-Options"]
     delete response.headers["x-frame-options"]
 
-    if (routePath && !routePath.startsWith("/forms/")) {
+    const isEmbeddableRoute = routePath?.startsWith('/forms/') || routePath?.startsWith('/agent-drafts/preview')
+
+    if (routePath && !isEmbeddableRoute) {
       // Build frame-ancestors for non-form routes: localhost variants + matching allowlisted domain (if Referer present)
       // Note: CSP frame-ancestors doesn't support port wildcards, so we list common dev ports
       const commonPorts = ['', ':3000', ':3001', ':4200', ':5000', ':5173', ':8000', ':8080', ':8081', ':9000']
@@ -46,7 +48,7 @@ export default defineNitroPlugin((nitroApp) => {
       // Restrict embedding to localhost + (optionally) matched allowlisted domain
       response.headers["Content-Security-Policy"] = `frame-ancestors ${ancestors.join(' ')};`
     } else {
-      // Forms: embeddable anywhere, omit CSP directive
+      // Public forms and short-lived signed agent previews are embeddable anywhere.
       delete response.headers["Content-Security-Policy"]
     }
 

--- a/client/server/utils/agentDraftApi.js
+++ b/client/server/utils/agentDraftApi.js
@@ -1,0 +1,55 @@
+const SESSION_COOKIE = 'opnform_agent_draft_session'
+
+function apiHeaders(event, includeAuth = false) {
+  const config = useRuntimeConfig(event)
+  const headers = {
+    accept: 'application/json',
+    'x-api-secret': config.apiSecret,
+  }
+  const session = getCookie(event, SESSION_COOKIE)
+  if (session) {
+    headers['x-agent-draft-session'] = session
+  }
+  if (includeAuth) {
+    const token = getCookie(event, 'opnform_token')
+    if (token) {
+      headers.authorization = `Bearer ${token}`
+    }
+  }
+  return headers
+}
+
+export async function agentDraftApi(event, path, options = {}) {
+  const config = useRuntimeConfig(event)
+  const apiBase = config.privateApiBase || config.public.apiBase
+  const { includeAuth = false, headers: optionHeaders, ...fetchOptions } = options
+
+  try {
+    return await $fetch(path, {
+      baseURL: apiBase,
+      ...fetchOptions,
+      headers: {
+        ...apiHeaders(event, includeAuth),
+        ...optionHeaders,
+      },
+    })
+  } catch (error) {
+    throw createError({
+      statusCode: error?.statusCode || error?.response?.status || 500,
+      statusMessage: error?.data?.message || error?.message || 'Agent draft request failed',
+      data: error?.data,
+    })
+  }
+}
+
+export function setAgentDraftSession(event, session, expiresAt) {
+  const requestUrl = getRequestURL(event)
+  const maxAge = Math.max(1, Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000))
+  setCookie(event, SESSION_COOKIE, session, {
+    httpOnly: true,
+    secure: requestUrl.protocol === 'https:',
+    sameSite: 'lax',
+    path: '/',
+    maxAge,
+  })
+}

--- a/client/test/unit/agent-draft-autosave.test.ts
+++ b/client/test/unit/agent-draft-autosave.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAgentDraftAutosave } from '../../lib/forms/agent-draft-autosave.js'
+
+describe('agent draft autosave', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('runs a scheduled save after the debounce', async () => {
+    vi.useFakeTimers()
+    const sync = vi.fn().mockResolvedValue(undefined)
+    const autosave = createAgentDraftAutosave(sync, 900)
+
+    autosave.schedule()
+    await vi.advanceTimersByTimeAsync(900)
+
+    expect(sync).toHaveBeenCalledOnce()
+    expect(sync).toHaveBeenCalledWith({ keepalive: false })
+  })
+
+  it('flushes a pending save with keepalive and cancels the debounce', async () => {
+    vi.useFakeTimers()
+    const sync = vi.fn().mockResolvedValue(undefined)
+    const autosave = createAgentDraftAutosave(sync, 900)
+
+    autosave.schedule()
+    await autosave.flush()
+    await vi.advanceTimersByTimeAsync(900)
+
+    expect(sync).toHaveBeenCalledOnce()
+    expect(sync).toHaveBeenCalledWith({ keepalive: true })
+  })
+})

--- a/client/test/unit/agent-draft-session.test.ts
+++ b/client/test/unit/agent-draft-session.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentDraftSessionRequest } from '../../lib/forms/agent-draft-session'
+
+describe('agent draft editor session requests', () => {
+  it('consumes a handoff capability from the URL fragment', () => {
+    expect(getAgentDraftSessionRequest('#handoff=secret-capability')).toEqual({
+      url: '/api/agent-drafts/handoff',
+      options: {
+        method: 'POST',
+        body: { handoff_token: 'secret-capability' },
+      },
+      consumesHandoff: true,
+    })
+  })
+
+  it('restores the existing cookie session after a refresh', () => {
+    expect(getAgentDraftSessionRequest()).toEqual({
+      url: '/api/agent-drafts/current',
+      options: undefined,
+      consumesHandoff: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add short-lived signed previews and an MCP App preview surface
- add one-time editor handoffs backed by HttpOnly sessions and optimistic versioning
- let signed-in users explicitly claim a guest draft into a writable workspace
- sanitize rich text and disable custom-code execution in agent draft surfaces

## Review
A full code-review pass was completed. Findings around URL token leakage, read-only tool annotations, CSP/frame behavior, implicit claim after login, and agent-supplied HTML/code execution were fixed before opening this PR.

## Validation
- `./vendor/bin/pest -p`: 1880 passed, 3 skipped
- targeted MCP tests: 26 passed
- `./vendor/bin/pint --test`: 871 files passed
- targeted PHPStan: passed
- global PHPStan: only two pre-existing `Workspace::owners` relation findings in the billing backfill command
- `npm run test --if-present`: 714 passed
- `npm run lint`: passed
- Nuxt production build: passed
- end-to-end HTTP handoff, versioned sync, and authenticated claim flow: passed