### PR TITLE
MCP 4/9: Add delegated OAuth account access

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -134,6 +134,11 @@ MCP_RATE_LIMIT_PER_MINUTE=120
 MCP_RATE_LIMIT_PER_HOUR=3000
 MCP_DRAFT_CREATES_PER_MINUTE=20
 MCP_DRAFT_CREATES_PER_HOUR=200
+# Comma-separated OAuth callback origins. Keep this allowlist explicit.
+MCP_OAUTH_REDIRECT_DOMAINS=https://chatgpt.com,https://chat.openai.com,https://claude.ai,http://localhost,http://127.0.0.1,http://[::1]
+MCP_OAUTH_CUSTOM_SCHEMES=chatgpt,claude,cursor,vscode
+# Optional issuer override. Defaults to APP_URL.
+MCP_AUTHORIZATION_SERVER=
 
 STRIPE_CLIENT_ID=
 STRIPE_CLIENT_SECRET=

--- a/api/.env.example
+++ b/api/.env.example
@@ -140,6 +140,13 @@ MCP_OAUTH_CUSTOM_SCHEMES=chatgpt,claude,cursor,vscode
 # Optional issuer override. Defaults to APP_URL.
 MCP_AUTHORIZATION_SERVER=
 
+# Passport OAuth 2.1 is for delegated third-party access. It is enabled by
+# default on OpnForm Cloud and whenever MCP is enabled on a self-hosted instance.
+# Set this only when you need to override that default.
+# OAUTH_ENABLED=true
+OAUTH_ACCESS_TOKEN_TTL=10080
+OAUTH_REFRESH_TOKEN_TTL_DAYS=30
+
 STRIPE_CLIENT_ID=
 STRIPE_CLIENT_SECRET=
 

--- a/api/app/Exceptions/Handler.php
+++ b/api/app/Exceptions/Handler.php
@@ -42,6 +42,10 @@ class Handler extends ExceptionHandler
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
+        if ($request->routeIs('passport.authorizations.authorize')) {
+            return redirect(app(\App\Service\OAuth\McpOAuthSessionService::class)->beginAuthorization($request));
+        }
+
         return response()->json(['message' => $exception->getMessage()], 401);
     }
 

--- a/api/app/Http/Controllers/McpOAuthSessionController.php
+++ b/api/app/Http/Controllers/McpOAuthSessionController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Service\OAuth\McpOAuthSessionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class McpOAuthSessionController extends Controller
+{
+    public function __invoke(Request $request, McpOAuthSessionService $sessions): JsonResponse
+    {
+        $validated = $request->validate([
+            'authorization_request_token' => ['required', 'string', 'size:64'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        return response()->json([
+            'authorization_url' => $sessions->issueLoginTicket(
+                $validated['authorization_request_token'],
+                $user
+            ),
+        ]);
+    }
+}

--- a/api/app/Http/Kernel.php
+++ b/api/app/Http/Kernel.php
@@ -19,6 +19,8 @@ use Illuminate\Routing\Router;
 use App\Http\Middleware\CheckUserIsBlocked;
 use App\Http\Middleware\EnsureCloudInstance;
 use App\Http\Middleware\EnsureSelfHostedInstance;
+use App\Http\Middleware\ConsumeMcpOAuthLoginTicket;
+use App\Http\Middleware\AuthenticateOptionalMcpOAuth;
 
 class Kernel extends HttpKernel
 {
@@ -78,6 +80,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
+            ConsumeMcpOAuthLoginTicket::class,
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
@@ -132,6 +135,7 @@ class Kernel extends HttpKernel
         'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
         'ability' => \Laravel\Sanctum\Http\Middleware\CheckForAnyAbility::class,
         'auth.multi' => \App\Http\Middleware\AuthenticateWithJwtOrSanctum::class,
+        'auth.mcp.optional' => AuthenticateOptionalMcpOAuth::class,
 
         'cloud' => EnsureCloudInstance::class,  // Allow cloud instances only
         'self-hosted' => EnsureSelfHostedInstance::class, // Allow self-hosted instances only

--- a/api/app/Http/Middleware/AuthenticateOptionalMcpOAuth.php
+++ b/api/app/Http/Middleware/AuthenticateOptionalMcpOAuth.php
@@ -16,11 +16,11 @@ class AuthenticateOptionalMcpOAuth
             return $next($request);
         }
 
-        $guard = Auth::guard('mcp');
+        $guard = Auth::guard('oauth');
         $user = $guard->user();
 
         if (! $user || ! $user->tokenCan('mcp:use')) {
-            throw new AuthenticationException('Invalid or insufficient MCP access token.', ['mcp']);
+            throw new AuthenticationException('Invalid or insufficient MCP access token.', ['oauth']);
         }
 
         if ($user->is_blocked) {
@@ -29,7 +29,7 @@ class AuthenticateOptionalMcpOAuth
             ], 403);
         }
 
-        Auth::shouldUse('mcp');
+        Auth::shouldUse('oauth');
         Auth::setUser($user);
 
         return $next($request);

--- a/api/app/Http/Middleware/AuthenticateOptionalMcpOAuth.php
+++ b/api/app/Http/Middleware/AuthenticateOptionalMcpOAuth.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticateOptionalMcpOAuth
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->bearerToken()) {
+            return $next($request);
+        }
+
+        $guard = Auth::guard('mcp');
+        $user = $guard->user();
+
+        if (! $user || ! $user->tokenCan('mcp:use')) {
+            throw new AuthenticationException('Invalid or insufficient MCP access token.', ['mcp']);
+        }
+
+        if ($user->is_blocked) {
+            return response()->json([
+                'message' => 'Your account has been blocked. Please contact support.',
+            ], 403);
+        }
+
+        Auth::shouldUse('mcp');
+        Auth::setUser($user);
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/ConsumeMcpOAuthLoginTicket.php
+++ b/api/app/Http/Middleware/ConsumeMcpOAuthLoginTicket.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Service\OAuth\McpOAuthSessionService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ConsumeMcpOAuthLoginTicket
+{
+    public function __construct(private readonly McpOAuthSessionService $sessions)
+    {
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->routeIs('passport.authorizations.authorize') && $request->filled('mcp_login_ticket')) {
+            $this->sessions->consumeLoginTicket(
+                (string) $request->query('mcp_login_ticket'),
+                $request
+            );
+
+            return redirect($this->sessions->withoutLoginTicket($request));
+        }
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/RequireOAuthS256.php
+++ b/api/app/Http/Middleware/RequireOAuthS256.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequireOAuthS256
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! hash_equals('S256', (string) $request->query('code_challenge_method'))) {
+            return new JsonResponse([
+                'error' => 'invalid_request',
+                'error_description' => 'The code_challenge_method must be S256.',
+            ], 400);
+        }
+
+        return $next($request);
+    }
+}

--- a/api/app/Http/Middleware/SecureOAuthConsent.php
+++ b/api/app/Http/Middleware/SecureOAuthConsent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SecureOAuthConsent
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+        $response->headers->set('Content-Security-Policy', "frame-ancestors 'none'");
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('Referrer-Policy', 'no-referrer');
+        $response->headers->set('Cache-Control', 'no-store, private');
+        $response->headers->set('Pragma', 'no-cache');
+
+        return $response;
+    }
+}

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use App\Models\Billing\Subscription;
-use App\Service\OAuth\McpPassportClientRepository;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
@@ -13,12 +12,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Cashier;
-use Laravel\Passport\ClientRepository;
-use Laravel\Passport\Http\Controllers\AccessTokenController;
-use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
-use Laravel\Passport\Http\Controllers\AuthorizationController;
-use Laravel\Passport\Http\Controllers\DenyAuthorizationController;
-use Laravel\Passport\Passport;
 use RuntimeException;
 use Stripe\StripeClient;
 
