### PR TITLE
MCP 5/9: Manage account forms safely

### DIFF
--- a/api/app/Mcp/Servers/OpnFormServer.php
+++ b/api/app/Mcp/Servers/OpnFormServer.php
@@ -7,6 +7,15 @@ use App\Mcp\Resources\FormFieldCatalogResource;
 use App\Mcp\Apps\FormDraftPreviewApp;
 use App\Mcp\Tools\CreateFormDraftTool;
 use App\Mcp\Tools\GetFormDraftTool;
+use App\Mcp\Tools\GetAccountContextTool;
+use App\Mcp\Tools\ListWorkspacesTool;
+use App\Mcp\Tools\GetWorkspaceTool;
+use App\Mcp\Tools\ListFormsTool;
+use App\Mcp\Tools\GetFormTool;
+use App\Mcp\Tools\CreateFormTool;
+use App\Mcp\Tools\UpdateFormTool;
+use App\Mcp\Tools\PublishFormTool;
+use App\Mcp\Tools\TrashFormTool;
 use App\Mcp\Tools\PatchFormDraftTool;
 use App\Mcp\Tools\PreviewFormDraftTool;
 use App\Mcp\Tools\OpenFormDraftInEditorTool;
@@ -28,6 +37,15 @@ class OpnFormServer extends Server
         PatchFormDraftTool::class,
         PreviewFormDraftTool::class,
         OpenFormDraftInEditorTool::class,
+        GetAccountContextTool::class,
+        ListWorkspacesTool::class,
+        GetWorkspaceTool::class,
+        ListFormsTool::class,
+        GetFormTool::class,
+        CreateFormTool::class,
+        UpdateFormTool::class,
+        PublishFormTool::class,
+        TrashFormTool::class,
     ];
 
     protected array $resources = [

--- a/api/app/Mcp/Tools/AuthenticatedMcpTool.php
+++ b/api/app/Mcp/Tools/AuthenticatedMcpTool.php
@@ -11,7 +11,7 @@ abstract class AuthenticatedMcpTool extends Tool
 {
     public function shouldRegister(): bool
     {
-        return auth('mcp')->check();
+        return auth('oauth')->check();
     }
 
     protected function user(Request $request): User

--- a/api/app/Mcp/Tools/AuthenticatedMcpTool.php
+++ b/api/app/Mcp/Tools/AuthenticatedMcpTool.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\User;
+use Illuminate\Auth\AuthenticationException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Server\Tool;
+
+abstract class AuthenticatedMcpTool extends Tool
+{
+    public function shouldRegister(): bool
+    {
+        return auth('mcp')->check();
+    }
+
+    protected function user(Request $request): User
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            throw new AuthenticationException('Connect your OpnForm account with OAuth to use this tool.');
+        }
+
+        return $user;
+    }
+}

--- a/api/app/Mcp/Tools/CreateFormTool.php
+++ b/api/app/Mcp/Tools/CreateFormTool.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('create_form')]
+#[Description('Create a form in an accessible writable workspace from the canonical definition. It is always saved as an unpublished draft. If the account has exactly one workspace, workspace_id may be omitted.')]
+#[IsOpenWorld(false)]
+class CreateFormTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate([
+            'workspace_id' => ['nullable', 'integer', 'min:1'],
+            'definition' => ['required', 'array'],
+        ]);
+
+        return Response::structured($forms->create(
+            $this->user($request),
+            $validated['workspace_id'] ?? null,
+            $validated['definition'],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'workspace_id' => $schema->integer()->description('Required only when the account has multiple workspaces.')->min(1),
+            'definition' => $schema->object()->description('Canonical OpnForm agent form definition v1.')->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/GetAccountContextTool.php
+++ b/api/app/Mcp/Tools/GetAccountContextTool.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_account_context')]
+#[Description('Confirm the connected OpnForm account and summarize its accessible workspaces. Use this before account-scoped work when the current context is unclear.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetAccountContextTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $user = $this->user($request);
+        $workspaces = $forms->listWorkspaces($user);
+
+        return Response::structured([
+            'account' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+            ],
+            'workspaces' => $workspaces,
+            'workspace_selection_required' => count($workspaces) > 1,
+        ]);
+    }
+}

--- a/api/app/Mcp/Tools/GetFormTool.php
+++ b/api/app/Mcp/Tools/GetFormTool.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('get_form')]
-#[Description('Fetch an accessible form as the canonical agent form definition. Use its revision value when calling update_form.')]
+#[Description('Fetch an accessible form as the canonical agent form definition. Use its revision value when calling update_form, publish_form, or trash_form.')]
 #[IsReadOnly]
 #[IsOpenWorld(false)]
 class GetFormTool extends AuthenticatedMcpTool

--- a/api/app/Mcp/Tools/GetFormTool.php
+++ b/api/app/Mcp/Tools/GetFormTool.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_form')]
+#[Description('Fetch an accessible form as the canonical agent form definition. Use its revision value when calling update_form.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetFormTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate(['form_id' => ['required', 'integer', 'min:1']]);
+        $form = $forms->form($this->user($request), $validated['form_id']);
+
+        return Response::structured(['form' => $forms->serializeForm($form)]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return ['form_id' => $schema->integer()->min(1)->required()];
+    }
+}

--- a/api/app/Mcp/Tools/GetWorkspaceTool.php
+++ b/api/app/Mcp/Tools/GetWorkspaceTool.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_workspace')]
+#[Description('Read one accessible OpnForm workspace and the connected account role. This integration never changes workspace settings or members.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetWorkspaceTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate(['workspace_id' => ['required', 'integer', 'min:1']]);
+
+        return Response::structured([
+            'workspace' => $forms->serializeWorkspace($forms->workspace($this->user($request), $validated['workspace_id'])),
+        ]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return ['workspace_id' => $schema->integer()->min(1)->required()];
+    }
+}