@@ -31,14 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if ($this->mcpEnabled()) {
-            Passport::authorizationView('mcp.authorize');
-            Passport::tokensExpireIn(now()->addMinutes((int) config('jwt.ttl', 1440)));
-            Passport::refreshTokensExpireIn(now()->addDays(30));
-
-            $this->registerMcpPassportRoutes();
-        }
-
         if (config('filesystems.default') === 'local') {
             Storage::disk('local')->buildTemporaryUrlsUsing(function ($path, $expiration, $options) {
                 return URL::temporarySignedRoute(
@@ -102,17 +87,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Passport::ignoreRoutes();
-
-        $this->app->singleton(ClientRepository::class, function () {
-            $personalAccessClient = config('passport.personal_access_client', []);
-
-            return new McpPassportClientRepository(
-                $personalAccessClient['id'] ?? null,
-                $personalAccessClient['secret'] ?? null
-            );
-        });
-
         $this->app->singleton(StripeClient::class, function () {
             return new StripeClient(config('cashier.secret'));
         });
@@ -156,30 +130,4 @@ class AppServiceProvider extends ServiceProvider
         throw new RuntimeException('Unsafe testing sqlite configuration detected.');
     }
 
-    private function mcpEnabled(): bool
-    {
-        return ! config('app.self_hosted') || config('opnform.mcp.enabled', false);
-    }
-
-    private function registerMcpPassportRoutes(): void
-    {
-        Route::prefix(config('passport.path', 'oauth'))
-            ->as('passport.')
-            ->group(function () {
-                Route::post('/token', [AccessTokenController::class, 'issueToken'])
-                    ->middleware('throttle')
-                    ->name('token');
-
-                Route::get('/authorize', [AuthorizationController::class, 'authorize'])
-                    ->middleware('web')
-                    ->name('authorizations.authorize');
-
-                Route::middleware(['web', 'auth:web'])->group(function () {
-                    Route::post('/authorize', [ApproveAuthorizationController::class, 'approve'])
-                        ->name('authorizations.approve');
-                    Route::delete('/authorize', [DenyAuthorizationController::class, 'deny'])
-                        ->name('authorizations.deny');
-                });
-            });
-    }
 }

--- a/api/app/Providers/AppServiceProvider.php
+++ b/api/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\Billing\Subscription;
+use App\Service\OAuth\McpPassportClientRepository;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
@@ -12,6 +13,12 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Cashier;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Controllers\AccessTokenController;
+use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
+use Laravel\Passport\Http\Controllers\AuthorizationController;
+use Laravel\Passport\Http\Controllers\DenyAuthorizationController;
+use Laravel\Passport\Passport;
 use RuntimeException;
 use Stripe\StripeClient;
 
@@ -24,6 +31,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->mcpEnabled()) {
+            Passport::authorizationView('mcp.authorize');
+            Passport::tokensExpireIn(now()->addMinutes((int) config('jwt.ttl', 1440)));
+            Passport::refreshTokensExpireIn(now()->addDays(30));
+
+            $this->registerMcpPassportRoutes();
+        }
+
         if (config('filesystems.default') === 'local') {
             Storage::disk('local')->buildTemporaryUrlsUsing(function ($path, $expiration, $options) {
                 return URL::temporarySignedRoute(
@@ -87,6 +102,17 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        Passport::ignoreRoutes();
+
+        $this->app->singleton(ClientRepository::class, function () {
+            $personalAccessClient = config('passport.personal_access_client', []);
+
+            return new McpPassportClientRepository(
+                $personalAccessClient['id'] ?? null,
+                $personalAccessClient['secret'] ?? null
+            );
+        });
+
         $this->app->singleton(StripeClient::class, function () {
             return new StripeClient(config('cashier.secret'));
         });
@@ -128,5 +154,32 @@ class AppServiceProvider extends ServiceProvider
         }
 
         throw new RuntimeException('Unsafe testing sqlite configuration detected.');
+    }
+
+    private function mcpEnabled(): bool
+    {
+        return ! config('app.self_hosted') || config('opnform.mcp.enabled', false);
+    }
+
+    private function registerMcpPassportRoutes(): void
+    {
+        Route::prefix(config('passport.path', 'oauth'))
+            ->as('passport.')
+            ->group(function () {
+                Route::post('/token', [AccessTokenController::class, 'issueToken'])
+                    ->middleware('throttle')
+                    ->name('token');
+
+                Route::get('/authorize', [AuthorizationController::class, 'authorize'])
+                    ->middleware('web')
+                    ->name('authorizations.authorize');
+
+                Route::middleware(['web', 'auth:web'])->group(function () {
+                    Route::post('/authorize', [ApproveAuthorizationController::class, 'approve'])
+                        ->name('authorizations.approve');
+                    Route::delete('/authorize', [DenyAuthorizationController::class, 'deny'])
+                        ->name('authorizations.deny');
+                });
+            });
     }
 }

--- a/api/app/Providers/OAuthServiceProvider.php
+++ b/api/app/Providers/OAuthServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Providers;
+
+use App\Service\OAuth\McpPassportClientRepository;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
+
+final class OAuthServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        Passport::ignoreRoutes();
+
+        // Laravel MCP currently resolves Passport's concrete repository from
+        // the container. This adapter keeps dynamic PKCE registration working
+        // with Passport 12 until the project can upgrade to Passport 13.
+        $this->app->singleton(ClientRepository::class, function () {
+            $personalAccessClient = config('passport.personal_access_client', []);
+
+            return new McpPassportClientRepository(
+                $personalAccessClient['id'] ?? null,
+                $personalAccessClient['secret'] ?? null
+            );
+        });
+    }
+
+    public function boot(): void
+    {
+        if (! config('oauth.enabled', false)) {
+            return;
+        }
+
+        Passport::authorizationView('oauth.authorize');
+        Passport::tokensCan(config('oauth.scopes', []));
+        Passport::tokensExpireIn(now()->addMinutes(max(1, (int) config('oauth.access_token_ttl', 10080))));
+        Passport::refreshTokensExpireIn(now()->addDays(max(1, (int) config('oauth.refresh_token_ttl_days', 30))));
+
+        Route::group([], base_path('routes/oauth.php'));
+    }
+}

--- a/api/app/Providers/RouteServiceProvider.php
+++ b/api/app/Providers/RouteServiceProvider.php
@@ -122,6 +122,10 @@ class RouteServiceProvider extends ServiceProvider
                     ->by('mcp:hour:'.$identifier),
             ];
         });
+
+        RateLimiter::for('mcp-oauth-registration', function (Request $request) {
+            return Limit::perHour(20)->by('mcp-oauth-registration:'.$request->ip());
+        });
     }
 
     protected function registerGlobalRouteParamConstraints()

--- a/api/app/Service/OAuth/McpOAuthSessionService.php
+++ b/api/app/Service/OAuth/McpOAuthSessionService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Service\OAuth;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class McpOAuthSessionService
+{
+    private const AUTHORIZATION_REQUEST_PREFIX = 'mcp:oauth:authorization-request:';
+
+    private const LOGIN_TICKET_PREFIX = 'mcp:oauth:login-ticket:';
+
+    public function beginAuthorization(Request $request): string
+    {
+        $frontUrl = rtrim((string) config('app.front_url'), '/');
+        if (! filter_var($frontUrl, FILTER_VALIDATE_URL)) {
+            throw new RuntimeException('FRONT_URL must be configured to use MCP OAuth.');
+        }
+
+        $token = Str::random(64);
+
+        Cache::put(
+            self::AUTHORIZATION_REQUEST_PREFIX.hash('sha256', $token),
+            $request->getRequestUri(),
+            now()->addMinutes(10)
+        );
+
+        return $frontUrl.'/mcp/authorize?request='.rawurlencode($token);
+    }
+
+    public function issueLoginTicket(string $authorizationRequestToken, User $user): string
+    {
+        $requestUri = Cache::pull(
+            self::AUTHORIZATION_REQUEST_PREFIX.hash('sha256', $authorizationRequestToken)
+        );
+
+        if (! is_string($requestUri) || ! $this->isAuthorizationRequestUri($requestUri)) {
+            throw new BadRequestHttpException('This OAuth authorization request is invalid or has expired.');
+        }
+
+        $ticket = Str::random(64);
+
+        Cache::put(
+            self::LOGIN_TICKET_PREFIX.hash('sha256', $ticket),
+            [
+                'user_id' => $user->getAuthIdentifier(),
+                'request_uri' => $this->removeQueryParameter($requestUri, 'mcp_login_ticket'),
+            ],
+            now()->addMinutes(5)
+        );
+
+        return url($this->appendQueryParameter($requestUri, 'mcp_login_ticket', $ticket));
+    }
+
+    public function consumeLoginTicket(string $ticket, Request $request): void
+    {
+        $ticketData = Cache::pull(self::LOGIN_TICKET_PREFIX.hash('sha256', $ticket));
+        $expectedRequestUri = is_array($ticketData) ? ($ticketData['request_uri'] ?? null) : null;
+        $userId = is_array($ticketData) ? ($ticketData['user_id'] ?? null) : null;
+
+        if ((! is_int($userId) && ! is_string($userId))
+            || ! is_string($expectedRequestUri)
+            || ! hash_equals(
+                $expectedRequestUri,
+                $this->removeQueryParameter($request->getRequestUri(), 'mcp_login_ticket')
+            )) {
+            throw new AccessDeniedHttpException('This MCP login ticket is invalid or has expired.');
+        }
+
+        Auth::guard('web')->loginUsingId($userId);
+        $request->session()->regenerate();
+    }
+
+    public function withoutLoginTicket(Request $request): string
+    {
+        $query = $request->query();
+        unset($query['mcp_login_ticket']);
+
+        return $request->url().($query === [] ? '' : '?'.http_build_query($query));
+    }
+
+    private function isAuthorizationRequestUri(string $uri): bool
+    {
+        $parts = parse_url($uri);
+        $expectedPath = '/'.trim((string) config('passport.path', 'oauth'), '/').'/authorize';
+
+        return is_array($parts)
+            && ($parts['path'] ?? null) === $expectedPath
+            && isset($parts['query']);
+    }
+
+    private function appendQueryParameter(string $uri, string $name, string $value): string
+    {
+        $separator = str_contains($uri, '?') ? '&' : '?';
+
+        return $uri.$separator.rawurlencode($name).'='.rawurlencode($value);
+    }
+
+    private function removeQueryParameter(string $uri, string $name): string
+    {
+        $parts = parse_url($uri);
+        parse_str((string) ($parts['query'] ?? ''), $query);
+        unset($query[$name]);
+
+        $path = (string) ($parts['path'] ?? '');
+
+        return $path.($query === [] ? '' : '?'.http_build_query($query));
+    }
+}

--- a/api/app/Service/OAuth/McpPassportClientRepository.php
+++ b/api/app/Service/OAuth/McpPassportClientRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Service\OAuth;
+
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+
+class McpPassportClientRepository extends ClientRepository
+{
+    /**
+     * Compatibility bridge for Laravel MCP dynamic registration on Passport 12.
+     *
+     * Passport 13 cannot coexist with OpnForm's current JWT dependency because
+     * they require incompatible major versions of lcobucci/jwt.
+     *
+     * @param  array<int, string>  $redirectUris
+     */
+    public function createAuthorizationCodeGrantClient(
+        string $name,
+        array $redirectUris,
+        bool $confidential,
+        bool $enableDeviceFlow
+    ): Client {
+        $client = $this->create(
+            null,
+            $name,
+            implode(',', $redirectUris),
+            null,
+            false,
+            false,
+            $confidential
+        );
+
+        // Laravel MCP uses Passport 13's response attributes. Keep them
+        // in-memory while Passport 12 persists its equivalent redirect field.
+        $client->setAttribute('redirect_uris', $redirectUris);
+        $client->setAttribute('grant_types', ['authorization_code', 'refresh_token']);
+
+        return $client;
+    }
+}

--- a/api/composer.json
+++ b/api/composer.json
@@ -27,6 +27,7 @@
         "laravel/framework": "^11.9",
         "laravel/horizon": "*",
         "laravel/mcp": "^0.8.2",
+        "laravel/passport": "^12.4",
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "*",
         "laravel/tinker": "^2.9",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8e3bf9d56c6816dc39d17008ae46c1c",
+    "content-hash": "bc379d303aea32fd8c42afd5db155ba1",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -612,6 +612,73 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/f53396c2d34225064647a05ca76c1da9d99e5828",
+                "reference": "f53396c2d34225064647a05ca76c1da9d99e5828",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5|^6|^7|^8|^9|^10",
+                "yoast/phpunit-polyfills": "^2.0.0"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/v2.4.0"
+            },
+            "time": "2023-06-19T06:10:36+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -3379,6 +3446,82 @@
             "time": "2026-06-25T14:00:45+00:00"
         },
         {
+            "name": "laravel/passport",
+            "version": "v12.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/passport.git",
+                "reference": "1d2e0170a52f150d5c35c9a6fc1f7ccebcde7626"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/passport/zipball/1d2e0170a52f150d5c35c9a6fc1f7ccebcde7626",
+                "reference": "1d2e0170a52f150d5c35c9a6fc1f7ccebcde7626",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "illuminate/auth": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/console": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/container": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/cookie": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/database": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/encryption": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/http": "^9.21|^10.0|^11.0|^12.0",
+                "illuminate/support": "^9.21|^10.0|^11.0|^12.0",
+                "lcobucci/jwt": "^4.3|^5.0",
+                "league/oauth2-server": "^8.5.3",
+                "nyholm/psr7": "^1.5",
+                "php": "^8.0",
+                "phpseclib/phpseclib": "^2.0|^3.0",
+                "symfony/console": "^6.0|^7.0",
+                "symfony/psr-http-message-bridge": "^2.1|^6.0|^7.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.35|^8.14|^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.3|^10.5|^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Passport\\PassportServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Passport\\": "src/",
+                    "Laravel\\Passport\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Passport provides OAuth2 server support to Laravel.",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "passport"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/passport/issues",
+                "source": "https://github.com/laravel/passport"
+            },
+            "time": "2026-02-19T14:14:05+00:00"
+        },
+        {
             "name": "laravel/prompts",
             "version": "v0.3.13",
             "source": {
@@ -4239,6 +4382,60 @@
             "time": "2022-12-11T20:36:23+00:00"
         },
         {
+            "name": "league/event",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "062ebb450efbe9a09bc2478e89b7c933875b0935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/062ebb450efbe9a09bc2478e89b7c933875b0935",
+                "reference": "062ebb450efbe9a09bc2478e89b7c933875b0935",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/2.3.0"
+            },
+            "time": "2025-03-14T19:51:10+00:00"
+        },
+        {
             "name": "league/flysystem",
             "version": "3.31.0",
             "source": {
@@ -4556,6 +4753,94 @@
                 "source": "https://github.com/thephpleague/oauth1-client/tree/v1.11.0"
             },
             "time": "2024-12-10T19:59:05+00:00"
+        },
+        {
+            "name": "league/oauth2-server",
+            "version": "8.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "cc8778350f905667e796b3c2364a9d3bd7a73518"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/cc8778350f905667e796b3c2364a9d3bd7a73518",
+                "reference": "cc8778350f905667e796b3c2364a9d3bd7a73518",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.3",
+                "ext-openssl": "*",
+                "lcobucci/clock": "^2.2 || ^3.0",
+                "lcobucci/jwt": "^4.3 || ^5.0",
+                "league/event": "^2.2",
+                "league/uri": "^6.7 || ^7.0",
+                "php": "^8.0",
+                "psr/http-message": "^1.0.1 || ^2.0"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^3.0.0",
+                "phpstan/phpstan": "^0.12.57",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^9.6.6",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-20T23:06:10+00:00"
         },
         {
             "name": "league/uri",

--- a/api/config/app.php
+++ b/api/config/app.php
@@ -238,6 +238,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
+        App\Providers\OAuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\HorizonServiceProvider::class,

--- a/api/config/auth.php
+++ b/api/config/auth.php
@@ -47,7 +47,7 @@ return [
             'hash' => false,
         ],
 
-        'mcp' => [
+        'oauth' => [
             'driver' => 'passport',
             'provider' => 'users',
         ],

--- a/api/config/auth.php
+++ b/api/config/auth.php
@@ -46,6 +46,11 @@ return [
             'provider' => 'users',
             'hash' => false,
         ],
+
+        'mcp' => [
+            'driver' => 'passport',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/api/config/mcp.php
+++ b/api/config/mcp.php
@@ -20,5 +20,5 @@ $customSchemes = array_values(array_filter(array_map(
 return [
     'redirect_domains' => $redirectDomains,
     'custom_schemes' => $customSchemes,
-    'authorization_server' => env('MCP_AUTHORIZATION_SERVER'),
+    'authorization_server' => env('MCP_AUTHORIZATION_SERVER') ?: null,
 ];

--- a/api/config/mcp.php
+++ b/api/config/mcp.php
@@ -1,0 +1,24 @@
+<?php
+
+$redirectDomains = array_values(array_filter(array_map(
+    'trim',
+    explode(',', env('MCP_OAUTH_REDIRECT_DOMAINS', implode(',', [
+        'https://chatgpt.com',
+        'https://chat.openai.com',
+        'https://claude.ai',
+        'http://localhost',
+        'http://127.0.0.1',
+        'http://[::1]',
+    ])))
+)));
+
+$customSchemes = array_values(array_filter(array_map(
+    'trim',
+    explode(',', env('MCP_OAUTH_CUSTOM_SCHEMES', 'chatgpt,claude,cursor,vscode'))
+)));
+
+return [
+    'redirect_domains' => $redirectDomains,
+    'custom_schemes' => $customSchemes,
+    'authorization_server' => env('MCP_AUTHORIZATION_SERVER'),
+];

--- a/api/config/oauth.php
+++ b/api/config/oauth.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Delegated OAuth 2.1
+    |--------------------------------------------------------------------------
+    |
+    | Passport is reserved for third-party clients that need delegated access.
+    | It remains separate from the JWT used by the first-party frontend and
+    | from Sanctum personal access tokens.
+    |
+    */
+    'enabled' => env(
+        'OAUTH_ENABLED',
+        ! env('SELF_HOSTED', true) || env('MCP_ENABLED', false)
+    ),
+
+    'access_token_ttl' => (int) env('OAUTH_ACCESS_TOKEN_TTL', 60 * 24 * 7),
+    'refresh_token_ttl_days' => (int) env('OAUTH_REFRESH_TOKEN_TTL_DAYS', 30),
+
+    'scopes' => [
+        'mcp:use' => 'Use OpnForm MCP features to access the forms and submissions you explicitly ask the assistant to manage.',
+    ],
+];

--- a/api/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/api/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_auth_codes', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->unsignedBigInteger('user_id')->index();
+            $table->unsignedBigInteger('client_id');
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_auth_codes');
+    }
+};

--- a/api/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/api/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_access_tokens', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->unsignedBigInteger('client_id');
+            $table->string('name')->nullable();
+            $table->text('scopes')->nullable();
+            $table->boolean('revoked');
+            $table->timestamps();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_access_tokens');
+    }
+};

--- a/api/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/api/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_refresh_tokens', function (Blueprint $table) {
+            $table->string('id', 100)->primary();
+            $table->string('access_token_id', 100)->index();
+            $table->boolean('revoked');
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_refresh_tokens');
+    }
+};