--- a/api/app/Mcp/Tools/ListFormsTool.php
+++ b/api/app/Mcp/Tools/ListFormsTool.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\Forms\Form;
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('list_forms')]
+#[Description('List forms accessible to the connected account. Filter by workspace, title, or visibility; results are paginated and exclude trashed forms.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class ListFormsTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate([
+            'workspace_id' => ['nullable', 'integer', 'min:1'],
+            'search' => ['nullable', 'string', 'max:255'],
+            'visibility' => ['nullable', Rule::in(Form::VISIBILITY)],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        return Response::structured($forms->listForms(
+            $this->user($request),
+            $validated['workspace_id'] ?? null,
+            $validated['search'] ?? null,
+            $validated['visibility'] ?? null,
+            $validated['page'] ?? 1,
+            $validated['per_page'] ?? 20,
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'workspace_id' => $schema->integer()->min(1),
+            'search' => $schema->string()->max(255),
+            'visibility' => $schema->string()->enum(Form::VISIBILITY),
+            'page' => $schema->integer()->min(1)->default(1),
+            'per_page' => $schema->integer()->min(1)->max(100)->default(20),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/ListWorkspacesTool.php
+++ b/api/app/Mcp/Tools/ListWorkspacesTool.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('list_workspaces')]
+#[Description('List workspaces available to the connected account, including its role and whether forms can be changed. Workspace management is intentionally not available.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class ListWorkspacesTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        return Response::structured([
+            'workspaces' => $forms->listWorkspaces($this->user($request)),
+        ]);
+    }
+}

--- a/api/app/Mcp/Tools/PublishFormTool.php
+++ b/api/app/Mcp/Tools/PublishFormTool.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('publish_form')]
+#[Description('Publish an accessible writable form. Call only after showing the result or preview and receiving explicit confirmation from the user.')]
+#[IsOpenWorld]
+class PublishFormTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'confirm_publish' => ['required', 'boolean'],
+        ]);
+
+        return Response::structured($forms->publish(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['confirm_publish'],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'confirm_publish' => $schema->boolean()->description('True only after the user explicitly confirms publication.')->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/PublishFormTool.php
+++ b/api/app/Mcp/Tools/PublishFormTool.php
@@ -12,7 +12,7 @@ use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('publish_form')]
-#[Description('Publish an accessible writable form. Call only after showing the result or preview and receiving explicit confirmation from the user.')]
+#[Description('Publish an accessible writable form at its current revision. Call only after showing the result or preview and receiving explicit confirmation from the user.')]
 #[IsOpenWorld]
 class PublishFormTool extends AuthenticatedMcpTool
 {
@@ -20,12 +20,14 @@ class PublishFormTool extends AuthenticatedMcpTool
     {
         $validated = $request->validate([
             'form_id' => ['required', 'integer', 'min:1'],
+            'expected_revision' => ['required', 'string', 'size:64'],
             'confirm_publish' => ['required', 'boolean'],
         ]);
 
         return Response::structured($forms->publish(
             $this->user($request),
             $validated['form_id'],
+            $validated['expected_revision'],
             $validated['confirm_publish'],
         ));
     }
@@ -34,6 +36,7 @@ class PublishFormTool extends AuthenticatedMcpTool
     {
         return [
             'form_id' => $schema->integer()->min(1)->required(),
+            'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
             'confirm_publish' => $schema->boolean()->description('True only after the user explicitly confirms publication.')->required(),
         ];
     }

--- a/api/app/Mcp/Tools/TrashFormTool.php
+++ b/api/app/Mcp/Tools/TrashFormTool.php
@@ -13,7 +13,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 
 #[Name('trash_form')]
-#[Description('Move an accessible writable form to soft-delete trash. Call only after explicit user confirmation. Restore and permanent deletion are intentionally not exposed.')]
+#[Description('Move an accessible writable form at its current revision to soft-delete trash. Call only after explicit user confirmation. Restore and permanent deletion are intentionally not exposed.')]
 #[IsDestructive]
 #[IsOpenWorld(false)]
 class TrashFormTool extends AuthenticatedMcpTool
@@ -22,12 +22,14 @@ class TrashFormTool extends AuthenticatedMcpTool
     {
         $validated = $request->validate([
             'form_id' => ['required', 'integer', 'min:1'],
+            'expected_revision' => ['required', 'string', 'size:64'],
             'confirm_trash' => ['required', 'boolean'],
         ]);
 
         return Response::structured($forms->trash(
             $this->user($request),
             $validated['form_id'],
+            $validated['expected_revision'],
             $validated['confirm_trash'],
         ));
     }
@@ -36,6 +38,7 @@ class TrashFormTool extends AuthenticatedMcpTool
     {
         return [
             'form_id' => $schema->integer()->min(1)->required(),
+            'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
             'confirm_trash' => $schema->boolean()->description('True only after the user explicitly confirms moving the form to trash.')->required(),
         ];
     }

--- a/api/app/Mcp/Tools/TrashFormTool.php
+++ b/api/app/Mcp/Tools/TrashFormTool.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('trash_form')]
+#[Description('Move an accessible writable form to soft-delete trash. Call only after explicit user confirmation. Restore and permanent deletion are intentionally not exposed.')]
+#[IsDestructive]
+#[IsOpenWorld(false)]
+class TrashFormTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'confirm_trash' => ['required', 'boolean'],
+        ]);
+
+        return Response::structured($forms->trash(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['confirm_trash'],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'confirm_trash' => $schema->boolean()->description('True only after the user explicitly confirms moving the form to trash.')->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/UpdateFormTool.php
+++ b/api/app/Mcp/Tools/UpdateFormTool.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+
+#[Name('update_form')]
+#[Description('Replace the editable definition of an accessible form. Requires the revision value returned by get_form to prevent silent concurrent overwrites. This tool cannot publish or trash a form.')]
+#[IsOpenWorld(false)]
+class UpdateFormTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpFormManagementService $forms): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'expected_revision' => ['required', 'string', 'size:64'],
+            'definition' => ['required', 'array'],
+        ]);
+
+        return Response::structured($forms->update(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['expected_revision'],
+            $validated['definition'],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
+            'definition' => $schema->object()->description('Complete canonical OpnForm agent form definition v1.')->required(),
+        ];
+    }
+}