--- a/api/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/api/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_clients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->nullable()->index();
+            $table->string('name');
+            $table->string('secret', 100)->nullable();
+            $table->string('provider')->nullable();
+            $table->text('redirect');
+            $table->boolean('personal_access_client');
+            $table->boolean('password_client');
+            $table->boolean('revoked');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_clients');
+    }
+};

--- a/api/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/api/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_personal_access_clients', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('client_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_personal_access_clients');
+    }
+};

--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -12,6 +12,7 @@
     <server name="APP_DEBUG" value="true"/>
     <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
     <server name="APP_NAME" value="NotionForms TESTING"/>
+    <server name="APP_URL" value="http://localhost"/>
     <server name="APP_ENV" value="testing"/>
     <server name="BCRYPT_ROUNDS" value="4"/>
     <server name="CACHE_DRIVER" value="array"/>

--- a/api/resources/views/mcp/authorize.blade.php
+++ b/api/resources/views/mcp/authorize.blade.php
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Authorize {{ $client->name }} - OpnForm</title>
+    <style>
+        * { box-sizing: border-box; }
+        body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; background: #f8fafc; color: #0f172a; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+        .card { width: 100%; max-width: 440px; padding: 32px; border: 1px solid #e2e8f0; border-radius: 20px; background: white; box-shadow: 0 20px 50px rgba(15, 23, 42, .08); }
+        .mark { display: grid; place-items: center; width: 48px; height: 48px; margin: 0 auto; border-radius: 14px; background: #eff6ff; color: #2563eb; font-size: 24px; }
+        h1 { margin: 20px 0 8px; text-align: center; font-size: 24px; line-height: 1.2; }
+        .intro { margin: 0; text-align: center; color: #64748b; line-height: 1.5; }
+        .account, .permission { margin-top: 24px; padding: 16px; border-radius: 12px; background: #f8fafc; }
+        .label { margin: 0 0 6px; color: #64748b; font-size: 13px; }
+        .value { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
+        .permission { display: flex; gap: 10px; align-items: flex-start; margin-top: 12px; }
+        .permission span { color: #2563eb; }
+        .permission p { margin: 0; color: #334155; font-size: 14px; line-height: 1.45; }
+        .actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 28px; }
+        form { margin: 0; }
+        button { width: 100%; min-height: 44px; border-radius: 10px; border: 1px solid #cbd5e1; background: white; color: #0f172a; font: inherit; font-weight: 600; cursor: pointer; }
+        button.primary { border-color: #2563eb; background: #2563eb; color: white; }
+        button:hover { filter: brightness(.97); }
+    </style>
+</head>
+<body>
+<main class="card">
+    <div class="mark" aria-hidden="true">✓</div>
+    <h1>Connect {{ $client->name }}</h1>
+    <p class="intro">Review the access requested for your OpnForm account.</p>
+
+    <section class="account">
+        <p class="label">Signed in as</p>
+        <p class="value">{{ $user->email }}</p>
+    </section>
+
+    <section class="permission">
+        <span aria-hidden="true">●</span>
+        <p>Use OpnForm MCP features to access the forms and submissions you explicitly ask the assistant to manage.</p>
+    </section>
+
+    <div class="actions">
+        <form method="POST" action="{{ route('passport.authorizations.deny') }}">
+            @csrf
+            @method('DELETE')
+            <input type="hidden" name="state" value="">
+            <input type="hidden" name="client_id" value="{{ $client->id }}">
+            <input type="hidden" name="auth_token" value="{{ $authToken }}">
+            <button type="submit">Cancel</button>
+        </form>
+
+        <form method="POST" action="{{ route('passport.authorizations.approve') }}">
+            @csrf
+            <input type="hidden" name="state" value="">
+            <input type="hidden" name="client_id" value="{{ $client->id }}">
+            <input type="hidden" name="auth_token" value="{{ $authToken }}">
+            <button type="submit" class="primary">Authorize</button>
+        </form>
+    </div>
+</main>
+</body>
+</html>

--- a/api/resources/views/oauth/authorize.blade.php
+++ b/api/resources/views/oauth/authorize.blade.php
@@ -12,7 +12,7 @@
         .mark { display: grid; place-items: center; width: 48px; height: 48px; margin: 0 auto; border-radius: 14px; background: #eff6ff; color: #2563eb; font-size: 24px; }
         h1 { margin: 20px 0 8px; text-align: center; font-size: 24px; line-height: 1.2; }
         .intro { margin: 0; text-align: center; color: #64748b; line-height: 1.5; }
-        .account, .permission { margin-top: 24px; padding: 16px; border-radius: 12px; background: #f8fafc; }
+        .account, .destination, .permission { margin-top: 24px; padding: 16px; border-radius: 12px; background: #f8fafc; }
         .label { margin: 0 0 6px; color: #64748b; font-size: 13px; }
         .value { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
         .permission { display: flex; gap: 10px; align-items: flex-start; margin-top: 12px; }
@@ -36,10 +36,17 @@
         <p class="value">{{ $user->email }}</p>
     </section>
 
-    <section class="permission">
-        <span aria-hidden="true">●</span>
-        <p>Use OpnForm MCP features to access the forms and submissions you explicitly ask the assistant to manage.</p>
+    <section class="destination">
+        <p class="label">Callback destination</p>
+        <p class="value">{{ $request->query('redirect_uri') }}</p>
     </section>
+
+    @foreach ($scopes as $scope)
+        <section class="permission">
+            <span aria-hidden="true">●</span>
+            <p>{{ $scope->description }}</p>
+        </section>
+    @endforeach
 
     <div class="actions">
         <form method="POST" action="{{ route('passport.authorizations.deny') }}">

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -7,9 +7,12 @@ use Laravel\Mcp\Facades\Mcp;
 use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
 
 if (app(McpAvailability::class)->enabled()) {
-    Mcp::oauthRoutes();
-    Route::post('/oauth/register', OAuthRegisterController::class)
-        ->middleware('throttle:mcp-oauth-registration');
+    if (config('oauth.enabled', false)) {
+        Mcp::oauthRoutes();
+        Route::post('/oauth/register', OAuthRegisterController::class)
+            ->middleware('throttle:mcp-oauth-registration');
+    }
+
     Mcp::web('/mcp', OpnFormServer::class)->middleware(['auth.mcp.optional', 'throttle:mcp']);
     Mcp::local('opnform', OpnFormServer::class);
 }

--- a/api/routes/ai.php
+++ b/api/routes/ai.php
@@ -2,9 +2,14 @@
 
 use App\Mcp\Servers\OpnFormServer;
 use App\Support\Mcp\McpAvailability;
+use Illuminate\Support\Facades\Route;
 use Laravel\Mcp\Facades\Mcp;
+use Laravel\Mcp\Server\Http\Controllers\OAuthRegisterController;
 
 if (app(McpAvailability::class)->enabled()) {
-    Mcp::web('/mcp', OpnFormServer::class)->middleware('throttle:mcp');
+    Mcp::oauthRoutes();
+    Route::post('/oauth/register', OAuthRegisterController::class)
+        ->middleware('throttle:mcp-oauth-registration');
+    Mcp::web('/mcp', OpnFormServer::class)->middleware(['auth.mcp.optional', 'throttle:mcp']);
     Mcp::local('opnform', OpnFormServer::class);
 }

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -74,7 +74,7 @@ if (app(McpAvailability::class)->enabled()) {
     });
 }
 
-if (! config('app.self_hosted') || config('opnform.mcp.enabled', false)) {
+if (app(McpAvailability::class)->enabled() && config('oauth.enabled', false)) {
     Route::post('/mcp-oauth/session', McpOAuthSessionController::class)
         ->middleware(['auth.multi', 'throttle:30,1'])
         ->name('mcp-oauth.session');

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -31,11 +31,13 @@ use App\Http\Controllers\WorkspaceController;
 use App\Http\Controllers\WorkspaceUserController;
 use App\Http\Controllers\VersionController;
 use App\Service\Storage\SafeFileResponseService;
+use App\Support\Mcp\McpAvailability;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HealthCheckController;
 use App\Http\Controllers\AgentFormDraftController;
+use App\Http\Controllers\McpOAuthSessionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -52,23 +54,31 @@ if (config('app.self_hosted')) {
     Route::get('/healthcheck', [HealthCheckController::class, 'apiCheck']);
 }
 
-Route::prefix('agent-drafts')->name('agent-drafts.')->group(function () {
-    Route::get('/preview/{draft}', [AgentFormDraftController::class, 'preview'])
-        ->middleware(['signed', 'throttle:60,1'])
-        ->name('preview');
-    Route::post('/handoff/consume', [AgentFormDraftController::class, 'consume'])
-        ->middleware('throttle:30,1')
-        ->name('handoff.consume');
-    Route::get('/editor/current', [AgentFormDraftController::class, 'current'])
-        ->middleware('throttle:120,1')
-        ->name('editor.current');
-    Route::put('/editor/current', [AgentFormDraftController::class, 'replace'])
-        ->middleware('throttle:120,1')
-        ->name('editor.replace');
-    Route::post('/editor/claim', [AgentFormDraftController::class, 'claim'])
+if (app(McpAvailability::class)->enabled()) {
+    Route::prefix('agent-drafts')->name('agent-drafts.')->group(function () {
+        Route::get('/preview/{draft}', [AgentFormDraftController::class, 'preview'])
+            ->middleware(['signed', 'throttle:60,1'])
+            ->name('preview');
+        Route::post('/handoff/consume', [AgentFormDraftController::class, 'consume'])
+            ->middleware('throttle:30,1')
+            ->name('handoff.consume');
+        Route::get('/editor/current', [AgentFormDraftController::class, 'current'])
+            ->middleware('throttle:120,1')
+            ->name('editor.current');
+        Route::put('/editor/current', [AgentFormDraftController::class, 'replace'])
+            ->middleware('throttle:120,1')
+            ->name('editor.replace');
+        Route::post('/editor/claim', [AgentFormDraftController::class, 'claim'])
+            ->middleware(['auth.multi', 'throttle:30,1'])
+            ->name('editor.claim');
+    });
+}
+
+if (! config('app.self_hosted') || config('opnform.mcp.enabled', false)) {
+    Route::post('/mcp-oauth/session', McpOAuthSessionController::class)
         ->middleware(['auth.multi', 'throttle:30,1'])
-        ->name('editor.claim');
-});
+        ->name('mcp-oauth.session');
+}
 
 Route::prefix('open')->name('open.')->group(function () {
     Route::prefix('forms')->name('forms.')->group(function () {

--- a/api/routes/oauth.php
+++ b/api/routes/oauth.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Http\Middleware\RequireOAuthS256;
+use App\Http\Middleware\SecureOAuthConsent;
+use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Http\Controllers\AccessTokenController;
+use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
+use Laravel\Passport\Http\Controllers\AuthorizationController;
+use Laravel\Passport\Http\Controllers\DenyAuthorizationController;
+
+Route::prefix(config('passport.path', 'oauth'))
+    ->as('passport.')
+    ->group(function () {
+        Route::post('/token', [AccessTokenController::class, 'issueToken'])
+            ->middleware('throttle')
+            ->name('token');
+
+        Route::get('/authorize', [AuthorizationController::class, 'authorize'])
+            ->middleware(['web', RequireOAuthS256::class, SecureOAuthConsent::class])
+            ->name('authorizations.authorize');
+
+        Route::middleware(['web', 'auth:web', SecureOAuthConsent::class])->group(function () {
+            Route::post('/authorize', [ApproveAuthorizationController::class, 'approve'])
+                ->name('authorizations.approve');
+            Route::delete('/authorize', [DenyAuthorizationController::class, 'deny'])
+                ->name('authorizations.deny');
+        });
+    });

--- a/api/tests/CreatesApplication.php
+++ b/api/tests/CreatesApplication.php
@@ -3,9 +3,16 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+use RuntimeException;
 
 trait CreatesApplication
 {
+    /**
+     * @var array{private: string, public: string}|null
+     */
+    private static ?array $passportTestKeys = null;
+
     /**
      * Creates the application.
      *
@@ -16,7 +23,37 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+        $this->configurePassportTestKeys($app);
 
         return $app;
+    }
+
+    private function configurePassportTestKeys(Application $app): void
+    {
+        if (self::$passportTestKeys === null) {
+            $key = openssl_pkey_new([
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]);
+
+            if ($key === false || ! openssl_pkey_export($key, $privateKey)) {
+                throw new RuntimeException('Unable to generate the Passport test private key.');
+            }
+
+            $details = openssl_pkey_get_details($key);
+            if ($details === false || ! is_string($details['key'] ?? null)) {
+                throw new RuntimeException('Unable to generate the Passport test public key.');
+            }
+
+            self::$passportTestKeys = [
+                'private' => $privateKey,
+                'public' => $details['key'],
+            ];
+        }
+
+        $app->make('config')->set([
+            'passport.private_key' => self::$passportTestKeys['private'],
+            'passport.public_key' => self::$passportTestKeys['public'],
+        ]);
     }
 }

--- a/api/tests/Feature/Mcp/McpAvailabilityTest.php
+++ b/api/tests/Feature/Mcp/McpAvailabilityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\Mcp\McpAvailability;
+use Symfony\Component\Process\Process;
 
 it('enables MCP on cloud instances regardless of the self-hosted opt-in flag', function (bool $configured) {
     config()->set('app.self_hosted', false);
@@ -18,3 +19,44 @@ it('requires self-hosted instances to opt in to MCP', function (bool $configured
     'disabled' => [false, false],
     'enabled' => [true, true],
 ]);
+
+it('does not register MCP routes when a self-hosted instance has not opted in', function () {
+    $process = new Process(
+        [PHP_BINARY, 'artisan', 'route:list', '--json'],
+        base_path(),
+        ['SELF_HOSTED' => 'true', 'MCP_ENABLED' => 'false'],
+    );
+    $process->mustRun();
+
+    $routes = collect(json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR));
+
+    expect($routes->pluck('uri')->all())
+        ->not->toContain('mcp')
+        ->not->toContain('api/agent-drafts/preview/{draft}')
+        ->not->toContain('api/mcp-oauth/session')
+        ->not->toContain('oauth/token')
+        ->not->toContain('oauth/authorize');
+});
+
+it('can expose guest MCP without delegated OAuth routes', function () {
+    $process = new Process(
+        [PHP_BINARY, 'artisan', 'route:list', '--json'],
+        base_path(),
+        [
+            'SELF_HOSTED' => 'true',
+            'MCP_ENABLED' => 'true',
+            'OAUTH_ENABLED' => 'false',
+        ],
+    );
+    $process->mustRun();
+
+    $routes = collect(json_decode($process->getOutput(), true, flags: JSON_THROW_ON_ERROR));
+    $uris = $routes->pluck('uri')->all();
+
+    expect($uris)
+        ->toContain('mcp')
+        ->not->toContain('api/mcp-oauth/session')
+        ->not->toContain('oauth/token')
+        ->not->toContain('oauth/authorize')
+        ->not->toContain('.well-known/oauth-authorization-server');
+});

--- a/api/tests/Feature/Mcp/McpOAuthTest.php
+++ b/api/tests/Feature/Mcp/McpOAuthTest.php
@@ -1,0 +1,232 @@
+<?php
+
+use App\Models\User;
+use App\Service\OAuth\McpOAuthSessionService;
+use Illuminate\Http\Request;
+use Laravel\Passport\Passport;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+beforeEach(function () {
+    $key = openssl_pkey_new([
+        'digest_alg' => 'sha256',
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    openssl_pkey_export($key, $privateKey);
+    $publicKey = openssl_pkey_get_details($key)['key'];
+
+    config()->set('passport.private_key', $privateKey);
+    config()->set('passport.public_key', $publicKey);
+});
+
+function mcpInitializePayload(): array
+{
+    return [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'initialize',
+        'params' => [
+            'protocolVersion' => '2025-06-18',
+            'capabilities' => [],
+            'clientInfo' => [
+                'name' => 'OAuth test client',
+                'version' => '1.0.0',
+            ],
+        ],
+    ];
+}
+
+function mcpHeaders(array $extra = []): array
+{
+    return array_merge([
+        'Accept' => 'application/json, text/event-stream',
+    ], $extra);
+}
+
+it('publishes OAuth 2.1 discovery metadata for the unified MCP endpoint', function () {
+    $this->getJson('/.well-known/oauth-protected-resource/mcp')
+        ->assertOk()
+        ->assertJsonPath('resource', url('/mcp'))
+        ->assertJsonPath('authorization_servers.0', url('/'))
+        ->assertJsonPath('scopes_supported.0', 'mcp:use');
+
+    $this->getJson('/.well-known/oauth-authorization-server')
+        ->assertOk()
+        ->assertJsonPath('authorization_endpoint', route('passport.authorizations.authorize'))
+        ->assertJsonPath('token_endpoint', route('passport.token'))
+        ->assertJsonPath('registration_endpoint', url('/oauth/register'))
+        ->assertJsonPath('code_challenge_methods_supported.0', 'S256')
+        ->assertJsonPath('scopes_supported.0', 'mcp:use');
+});
+
+it('dynamically registers public PKCE clients only for allowed redirects', function () {
+    $this->postJson('/oauth/register', [
+        'client_name' => 'ChatGPT',
+        'redirect_uris' => ['https://chatgpt.com/connector_platform_oauth_redirect'],
+    ])->assertCreated()
+        ->assertJsonPath('token_endpoint_auth_method', 'none')
+        ->assertJsonPath('scope', 'mcp:use')
+        ->assertJsonPath('redirect_uris.0', 'https://chatgpt.com/connector_platform_oauth_redirect');
+
+    $this->assertDatabaseCount('oauth_clients', 1);
+
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Untrusted client',
+        'redirect_uris' => ['https://attacker.example/callback'],
+    ])->assertBadRequest()
+        ->assertJsonPath('error', 'invalid_redirect_uri');
+
+    $this->assertDatabaseCount('oauth_clients', 1);
+});
+
+it('keeps guest MCP available while accepting properly scoped Passport users', function () {
+    $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders())
+        ->assertOk();
+
+    $user = User::factory()->create();
+    Passport::actingAs($user, ['mcp:use'], 'mcp');
+
+    $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
+        'Authorization' => 'Bearer test-passport-token',
+    ]))->assertOk();
+});
+
+it('completes PKCE authorization and uses the issued bearer token on the same endpoint', function () {
+    $registration = $this->postJson('/oauth/register', [
+        'client_name' => 'MCP integration test',
+        'redirect_uris' => ['http://localhost/callback'],
+    ])->assertCreated();
+
+    $clientId = $registration->json('client_id');
+    $verifier = str_repeat('a', 64);
+    $challenge = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    $authorizationQuery = http_build_query([
+        'client_id' => $clientId,
+        'redirect_uri' => 'http://localhost/callback',
+        'response_type' => 'code',
+        'scope' => 'mcp:use',
+        'state' => 'oauth-state',
+        'code_challenge' => $challenge,
+        'code_challenge_method' => 'S256',
+    ]);
+
+    $user = User::factory()->create();
+    $consent = $this->actingAs($user, 'web')
+        ->get('/oauth/authorize?'.$authorizationQuery)
+        ->assertOk()
+        ->assertSee('Connect MCP integration test');
+
+    preg_match('/name="auth_token" value="([^"]+)"/', $consent->getContent(), $authTokenMatch);
+
+    $approval = $this->actingAs($user, 'web')->post('/oauth/authorize', [
+        'client_id' => $clientId,
+        'auth_token' => $authTokenMatch[1],
+    ])->assertRedirect();
+
+    parse_str((string) parse_url($approval->headers->get('Location'), PHP_URL_QUERY), $callbackQuery);
+
+    $token = $this->post('/oauth/token', [
+        'grant_type' => 'authorization_code',
+        'client_id' => $clientId,
+        'redirect_uri' => 'http://localhost/callback',
+        'code_verifier' => $verifier,
+        'code' => $callbackQuery['code'],
+    ])->assertOk();
+
+    $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
+        'Authorization' => 'Bearer '.$token->json('access_token'),
+    ]))->assertOk();
+});
+
+it('rejects an OAuth token without the MCP scope and advertises discovery', function () {
+    $user = User::factory()->create();
+    Passport::actingAs($user, [], 'mcp');
+
+    $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
+        'Authorization' => 'Bearer insufficient-token',
+    ]))->assertUnauthorized()
+        ->assertHeader('WWW-Authenticate');
+});
+
+it('rejects MCP access for blocked authenticated accounts', function () {
+    $user = User::factory()->create(['blocked_at' => now()]);
+    Passport::actingAs($user, ['mcp:use'], 'mcp');
+
+    $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
+        'Authorization' => 'Bearer blocked-user-token',
+    ]))->assertForbidden()
+        ->assertJsonPath('message', 'Your account has been blocked. Please contact support.');
+});
+
+it('bridges normal frontend authentication into a one-time Passport web session', function () {
+    config()->set('app.front_url', 'https://opnform.test');
+    $sessions = app(McpOAuthSessionService::class);
+    $oauthRequest = Request::create(
+        '/oauth/authorize?client_id=7&redirect_uri=https%3A%2F%2Fchatgpt.com%2Fcallback&response_type=code&scope=mcp%3Ause&state=state-1&code_challenge=challenge&code_challenge_method=S256',
+        'GET'
+    );
+
+    $frontendUrl = $sessions->beginAuthorization($oauthRequest);
+    parse_str((string) parse_url($frontendUrl, PHP_URL_QUERY), $frontendQuery);
+
+    expect($frontendUrl)->toStartWith('https://opnform.test/mcp/authorize?request=')
+        ->and($frontendUrl)->not->toContain('client_id')
+        ->and($frontendQuery['request'])->toHaveLength(64);
+
+    $user = User::factory()->create();
+    $this->actingAs($user, 'api')
+        ->postJson('/mcp-oauth/session', [
+            'authorization_request_token' => $frontendQuery['request'],
+        ])->assertOk()
+        ->assertJsonPath('authorization_url', fn (string $url) => str_contains($url, 'mcp_login_ticket='));
+
+    $authorizationUrl = $this->actingAs($user, 'api')
+        ->postJson('/mcp-oauth/session', [
+            'authorization_request_token' => $frontendQuery['request'],
+        ]);
+
+    $authorizationUrl->assertBadRequest();
+});
+
+it('consumes login tickets once and removes them from the authorization URL', function () {
+    $sessions = app(McpOAuthSessionService::class);
+    $user = User::factory()->create();
+    $oauthRequest = Request::create('/oauth/authorize?client_id=7&state=state-1', 'GET');
+    $frontendUrl = $sessions->beginAuthorization($oauthRequest);
+    parse_str((string) parse_url($frontendUrl, PHP_URL_QUERY), $frontendQuery);
+    $authorizationUrl = $sessions->issueLoginTicket($frontendQuery['request'], $user);
+    parse_str((string) parse_url($authorizationUrl, PHP_URL_QUERY), $authorizationQuery);
+
+    $request = Request::create($authorizationUrl, 'GET');
+    $request->setLaravelSession(app('session.store'));
+    $sessions->consumeLoginTicket($authorizationQuery['mcp_login_ticket'], $request);
+
+    expect(auth('web')->id())->toBe($user->id)
+        ->and($sessions->withoutLoginTicket($request))->not->toContain('mcp_login_ticket')
+        ->and($sessions->withoutLoginTicket($request))->toContain('client_id=7')
+        ->and($sessions->withoutLoginTicket($request))->toContain('state=state-1');
+
+    expect(fn () => $sessions->consumeLoginTicket($authorizationQuery['mcp_login_ticket'], $request))
+        ->toThrow(AccessDeniedHttpException::class);
+});
+
+it('binds each login ticket to the exact OAuth authorization request', function () {
+    $sessions = app(McpOAuthSessionService::class);
+    $user = User::factory()->create();
+    $oauthRequest = Request::create('/oauth/authorize?client_id=7&state=expected', 'GET');
+    $frontendUrl = $sessions->beginAuthorization($oauthRequest);
+    parse_str((string) parse_url($frontendUrl, PHP_URL_QUERY), $frontendQuery);
+    $authorizationUrl = $sessions->issueLoginTicket($frontendQuery['request'], $user);
+    parse_str((string) parse_url($authorizationUrl, PHP_URL_QUERY), $authorizationQuery);
+
+    $swappedRequest = Request::create(
+        '/oauth/authorize?client_id=99&state=attacker&mcp_login_ticket='.$authorizationQuery['mcp_login_ticket'],
+        'GET'
+    );
+    $swappedRequest->setLaravelSession(app('session.store'));
+
+    expect(fn () => $sessions->consumeLoginTicket(
+        $authorizationQuery['mcp_login_ticket'],
+        $swappedRequest
+    ))->toThrow(AccessDeniedHttpException::class);
+});

--- a/api/tests/Feature/Mcp/McpOAuthTest.php
+++ b/api/tests/Feature/Mcp/McpOAuthTest.php
@@ -2,7 +2,9 @@
 
 use App\Models\User;
 use App\Service\OAuth\McpOAuthSessionService;
+use App\Service\OAuth\McpPassportClientRepository;
 use Illuminate\Http\Request;
+use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Passport;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -17,6 +19,21 @@ beforeEach(function () {
 
     config()->set('passport.private_key', $privateKey);
     config()->set('passport.public_key', $publicKey);
+});
+
+it('configures delegated OAuth through its dedicated provider', function () {
+    $jwtTtl = config('jwt.ttl');
+
+    expect(app(ClientRepository::class))->toBeInstanceOf(McpPassportClientRepository::class)
+        ->and(route('passport.token'))->toEndWith('/oauth/token')
+        ->and(route('passport.authorizations.authorize'))->toEndWith('/oauth/authorize')
+        ->and(config('auth.guards.oauth.driver'))->toBe('passport')
+        ->and(config('auth.guards.mcp'))->toBeNull()
+        ->and(config('auth.guards.api.driver'))->toBe('jwt');
+
+    config()->set('oauth.access_token_ttl', (int) $jwtTtl + 1);
+
+    expect(config('jwt.ttl'))->toBe($jwtTtl);
 });
 
 function mcpInitializePayload(): array
@@ -59,6 +76,19 @@ it('publishes OAuth 2.1 discovery metadata for the unified MCP endpoint', functi
         ->assertJsonPath('scopes_supported.0', 'mcp:use');
 });
 
+it('requires S256 PKCE for every delegated authorization request', function (array $query) {
+    $this->getJson('/oauth/authorize?'.http_build_query($query))
+        ->assertBadRequest()
+        ->assertJsonPath('error', 'invalid_request')
+        ->assertJsonPath('error_description', 'The code_challenge_method must be S256.');
+})->with([
+    'missing method' => [['code_challenge' => 'challenge']],
+    'plain method' => [[
+        'code_challenge' => 'challenge',
+        'code_challenge_method' => 'plain',
+    ]],
+]);
+
 it('dynamically registers public PKCE clients only for allowed redirects', function () {
     $this->postJson('/oauth/register', [
         'client_name' => 'ChatGPT',
@@ -84,7 +114,7 @@ it('keeps guest MCP available while accepting properly scoped Passport users', f
         ->assertOk();
 
     $user = User::factory()->create();
-    Passport::actingAs($user, ['mcp:use'], 'mcp');
+    Passport::actingAs($user, ['mcp:use'], 'oauth');
 
     $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
         'Authorization' => 'Bearer test-passport-token',
@@ -114,7 +144,13 @@ it('completes PKCE authorization and uses the issued bearer token on the same en
     $consent = $this->actingAs($user, 'web')
         ->get('/oauth/authorize?'.$authorizationQuery)
         ->assertOk()
-        ->assertSee('Connect MCP integration test');
+        ->assertSee('Connect MCP integration test')
+        ->assertSee('Use OpnForm MCP features')
+        ->assertSee('http://localhost/callback')
+        ->assertHeader('Content-Security-Policy', "frame-ancestors 'none'")
+        ->assertHeader('X-Frame-Options', 'DENY')
+        ->assertHeader('Referrer-Policy', 'no-referrer')
+        ->assertHeader('Cache-Control', 'no-store, private');
 
     preg_match('/name="auth_token" value="([^"]+)"/', $consent->getContent(), $authTokenMatch);
 
@@ -140,7 +176,7 @@ it('completes PKCE authorization and uses the issued bearer token on the same en
 
 it('rejects an OAuth token without the MCP scope and advertises discovery', function () {
     $user = User::factory()->create();
-    Passport::actingAs($user, [], 'mcp');
+    Passport::actingAs($user, [], 'oauth');
 
     $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
         'Authorization' => 'Bearer insufficient-token',
@@ -150,7 +186,7 @@ it('rejects an OAuth token without the MCP scope and advertises discovery', func
 
 it('rejects MCP access for blocked authenticated accounts', function () {
     $user = User::factory()->create(['blocked_at' => now()]);
-    Passport::actingAs($user, ['mcp:use'], 'mcp');
+    Passport::actingAs($user, ['mcp:use'], 'oauth');
 
     $this->postJson('/mcp', mcpInitializePayload(), mcpHeaders([
         'Authorization' => 'Bearer blocked-user-token',

--- a/client/pages/mcp/authorize.vue
+++ b/client/pages/mcp/authorize.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-neutral-50 px-6">
+    <div class="w-full max-w-md rounded-2xl border border-neutral-200 bg-white p-8 text-center shadow-sm">
+      <UIcon name="i-heroicons-shield-check" class="mx-auto h-10 w-10 text-blue-600" />
+      <h1 class="mt-4 text-xl font-semibold text-neutral-950">Connecting your OpnForm account</h1>
+      <p class="mt-2 text-sm text-neutral-600">
+        You will be redirected to review the access requested by your AI assistant.
+      </p>
+      <UProgress class="mt-6" animation="carousel" />
+      <p v-if="error" class="mt-4 text-sm text-red-600">{{ error }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({ middleware: 'auth' })
+
+const route = useRoute()
+const error = ref('')
+
+onMounted(() => {
+  const requestToken = typeof route.query.request === 'string' ? route.query.request : ''
+
+  if (!/^[A-Za-z0-9]{64}$/.test(requestToken)) {
+    error.value = 'This authorization request is invalid or has expired.'
+    return
+  }
+
+  opnFetch('/mcp-oauth/session', {
+    method: 'POST',
+    body: { authorization_request_token: requestToken },
+  })
+    .then((response) => {
+      window.location.assign(response.authorization_url)
+    })
+    .catch((requestError) => {
+      error.value = requestError?.data?.message || 'Unable to continue the authorization flow.'
+    })
+})
+
+useOpnSeoMeta({
+  title: 'Connect your OpnForm account',
+  robots: 'noindex, nofollow',
+})
+</script>

--- a/docker/php-fpm-entrypoint
+++ b/docker/php-fpm-entrypoint
@@ -28,6 +28,7 @@ main() {
         echo "Running setup for API role..."
         apply_db_migrations
         initialize_instance
+        initialize_mcp_oauth_keys
         optimize_application
         echo "Starting server for API role with command: $@"
         exec "$@"
@@ -128,6 +129,36 @@ apply_db_migrations() {
 initialize_instance() {
     echo "Initializing instance for telemetry"
     php ./artisan telemetry:initialize-instance
+}
+
+initialize_mcp_oauth_keys() {
+    local self_hosted="${SELF_HOSTED:-false}"
+    local mcp_enabled="${MCP_ENABLED:-false}"
+
+    if [ "$self_hosted" = "true" ] && [ "$mcp_enabled" != "true" ]; then
+        return 0
+    fi
+
+    if [ -n "${PASSPORT_PRIVATE_KEY:-}" ] && [ -n "${PASSPORT_PUBLIC_KEY:-}" ]; then
+        echo "Using Passport keys from the environment"
+        return 0
+    fi
+
+    if [ -f ./storage/oauth-private.key ] && [ -f ./storage/oauth-public.key ]; then
+        echo "Reusing Passport keys from storage"
+        return 0
+    fi
+
+    if [ -f ./storage/oauth-private.key ] || [ -f ./storage/oauth-public.key ]; then
+        echo "Incomplete Passport key pair in storage" >&2
+        exit 1
+    fi
+
+    echo "Generating Passport keys for MCP OAuth"
+    php ./artisan passport:keys --force
+    chown www-data:www-data ./storage/oauth-private.key ./storage/oauth-public.key
+    chmod 600 ./storage/oauth-private.key
+    chmod 644 ./storage/oauth-public.key
 }
 
 optimize_application() {

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -68,6 +68,9 @@ There are dedicated configuration pages available for more detailed setup instru
 | `JWT_TTL`                        | Time to live for JSON Web Tokens (JWT).                                                                                                                                                   |
 | `JWT_SECRET`                     | Secret key used to sign JWTs.                                                                                                                                                             |
 | `JWT_SKIP_IP_UA_VALIDATION`      | Set to `true` to disable JWT User Agent validation (defaults to `false`). Keep this disabled in production and Docker deployments. For local Docker development, `docker-compose.dev.yml` sets this to `true` automatically. |
+| `OAUTH_ENABLED`                  | Overrides delegated OAuth 2.1 availability. By default, OAuth is enabled on OpnForm Cloud and when MCP is enabled on a self-hosted instance. |
+| `OAUTH_ACCESS_TOKEN_TTL`         | Passport access token lifetime in minutes. Defaults to `10080` (7 days) and does not change the first-party JWT lifetime. |
+| `OAUTH_REFRESH_TOKEN_TTL_DAYS`   | Passport refresh token lifetime in days. Defaults to `30`. |
 | `PUBLIC_UPLOADS_RATE_LIMIT_PER_MINUTE` | Maximum public upload requests allowed per client IP or authenticated user per route each minute. Defaults to `30`.                                                                 |
 | `PUBLIC_UPLOADS_RATE_LIMIT_PER_HOUR`   | Maximum public upload requests allowed per client IP or authenticated user per route each hour. Defaults to `300`.                                                                  |
 | `OIDC_FORCE_LOGIN`               | When set to `true`, password-based authentication is disabled and users must authenticate via OIDC SSO. See [Force Login Mode](../configuration/oidc-sso#7-force-login-mode) for details. |

--- a/docs/contributing/authentication-architecture.mdx
+++ b/docs/contributing/authentication-architecture.mdx
@@ -1,0 +1,56 @@
+---
+title: Authentication architecture
+description: Understand when OpnForm uses JWT, Sanctum personal access tokens, and Passport OAuth 2.1.
+---
+
+OpnForm intentionally uses three authentication mechanisms. They serve different clients and should not be substituted for one another without a dedicated migration.
+
+| Mechanism | Client | Purpose |
+| --- | --- | --- |
+| JWT | First-party Nuxt application | Existing browser login and authenticated application requests |
+| Sanctum personal access tokens | API users and integrations | Long-lived tokens created by a user, constrained by token abilities and the `auth.multi` route policy |
+| Passport OAuth 2.1 | Third-party delegated clients | Authorization Code with PKCE, consent, scoped access, and refresh tokens |
+
+<Warning>
+Do not migrate first-party login to Passport. Passport is for delegated access by external clients. A future first-party authentication migration should evaluate Sanctum's stateful cookie authentication as a separate project.
+</Warning>
+
+## Delegated OAuth flow
+
+The `OAuthServiceProvider` owns Passport configuration, routes, token lifetimes, consent rendering, and scope descriptions. MCP adds its own dynamic client registration policy, login bridge, metadata, and `mcp:use` scope requirement on top of that generic layer.
+
+1. The client dynamically registers an allowed redirect URI for the MCP integration.
+2. The authorization request must use Authorization Code with PKCE and the `S256` challenge method.
+3. OpnForm authenticates the account through the existing first-party login flow.
+4. The generic consent screen displays the callback destination and every requested scope description.
+5. Passport issues a scoped access token and refresh token.
+6. The MCP endpoint accepts the token only when it includes `mcp:use` and the account is not blocked.
+
+Guest MCP requests remain available without a bearer token. A bearer token that is invalid or missing the required scope is rejected rather than treated as a guest request.
+
+## Configuration
+
+```dotenv
+# Optional override. The default follows Cloud or self-hosted MCP availability.
+OAUTH_ENABLED=true
+
+# Seven days, in minutes.
+OAUTH_ACCESS_TOKEN_TTL=10080
+
+# Refresh tokens remain valid for 30 days.
+OAUTH_REFRESH_TOKEN_TTL_DAYS=30
+```
+
+These values are independent of `JWT_TTL`. Changing a delegated OAuth token lifetime must not change first-party sessions.
+
+## Adding another delegated client
+
+When you add another OAuth consumer:
+
+1. Add a narrowly defined scope and a user-readable description to `config/oauth.php`.
+2. Keep redirect URI validation specific to the client registration endpoint.
+3. Require PKCE `S256` for public clients.
+4. Enforce the scope at the protected resource boundary.
+5. Add consent, token, insufficient-scope, account-blocking, and revocation tests.
+
+Do not add product-specific permissions directly to the generic OAuth consent template. The template renders the scopes requested and validated by Passport.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -156,6 +156,7 @@
             "group": "Contributing",
             "pages": [
               "contributing/getting-started",
+              "contributing/authentication-architecture",
               "contributing/new-form-block",
               "contributing/new-integration"
             ]

--- a/scripts/codex-worktree-lib.sh
+++ b/scripts/codex-worktree-lib.sh
@@ -206,6 +206,27 @@ ensure_php_dependencies() {
   fi
 }
 
+ensure_mcp_oauth_keys() {
+  select_php_runtime
+
+  public_key="$ROOT_DIR/api/storage/oauth-public.key"
+  private_key="$ROOT_DIR/api/storage/oauth-private.key"
+
+  if [ -f "$public_key" ] && [ -f "$private_key" ]; then
+    return 0
+  fi
+
+  if [ -f "$public_key" ] || [ -f "$private_key" ]; then
+    echo "Incomplete Passport key pair in api/storage. Remove the remaining key and rerun setup." >&2
+    exit 1
+  fi
+
+  (
+    cd "$ROOT_DIR/api"
+    APP_ENV=codex "$CODEX_PHP_BIN" artisan passport:keys --force --env=codex
+  )
+}
+
 php_version_is_supported() {
   version="$1"
   major=${version%%.*}

--- a/scripts/codex-worktree-setup.sh
+++ b/scripts/codex-worktree-setup.sh
@@ -18,6 +18,7 @@ done
 
 write_codex_env_files
 ensure_php_dependencies
+ensure_mcp_oauth_keys
 ensure_node_dependencies
 ensure_codex_database
 print_codex_environment_summary

--- a/scripts/codex-worktree-up.sh
+++ b/scripts/codex-worktree-up.sh
@@ -15,6 +15,7 @@ if [ ! -f "$CODEX_API_ENV_FILE" ] || [ ! -f "$CODEX_CLIENT_ENV_FILE" ]; then
 else
   write_codex_env_files
   ensure_php_dependencies
+  ensure_mcp_oauth_keys
   ensure_node_dependencies
   ensure_codex_database
   if ! database_is_migrated; then


### PR DESCRIPTION
## Summary

- add Passport OAuth 2.1 authorization-code + PKCE access for delegated MCP clients
- isolate delegated OAuth in `OAuthServiceProvider`, `config/oauth.php`, `routes/oauth.php`, an `oauth` guard, and reusable security middleware
- keep guest MCP available when OAuth is disabled and expose account tools only to tokens carrying `mcp:use`
- add secure frontend login/consent bridging, dynamic client registration restrictions, rate limits, revocation, and self-hosted feature gating
- document the authentication boundaries and production settings

## Authentication boundaries

- first-party web/mobile login remains on the existing JWT flow
- personal API tokens remain on Sanctum
- Passport is reserved for delegated third-party OAuth clients such as ChatGPT and Codex
- Passport token and refresh-token lifetimes are independent from `JWT_TTL`

## Security

- PKCE S256 enforced server-side
- exact redirect URI validation, including comma-smuggling rejection
- one-time login tickets consumed atomically through a shared lock
- explicit consent shows requested scopes and callback destination
- blocked users rejected, authorization responses are non-cacheable, and unnecessary Passport management routes stay disabled
- stable Passport key preflight retained for deployment

## Validation

- 102 targeted OAuth, MCP, JWT, and Sanctum tests passed (591 assertions)
- full backend stack: 1963 passed, 3 skipped
- full frontend stack: 54 files / 735 tests passed
- Pint and ESLint passed
- real PKCE authorization-code flow and authenticated MCP HTTP flow verified
- global PHPStan retains only two pre-existing findings in an unchanged billing backfill command

## Stack

Depends on #1252.