--- a/api/app/Service/Forms/AgentFormDefinition.php
+++ b/api/app/Service/Forms/AgentFormDefinition.php
@@ -257,6 +257,26 @@ class AgentFormDefinition
         ];
     }
 
+    /**
+     * Return the canonical agent-editable portion of an existing form.
+     */
+    public function fromForm(Form $form): array
+    {
+        $definition = ['schema_version' => self::SCHEMA_VERSION];
+
+        foreach (self::ALLOWED_TOP_LEVEL_KEYS as $key) {
+            if ($key === 'schema_version') {
+                continue;
+            }
+
+            if (array_key_exists($key, $form->getAttributes())) {
+                $definition[$key] = $form->getAttribute($key);
+            }
+        }
+
+        return $definition;
+    }
+
     public function jsonSchema(): array
     {
         return [

--- a/api/app/Service/Forms/McpFormManagementService.php
+++ b/api/app/Service/Forms/McpFormManagementService.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Models\Forms\Form;
+use App\Models\Forms\FormSubmission;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class McpFormManagementService
+{
+    public function __construct(
+        private readonly AgentFormDefinition $definitions,
+        private readonly FormCreationService $formCreation,
+    ) {
+    }
+
+    public function workspace(User $user, int $workspaceId): Workspace
+    {
+        $workspace = $user->workspaces()
+            ->withPivot('role')
+            ->where('workspaces.id', $workspaceId)
+            ->first();
+
+        if (! $workspace) {
+            throw ValidationException::withMessages([
+                'workspace_id' => ['Workspace not found or not accessible.'],
+            ]);
+        }
+
+        return $workspace;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    public function listWorkspaces(User $user): array
+    {
+        return $user->workspaces()
+            ->withPivot('role')
+            ->orderBy('workspaces.name')
+            ->get()
+            ->map(fn (Workspace $workspace) => $this->serializeWorkspace($workspace))
+            ->all();
+    }
+
+    /** @return array<string, mixed> */
+    public function serializeWorkspace(Workspace $workspace): array
+    {
+        $role = $workspace->pivot?->role;
+
+        return [
+            'id' => $workspace->id,
+            'name' => $workspace->name,
+            'icon' => $workspace->icon,
+            'role' => $role,
+            'can_write_forms' => $role !== User::ROLE_READONLY,
+            'plan_tier' => $workspace->plan_tier,
+        ];
+    }
+
+    /** @return array{forms: array<int, array<string, mixed>>, pagination: array<string, int>} */
+    public function listForms(
+        User $user,
+        ?int $workspaceId,
+        ?string $search,
+        ?string $visibility,
+        int $page,
+        int $perPage,
+    ): array {
+        $workspaceIds = $user->workspaces()->pluck('workspaces.id');
+
+        if ($workspaceId !== null && ! $workspaceIds->contains($workspaceId)) {
+            throw ValidationException::withMessages([
+                'workspace_id' => ['Workspace not found or not accessible.'],
+            ]);
+        }
+
+        $query = Form::query()
+            ->whereIn('workspace_id', $workspaceIds)
+            ->with('workspace')
+            ->withCount(['submissions as submissions_count' => fn (Builder $query) => $query->where('status', FormSubmission::STATUS_COMPLETED)])
+            ->withTotalViews()
+            ->when($workspaceId !== null, fn (Builder $query) => $query->where('workspace_id', $workspaceId))
+            ->when($search, fn (Builder $query) => $query->whereRaw('LOWER(title) LIKE ?', ['%'.Str::lower($search).'%']))
+            ->when($visibility, fn (Builder $query) => $query->where('visibility', $visibility))
+            ->orderByDesc('updated_at');
+
+        $forms = $query->paginate($perPage, ['*'], 'page', $page);
+
+        return [
+            'forms' => collect($forms->items())->map(fn (Form $form) => $this->serializeFormSummary($form))->all(),
+            'pagination' => [
+                'page' => $forms->currentPage(),
+                'per_page' => $forms->perPage(),
+                'total' => $forms->total(),
+                'last_page' => $forms->lastPage(),
+            ],
+        ];
+    }
+
+    public function form(User $user, int $formId): Form
+    {
+        $form = Form::query()->with('workspace')->find($formId);
+
+        if (! $form || ! $user->ownsForm($form)) {
+            throw ValidationException::withMessages([
+                'form_id' => ['Form not found or not accessible.'],
+            ]);
+        }
+
+        return $form;
+    }
+
+    /** @return array<string, mixed> */
+    public function create(User $user, ?int $workspaceId, array $definition): array
+    {
+        $workspace = $this->resolveCreationWorkspace($user, $workspaceId);
+        $this->assertWritable($workspace, $user);
+
+        $definition = $this->definitions->normalizeAndValidate($definition);
+        $definition['visibility'] = 'draft';
+        $created = $this->formCreation->create($definition, $user, $workspace);
+
+        return [
+            'message' => 'Form created as an unpublished draft.',
+            'form' => $this->serializeForm($created['form']->load('workspace')),
+            'disabled_features' => $created['cleanings'],
+            'next_step' => 'Preview or edit the form. Ask the user before calling publish_form.',
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function update(User $user, int $formId, string $expectedRevision, array $definition): array
+    {
+        $form = $this->form($user, $formId);
+        $this->assertWritable($form->workspace, $user);
+        $this->assertFresh($form, $expectedRevision);
+
+        $definition = $this->definitions->normalizeAndValidate($definition);
+        $definition['visibility'] = $form->visibility;
+
+        $cleaner = (new FormCleaner())
+            ->processData($definition, $form)
+            ->simulateCleaning($form->workspace);
+        $formData = $cleaner->getData();
+        unset($formData['schema_version']);
+
+        $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
+        $formData['removed_properties'] = array_merge(
+            $form->removed_properties ?? [],
+            collect($form->properties)->filter(fn (array $field) => ! Str::of($field['type'])->startsWith('nf-') && ! isset($newPropertyIds[$field['id']]))->all(),
+        );
+
+        $form->update($formData);
+
+        return [
+            'message' => 'Form updated.',
+            'form' => $this->serializeForm($form->refresh()->load('workspace')),
+            'disabled_features' => $cleaner->getPerformedCleanings(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function publish(User $user, int $formId, bool $confirmed): array
+    {
+        if (! $confirmed) {
+            throw ValidationException::withMessages([
+                'confirm_publish' => ['Ask the user for explicit confirmation before publishing.'],
+            ]);
+        }
+
+        $form = $this->form($user, $formId);
+        $this->assertWritable($form->workspace, $user);
+        $form->update(['visibility' => 'public']);
+
+        return [
+            'message' => 'Form published.',
+            'form' => $this->serializeForm($form->refresh()->load('workspace')),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function trash(User $user, int $formId, bool $confirmed): array
+    {
+        if (! $confirmed) {
+            throw ValidationException::withMessages([
+                'confirm_trash' => ['Ask the user for explicit confirmation before moving the form to trash.'],
+            ]);
+        }
+
+        $form = $this->form($user, $formId);
+        $this->assertWritable($form->workspace, $user);
+        $summary = $this->serializeFormSummary($form);
+        $form->delete();
+
+        return [
+            'message' => 'Form moved to trash. This MCP integration does not expose restore or permanent deletion.',
+            'form' => $summary,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function serializeForm(Form $form): array
+    {
+        return array_merge($this->serializeFormSummary($form), [
+            'definition' => $this->definitions->fromForm($form),
+            'revision' => $this->revision($form),
+            'edit_url' => $form->edit_url,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function serializeFormSummary(Form $form): array
+    {
+        return [
+            'id' => $form->id,
+            'workspace_id' => $form->workspace_id,
+            'title' => $form->title,
+            'visibility' => $form->visibility,
+            'share_url' => $form->share_url,
+            'submissions_count' => $form->submissions_count,
+            'views_count' => $form->views_count,
+            'created_at' => $form->created_at?->toISOString(),
+            'updated_at' => $form->updated_at?->toISOString(),
+        ];
+    }
+
+    private function resolveCreationWorkspace(User $user, ?int $workspaceId): Workspace
+    {
+        if ($workspaceId !== null) {
+            return $this->workspace($user, $workspaceId);
+        }
+
+        $workspaces = $user->workspaces()->withPivot('role')->limit(2)->get();
+
+        if ($workspaces->count() === 1) {
+            return $workspaces->first();
+        }
+
+        throw ValidationException::withMessages([
+            'workspace_id' => [$workspaces->isEmpty()
+                ? 'No workspace is available for this account.'
+                : 'This account has multiple workspaces. Call list_workspaces and provide workspace_id.'],
+        ]);
+    }
+
+    private function assertWritable(Workspace $workspace, User $user): void
+    {
+        if ($workspace->isReadonlyUser($user)) {
+            throw ValidationException::withMessages([
+                'workspace_id' => ['This workspace membership is read-only.'],
+            ]);
+        }
+    }
+
+    private function assertFresh(Form $form, string $expectedRevision): void
+    {
+        if (! hash_equals($this->revision($form), $expectedRevision)) {
+            throw ValidationException::withMessages([
+                'expected_revision' => ['The form changed since it was fetched. Call get_form and retry with its revision value.'],
+            ]);
+        }
+    }
+
+    private function revision(Form $form): string
+    {
+        return hash('sha256', json_encode([
+            'id' => $form->id,
+            'updated_at' => $form->updated_at?->toISOString(),
+            'definition' => $this->definitions->fromForm($form),
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/api/app/Service/Forms/McpFormManagementService.php
+++ b/api/app/Service/Forms/McpFormManagementService.php
@@ -7,6 +7,7 @@ use App\Models\Forms\FormSubmission;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
@@ -100,9 +101,12 @@ class McpFormManagementService
         ];
     }
 
-    public function form(User $user, int $formId): Form
+    public function form(User $user, int $formId, bool $lockForUpdate = false): Form
     {
-        $form = Form::query()->with('workspace')->find($formId);
+        $form = Form::query()
+            ->with('workspace')
+            ->when($lockForUpdate, fn (Builder $query) => $query->lockForUpdate())
+            ->find($formId);
 
         if (! $form || ! $user->ownsForm($form)) {
             throw ValidationException::withMessages([
@@ -119,7 +123,7 @@ class McpFormManagementService
         $workspace = $this->resolveCreationWorkspace($user, $workspaceId);
         $this->assertWritable($workspace, $user);
 
-        $definition = $this->definitions->normalizeAndValidate($definition);
+        $definition = $this->definitions->normalizeAndValidate($definition, $workspace);
         $definition['visibility'] = 'draft';
         $created = $this->formCreation->create($definition, $user, $workspace);
 
@@ -134,36 +138,38 @@ class McpFormManagementService
     /** @return array<string, mixed> */
     public function update(User $user, int $formId, string $expectedRevision, array $definition): array
     {
-        $form = $this->form($user, $formId);
-        $this->assertWritable($form->workspace, $user);
-        $this->assertFresh($form, $expectedRevision);
+        return DB::transaction(function () use ($user, $formId, $expectedRevision, $definition) {
+            $form = $this->form($user, $formId, lockForUpdate: true);
+            $this->assertWritable($form->workspace, $user);
+            $this->assertFresh($form, $expectedRevision);
 
-        $definition = $this->definitions->normalizeAndValidate($definition);
-        $definition['visibility'] = $form->visibility;
+            $definition = $this->definitions->normalizeAndValidate($definition, $form->workspace);
+            $definition['visibility'] = $form->visibility;
 
-        $cleaner = (new FormCleaner())
-            ->processData($definition, $form)
-            ->simulateCleaning($form->workspace);
-        $formData = $cleaner->getData();
-        unset($formData['schema_version']);
+            $cleaner = (new FormCleaner())
+                ->processData($definition, $form)
+                ->simulateCleaning($form->workspace);
+            $formData = $cleaner->getData();
+            unset($formData['schema_version']);
 
-        $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
-        $formData['removed_properties'] = array_merge(
-            $form->removed_properties ?? [],
-            collect($form->properties)->filter(fn (array $field) => ! Str::of($field['type'])->startsWith('nf-') && ! isset($newPropertyIds[$field['id']]))->all(),
-        );
+            $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
+            $formData['removed_properties'] = array_merge(
+                $form->removed_properties ?? [],
+                collect($form->properties)->filter(fn (array $field) => ! Str::of($field['type'])->startsWith('nf-') && ! isset($newPropertyIds[$field['id']]))->all(),
+            );
 
-        $form->update($formData);
+            $form->update($formData);
 
-        return [
-            'message' => 'Form updated.',
-            'form' => $this->serializeForm($form->refresh()->load('workspace')),
-            'disabled_features' => $cleaner->getPerformedCleanings(),
-        ];
+            return [
+                'message' => 'Form updated.',
+                'form' => $this->serializeForm($form->refresh()->load('workspace')),
+                'disabled_features' => $cleaner->getPerformedCleanings(),
+            ];
+        });
     }
 
     /** @return array<string, mixed> */
-    public function publish(User $user, int $formId, bool $confirmed): array
+    public function publish(User $user, int $formId, string $expectedRevision, bool $confirmed): array
     {
         if (! $confirmed) {
             throw ValidationException::withMessages([
@@ -171,18 +177,21 @@ class McpFormManagementService
             ]);
         }
 
-        $form = $this->form($user, $formId);
-        $this->assertWritable($form->workspace, $user);
-        $form->update(['visibility' => 'public']);
+        return DB::transaction(function () use ($user, $formId, $expectedRevision) {
+            $form = $this->form($user, $formId, lockForUpdate: true);
+            $this->assertWritable($form->workspace, $user);
+            $this->assertFresh($form, $expectedRevision);
+            $form->update(['visibility' => 'public']);
 
-        return [
-            'message' => 'Form published.',
-            'form' => $this->serializeForm($form->refresh()->load('workspace')),
-        ];
+            return [
+                'message' => 'Form published.',
+                'form' => $this->serializeForm($form->refresh()->load('workspace')),
+            ];
+        });
     }
 
     /** @return array<string, mixed> */
-    public function trash(User $user, int $formId, bool $confirmed): array
+    public function trash(User $user, int $formId, string $expectedRevision, bool $confirmed): array
     {
         if (! $confirmed) {
             throw ValidationException::withMessages([
@@ -190,15 +199,18 @@ class McpFormManagementService
             ]);
         }
 
-        $form = $this->form($user, $formId);
-        $this->assertWritable($form->workspace, $user);
-        $summary = $this->serializeFormSummary($form);
-        $form->delete();
+        return DB::transaction(function () use ($user, $formId, $expectedRevision) {
+            $form = $this->form($user, $formId, lockForUpdate: true);
+            $this->assertWritable($form->workspace, $user);
+            $this->assertFresh($form, $expectedRevision);
+            $summary = $this->serializeFormSummary($form);
+            $form->delete();
 
-        return [
-            'message' => 'Form moved to trash. This MCP integration does not expose restore or permanent deletion.',
-            'form' => $summary,
-        ];
+            return [
+                'message' => 'Form moved to trash. This MCP integration does not expose restore or permanent deletion.',
+                'form' => $summary,
+            ];
+        });
     }
 
     /** @return array<string, mixed> */

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -53,7 +53,7 @@ it('registers account tools only for an authenticated MCP account', function () 
     expect(app(ListFormsTool::class)->eligibleForRegistration())->toBeFalse();
 
     $user = User::factory()->create();
-    auth('mcp')->setUser($user);
+    auth('oauth')->setUser($user);
 
     expect(app(ListFormsTool::class)->eligibleForRegistration())->toBeTrue();
 });
@@ -73,7 +73,7 @@ it('advertises guest tools anonymously and account tools only with scoped OAuth'
         ->assertDontSee('list_forms');
 
     $user = User::factory()->create();
-    Passport::actingAs($user, ['mcp:use'], 'mcp');
+    Passport::actingAs($user, ['mcp:use'], 'oauth');
 
     $this->postJson('/mcp', $payload, array_merge($headers, [
         'Authorization' => 'Bearer scoped-account-token',
@@ -87,13 +87,13 @@ it('lists only the connected account workspaces with form write capability', fun
     $readonly = managedWorkspace($user, User::ROLE_READONLY);
     Workspace::factory()->create(['name' => 'Other account workspace']);
 
-    OpnFormServer::actingAs($user, 'mcp')
+    OpnFormServer::actingAs($user, 'oauth')
         ->tool(GetAccountContextTool::class)
         ->assertOk()
         ->assertSee([$user->email, $writable->name, $readonly->name])
         ->assertDontSee('Other account workspace');
 
-    OpnFormServer::actingAs($user, 'mcp')
+    OpnFormServer::actingAs($user, 'oauth')
         ->tool(ListWorkspacesTool::class)
         ->assertOk()
         ->assertSee(['can_write_forms', User::ROLE_READONLY]);
@@ -103,7 +103,7 @@ it('creates an unpublished form automatically when the account has one workspace
     $user = User::factory()->create();
     $workspace = managedWorkspace($user);
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(CreateFormTool::class, [
         'definition' => managedFormDefinition(['visibility' => 'public']),
     ])->assertOk()
         ->assertSee(['unpublished draft', 'Agent-managed intake', 'publish_form']);
@@ -119,11 +119,11 @@ it('requires workspace selection only when multiple workspaces are available', f
     $selected = managedWorkspace($user);
     managedWorkspace($user);
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(CreateFormTool::class, [
         'definition' => managedFormDefinition(),
     ])->assertHasErrors(['multiple workspaces']);
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(CreateFormTool::class, [
         'workspace_id' => $selected->id,
         'definition' => managedFormDefinition(),
     ])->assertOk();
@@ -138,16 +138,16 @@ it('allows readonly members to inspect forms but rejects every mutation', functi
     $workspace->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
     $form = managedForm($owner, $workspace);
 
-    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetFormTool::class, [
+    OpnFormServer::actingAs($readonly, 'oauth')->tool(GetFormTool::class, [
         'form_id' => $form->id,
     ])->assertOk()->assertSee('Existing managed form');
 
-    OpnFormServer::actingAs($readonly, 'mcp')->tool(CreateFormTool::class, [
+    OpnFormServer::actingAs($readonly, 'oauth')->tool(CreateFormTool::class, [
         'workspace_id' => $workspace->id,
         'definition' => managedFormDefinition(),
     ])->assertHasErrors(['read-only']);
 
-    OpnFormServer::actingAs($readonly, 'mcp')->tool(PublishFormTool::class, [
+    OpnFormServer::actingAs($readonly, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
         'confirm_publish' => true,
     ])->assertHasErrors(['read-only']);
@@ -163,7 +163,7 @@ it('lists and searches only accessible non-trashed forms', function () {
     $other = User::factory()->create();
     managedForm($other, managedWorkspace($other), ['title' => 'Customer survey secret']);
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(ListFormsTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(ListFormsTool::class, [
         'search' => 'customer',
         'visibility' => 'draft',
     ])->assertOk()
@@ -178,7 +178,7 @@ it('updates a canonical form without changing publication state and rejects stal
     $management = app(\App\Service\Forms\McpFormManagementService::class);
     $expectedRevision = $management->serializeForm($management->form($user, $form->id))['revision'];
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(UpdateFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(UpdateFormTool::class, [
         'form_id' => $form->id,
         'expected_revision' => $expectedRevision,
         'definition' => managedFormDefinition([
@@ -189,7 +189,7 @@ it('updates a canonical form without changing publication state and rejects stal
 
     expect($form->refresh()->visibility)->toBe('public');
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(UpdateFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(UpdateFormTool::class, [
         'form_id' => $form->id,
         'expected_revision' => $expectedRevision,
         'definition' => managedFormDefinition(['title' => 'Stale overwrite']),
@@ -202,14 +202,14 @@ it('publishes only with confirmation and exposes no publication through update_f
     $user = User::factory()->create();
     $form = managedForm($user, managedWorkspace($user));
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(PublishFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
         'confirm_publish' => false,
     ])->assertHasErrors(['explicit confirmation']);
 
     expect($form->refresh()->visibility)->toBe('draft');
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(PublishFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
         'confirm_publish' => true,
     ])->assertOk()->assertSee('Form published');
@@ -221,14 +221,14 @@ it('moves forms to soft-delete trash only with confirmation', function () {
     $user = User::factory()->create();
     $form = managedForm($user, managedWorkspace($user));
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(TrashFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(TrashFormTool::class, [
         'form_id' => $form->id,
         'confirm_trash' => false,
     ])->assertHasErrors(['explicit confirmation']);
 
     $this->assertNotSoftDeleted($form);
 
-    OpnFormServer::actingAs($user, 'mcp')->tool(TrashFormTool::class, [
+    OpnFormServer::actingAs($user, 'oauth')->tool(TrashFormTool::class, [
         'form_id' => $form->id,
         'confirm_trash' => true,
     ])->assertOk()->assertSee(['moved to trash', 'does not expose restore']);

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -10,6 +10,7 @@ use App\Mcp\Tools\PublishFormTool;
 use App\Mcp\Tools\TrashFormTool;
 use App\Mcp\Tools\UpdateFormTool;
 use App\Models\Forms\Form;
+use App\Models\OAuthProvider;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Service\Forms\AgentFormDefinition;
@@ -47,6 +48,13 @@ function managedForm(User $user, Workspace $workspace, array $overrides = []): F
             'computed_variables' => [],
             'settings' => [],
         ], $overrides));
+}
+
+function managedFormRevision(User $user, Form $form): string
+{
+    $management = app(\App\Service\Forms\McpFormManagementService::class);
+
+    return $management->serializeForm($management->form($user, $form->id))['revision'];
 }
 
 it('registers account tools only for an authenticated MCP account', function () {
@@ -149,6 +157,7 @@ it('allows readonly members to inspect forms but rejects every mutation', functi
 
     OpnFormServer::actingAs($readonly, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
+        'expected_revision' => managedFormRevision($readonly, $form),
         'confirm_publish' => true,
     ])->assertHasErrors(['read-only']);
 });
@@ -198,19 +207,63 @@ it('updates a canonical form without changing publication state and rejects stal
     expect($form->refresh()->title)->toBe('Updated by agent');
 });
 
+it('rejects Stripe accounts outside the selected workspace on create and update', function () {
+    $user = User::factory()->create();
+    $workspace = managedWorkspace($user);
+    $form = managedForm($user, $workspace);
+    $foreignProvider = OAuthProvider::factory()->for(User::factory()->create())->create([
+        'provider' => 'stripe',
+        'provider_user_id' => 'acct_foreign',
+    ]);
+    $definition = managedFormDefinition([
+        'properties' => [[
+            'id' => 'payment-field',
+            'name' => 'Payment',
+            'type' => 'payment',
+            'amount' => 10,
+            'currency' => 'USD',
+            'stripe_account_id' => $foreignProvider->id,
+        ]],
+    ]);
+
+    OpnFormServer::actingAs($user, 'oauth')->tool(CreateFormTool::class, [
+        'workspace_id' => $workspace->id,
+        'definition' => $definition,
+    ])->assertHasErrors(['not associated with this workspace']);
+
+    OpnFormServer::actingAs($user, 'oauth')->tool(UpdateFormTool::class, [
+        'form_id' => $form->id,
+        'expected_revision' => managedFormRevision($user, $form),
+        'definition' => $definition,
+    ])->assertHasErrors(['not associated with this workspace']);
+
+    expect(Form::query()->count())->toBe(1)
+        ->and($form->refresh()->properties)->toBe(managedFormDefinition()['properties']);
+});
+
 it('publishes only with confirmation and exposes no publication through update_form', function () {
     $user = User::factory()->create();
     $form = managedForm($user, managedWorkspace($user));
+    $expectedRevision = managedFormRevision($user, $form);
 
     OpnFormServer::actingAs($user, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
         'confirm_publish' => false,
     ])->assertHasErrors(['explicit confirmation']);
 
     expect($form->refresh()->visibility)->toBe('draft');
 
+    $form->update(['title' => 'Changed after confirmation context']);
     OpnFormServer::actingAs($user, 'oauth')->tool(PublishFormTool::class, [
         'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
+        'confirm_publish' => true,
+    ])->assertHasErrors(['changed since it was fetched']);
+
+    OpnFormServer::actingAs($user, 'oauth')->tool(PublishFormTool::class, [
+        'form_id' => $form->id,
+        'expected_revision' => managedFormRevision($user, $form),
         'confirm_publish' => true,
     ])->assertOk()->assertSee('Form published');
 
@@ -220,16 +273,26 @@ it('publishes only with confirmation and exposes no publication through update_f
 it('moves forms to soft-delete trash only with confirmation', function () {
     $user = User::factory()->create();
     $form = managedForm($user, managedWorkspace($user));
+    $expectedRevision = managedFormRevision($user, $form);
 
     OpnFormServer::actingAs($user, 'oauth')->tool(TrashFormTool::class, [
         'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
         'confirm_trash' => false,
     ])->assertHasErrors(['explicit confirmation']);
 
     $this->assertNotSoftDeleted($form);
 
+    $form->update(['title' => 'Changed after confirmation context']);
     OpnFormServer::actingAs($user, 'oauth')->tool(TrashFormTool::class, [
         'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
+        'confirm_trash' => true,
+    ])->assertHasErrors(['changed since it was fetched']);
+
+    OpnFormServer::actingAs($user, 'oauth')->tool(TrashFormTool::class, [
+        'form_id' => $form->id,
+        'expected_revision' => managedFormRevision($user, $form),
         'confirm_trash' => true,
     ])->assertOk()->assertSee(['moved to trash', 'does not expose restore']);
 

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Mcp\Servers\OpnFormServer;
+use App\Mcp\Tools\CreateFormTool;
+use App\Mcp\Tools\GetAccountContextTool;
+use App\Mcp\Tools\GetFormTool;
+use App\Mcp\Tools\ListFormsTool;
+use App\Mcp\Tools\ListWorkspacesTool;
+use App\Mcp\Tools\PublishFormTool;
+use App\Mcp\Tools\TrashFormTool;
+use App\Mcp\Tools\UpdateFormTool;
+use App\Models\Forms\Form;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Service\Forms\AgentFormDefinition;
+use Laravel\Passport\Passport;
+
+function managedFormDefinition(array $overrides = []): array
+{
+    return array_replace([
+        'schema_version' => 1,
+        'title' => 'Agent-managed intake',
+        'properties' => [
+            ['id' => 'name', 'name' => 'Name', 'type' => 'text'],
+            ['id' => 'email', 'name' => 'Email', 'type' => 'email'],
+        ],
+    ], $overrides);
+}
+
+function managedWorkspace(User $user, string $role = User::ROLE_ADMIN): Workspace
+{
+    $workspace = Workspace::factory()->create();
+    $workspace->users()->attach($user, ['role' => $role]);
+
+    return $workspace;
+}
+
+function managedForm(User $user, Workspace $workspace, array $overrides = []): Form
+{
+    return Form::factory()
+        ->forWorkspace($workspace)
+        ->createdBy($user)
+        ->create(array_replace([
+            'title' => 'Existing managed form',
+            'visibility' => 'draft',
+            'properties' => managedFormDefinition()['properties'],
+            'computed_variables' => [],
+            'settings' => [],
+        ], $overrides));
+}
+
+it('registers account tools only for an authenticated MCP account', function () {
+    expect(app(ListFormsTool::class)->eligibleForRegistration())->toBeFalse();
+
+    $user = User::factory()->create();
+    auth('mcp')->setUser($user);
+
+    expect(app(ListFormsTool::class)->eligibleForRegistration())->toBeTrue();
+});
+
+it('advertises guest tools anonymously and account tools only with scoped OAuth', function () {
+    $payload = [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+        'params' => [],
+    ];
+    $headers = ['Accept' => 'application/json, text/event-stream'];
+
+    $this->postJson('/mcp', $payload, $headers)
+        ->assertOk()
+        ->assertSee('create_form_draft')
+        ->assertDontSee('list_forms');
+
+    $user = User::factory()->create();
+    Passport::actingAs($user, ['mcp:use'], 'mcp');
+
+    $this->postJson('/mcp', $payload, array_merge($headers, [
+        'Authorization' => 'Bearer scoped-account-token',
+    ]))->assertOk()
+        ->assertSee(['create_form_draft', 'list_forms', 'trash_form']);
+});
+
+it('lists only the connected account workspaces with form write capability', function () {
+    $user = User::factory()->create();
+    $writable = managedWorkspace($user);
+    $readonly = managedWorkspace($user, User::ROLE_READONLY);
+    Workspace::factory()->create(['name' => 'Other account workspace']);
+
+    OpnFormServer::actingAs($user, 'mcp')
+        ->tool(GetAccountContextTool::class)
+        ->assertOk()
+        ->assertSee([$user->email, $writable->name, $readonly->name])
+        ->assertDontSee('Other account workspace');
+
+    OpnFormServer::actingAs($user, 'mcp')
+        ->tool(ListWorkspacesTool::class)
+        ->assertOk()
+        ->assertSee(['can_write_forms', User::ROLE_READONLY]);
+});
+
+it('creates an unpublished form automatically when the account has one workspace', function () {
+    $user = User::factory()->create();
+    $workspace = managedWorkspace($user);
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+        'definition' => managedFormDefinition(['visibility' => 'public']),
+    ])->assertOk()
+        ->assertSee(['unpublished draft', 'Agent-managed intake', 'publish_form']);
+
+    $form = Form::query()->sole();
+    expect($form->workspace_id)->toBe($workspace->id)
+        ->and($form->creator_id)->toBe($user->id)
+        ->and($form->visibility)->toBe('draft');
+});
+
+it('requires workspace selection only when multiple workspaces are available', function () {
+    $user = User::factory()->create();
+    $selected = managedWorkspace($user);
+    managedWorkspace($user);
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+        'definition' => managedFormDefinition(),
+    ])->assertHasErrors(['multiple workspaces']);
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(CreateFormTool::class, [
+        'workspace_id' => $selected->id,
+        'definition' => managedFormDefinition(),
+    ])->assertOk();
+
+    expect(Form::query()->sole()->workspace_id)->toBe($selected->id);
+});
+
+it('allows readonly members to inspect forms but rejects every mutation', function () {
+    $owner = User::factory()->create();
+    $readonly = User::factory()->create();
+    $workspace = managedWorkspace($owner);
+    $workspace->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
+    $form = managedForm($owner, $workspace);
+
+    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetFormTool::class, [
+        'form_id' => $form->id,
+    ])->assertOk()->assertSee('Existing managed form');
+
+    OpnFormServer::actingAs($readonly, 'mcp')->tool(CreateFormTool::class, [
+        'workspace_id' => $workspace->id,
+        'definition' => managedFormDefinition(),
+    ])->assertHasErrors(['read-only']);
+
+    OpnFormServer::actingAs($readonly, 'mcp')->tool(PublishFormTool::class, [
+        'form_id' => $form->id,
+        'confirm_publish' => true,
+    ])->assertHasErrors(['read-only']);
+});
+
+it('lists and searches only accessible non-trashed forms', function () {
+    $user = User::factory()->create();
+    $workspace = managedWorkspace($user);
+    managedForm($user, $workspace, ['title' => 'Customer survey']);
+    $trashed = managedForm($user, $workspace, ['title' => 'Customer survey old']);
+    $trashed->delete();
+
+    $other = User::factory()->create();
+    managedForm($other, managedWorkspace($other), ['title' => 'Customer survey secret']);
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(ListFormsTool::class, [
+        'search' => 'customer',
+        'visibility' => 'draft',
+    ])->assertOk()
+        ->assertSee('Customer survey')
+        ->assertDontSee(['Customer survey old', 'Customer survey secret']);
+});
+
+it('updates a canonical form without changing publication state and rejects stale writes', function () {
+    $user = User::factory()->create();
+    $workspace = managedWorkspace($user);
+    $form = managedForm($user, $workspace, ['visibility' => 'public']);
+    $management = app(\App\Service\Forms\McpFormManagementService::class);
+    $expectedRevision = $management->serializeForm($management->form($user, $form->id))['revision'];
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(UpdateFormTool::class, [
+        'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
+        'definition' => managedFormDefinition([
+            'title' => 'Updated by agent',
+            'visibility' => 'draft',
+        ]),
+    ])->assertOk()->assertSee('Updated by agent');
+
+    expect($form->refresh()->visibility)->toBe('public');
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(UpdateFormTool::class, [
+        'form_id' => $form->id,
+        'expected_revision' => $expectedRevision,
+        'definition' => managedFormDefinition(['title' => 'Stale overwrite']),
+    ])->assertHasErrors(['changed since it was fetched']);
+
+    expect($form->refresh()->title)->toBe('Updated by agent');
+});
+
+it('publishes only with confirmation and exposes no publication through update_form', function () {
+    $user = User::factory()->create();
+    $form = managedForm($user, managedWorkspace($user));
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(PublishFormTool::class, [
+        'form_id' => $form->id,
+        'confirm_publish' => false,
+    ])->assertHasErrors(['explicit confirmation']);
+
+    expect($form->refresh()->visibility)->toBe('draft');
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(PublishFormTool::class, [
+        'form_id' => $form->id,
+        'confirm_publish' => true,
+    ])->assertOk()->assertSee('Form published');
+
+    expect($form->refresh()->visibility)->toBe('public');
+});
+
+it('moves forms to soft-delete trash only with confirmation', function () {
+    $user = User::factory()->create();
+    $form = managedForm($user, managedWorkspace($user));
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(TrashFormTool::class, [
+        'form_id' => $form->id,
+        'confirm_trash' => false,
+    ])->assertHasErrors(['explicit confirmation']);
+
+    $this->assertNotSoftDeleted($form);
+
+    OpnFormServer::actingAs($user, 'mcp')->tool(TrashFormTool::class, [
+        'form_id' => $form->id,
+        'confirm_trash' => true,
+    ])->assertOk()->assertSee(['moved to trash', 'does not expose restore']);
+
+    $this->assertSoftDeleted($form);
+});
+
+it('returns canonical definitions for legacy forms without mutating them', function () {
+    $user = User::factory()->create();
+    $form = managedForm($user, managedWorkspace($user));
+
+    $definition = app(AgentFormDefinition::class)->fromForm($form);
+
+    expect($definition)
+        ->toHaveKey('schema_version', 1)
+        ->toHaveKey('title', 'Existing managed form')
+        ->toHaveKey('properties')
+        ->not->toHaveKey('creator_id')
+        ->not->toHaveKey('workspace_id');
+});


### PR DESCRIPTION
## Summary

- expose account context plus workspace list/read tools only to OAuth-authenticated MCP clients
- add list, search, read, create, update, publish, and trash tools for forms
- force newly created forms to remain drafts and require explicit confirmation for publication and trash
- preserve read access for readonly members while rejecting all form mutations
- use canonical form definitions, plan cleaning warnings, and hash-based optimistic revisions

## Safety boundaries

- no workspace mutation tools
- no form restore or permanent-delete tools
- authenticated tools are absent from the guest catalogue and cannot be called anonymously
- direct membership checks prevent cross-workspace access

## Validation

- 1900 backend tests passed, 3 skipped
- 714 frontend tests passed
- 46 MCP tests passed with 228 assertions
- Pint passed on 895 files
- ESLint passed
- targeted MCP PHPStan passed
- global PHPStan reports only the two pre-existing Workspace owners relation findings

## Review fixes

- replaced timestamp concurrency checks with deterministic SHA-256 form revisions after tests demonstrated same-timestamp writes

## Stack

Depends on #1253.