### PR TITLE
MCP 6/9: Read, search, analyze, and export submissions

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -134,6 +134,8 @@ MCP_RATE_LIMIT_PER_MINUTE=120
 MCP_RATE_LIMIT_PER_HOUR=3000
 MCP_DRAFT_CREATES_PER_MINUTE=20
 MCP_DRAFT_CREATES_PER_HOUR=200
+MCP_SUBMISSION_EXPORTS_PER_MINUTE=5
+MCP_SUBMISSION_EXPORTS_PER_HOUR=30
 # Comma-separated OAuth callback origins. Keep this allowlist explicit.
 MCP_OAUTH_REDIRECT_DOMAINS=https://chatgpt.com,https://chat.openai.com,https://claude.ai,http://localhost,http://127.0.0.1,http://[::1]
 MCP_OAUTH_CUSTOM_SCHEMES=chatgpt,claude,cursor,vscode

--- a/api/app/Mcp/Servers/OpnFormServer.php
+++ b/api/app/Mcp/Servers/OpnFormServer.php
@@ -16,6 +16,11 @@ use App\Mcp\Tools\CreateFormTool;
 use App\Mcp\Tools\UpdateFormTool;
 use App\Mcp\Tools\PublishFormTool;
 use App\Mcp\Tools\TrashFormTool;
+use App\Mcp\Tools\ListSubmissionsTool;
+use App\Mcp\Tools\GetSubmissionTool;
+use App\Mcp\Tools\GetSubmissionStatsTool;
+use App\Mcp\Tools\ExportSubmissionsTool;
+use App\Mcp\Tools\GetSubmissionExportTool;
 use App\Mcp\Tools\PatchFormDraftTool;
 use App\Mcp\Tools\PreviewFormDraftTool;
 use App\Mcp\Tools\OpenFormDraftInEditorTool;
@@ -30,6 +35,10 @@ use Laravel\Mcp\Server\Attributes\Version;
 #[Instructions('Build and manage OpnForm forms. Guest-safe draft tools are available without authentication; account, form, and submission tools require OAuth. Read the schema and field catalog before generating a form definition, and validate definitions before saving them.')]
 class OpnFormServer extends Server
 {
+    public int $maxPaginationLength = 100;
+
+    public int $defaultPaginationLength = 50;
+
     protected array $tools = [
         ValidateFormDefinitionTool::class,
         CreateFormDraftTool::class,
@@ -46,6 +55,11 @@ class OpnFormServer extends Server
         UpdateFormTool::class,
         PublishFormTool::class,
         TrashFormTool::class,
+        ListSubmissionsTool::class,
+        GetSubmissionTool::class,
+        GetSubmissionStatsTool::class,
+        ExportSubmissionsTool::class,
+        GetSubmissionExportTool::class,
     ];
 
     protected array $resources = [

--- a/api/app/Mcp/Tools/ExportSubmissionsTool.php
+++ b/api/app/Mcp/Tools/ExportSubmissionsTool.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpSubmissionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('export_submissions')]
+#[Description('Queue a private CSV export for all submissions in an accessible form, or up to 1,000 selected submission IDs. Poll get_submission_export for its temporary download URL.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class ExportSubmissionsTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpSubmissionService $submissions): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'submission_ids' => ['nullable', 'array', 'max:1000'],
+            'submission_ids.*' => ['required', 'integer', 'min:1', 'distinct'],
+        ]);
+
+        return Response::structured($submissions->startExport(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['submission_ids'] ?? [],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'submission_ids' => $schema->array()
+                ->description('Optional selected IDs. Omit to export all submissions.')
+                ->items($schema->integer()->min(1))
+                ->max(1000),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/ExportSubmissionsTool.php
+++ b/api/app/Mcp/Tools/ExportSubmissionsTool.php
@@ -10,11 +10,9 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
-use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('export_submissions')]
 #[Description('Queue a private CSV export for all submissions in an accessible form, or up to 1,000 selected submission IDs. Poll get_submission_export for its temporary download URL.')]
-#[IsReadOnly]
 #[IsOpenWorld(false)]
 class ExportSubmissionsTool extends AuthenticatedMcpTool
 {

--- a/api/app/Mcp/Tools/GetSubmissionExportTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionExportTool.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpSubmissionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_submission_export')]
+#[Description('Check a queued submission export. When completed, returns a temporary private CSV download URL and its expiration time.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetSubmissionExportTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpSubmissionService $submissions): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'job_id' => ['required', 'uuid'],
+        ]);
+
+        return Response::structured($submissions->exportStatus(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['job_id'],
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'job_id' => $schema->string()->description('Export job UUID returned by export_submissions.')->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/GetSubmissionStatsTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionStatsTool.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpSubmissionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_submission_stats')]
+#[Description('Analyze submissions for an accessible form using the same bounded field summaries available in OpnForm. Returns all-time views/completion overview plus a status/date-filtered summary.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetSubmissionStatsTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpSubmissionService $submissions): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'status' => ['nullable', Rule::in(['all', 'completed', 'partial'])],
+            'date_from' => ['nullable', 'date', 'before_or_equal:date_to'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+        ]);
+
+        return Response::structured($submissions->stats(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['status'] ?? 'completed',
+            $validated['date_from'] ?? null,
+            $validated['date_to'] ?? null,
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'status' => $schema->string()->enum(['all', 'completed', 'partial'])->default('completed'),
+            'date_from' => $schema->string()->description('Inclusive ISO 8601 date.'),
+            'date_to' => $schema->string()->description('Inclusive ISO 8601 date.'),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/GetSubmissionTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionTool.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpSubmissionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('get_submission')]
+#[Description('Read one submission from an accessible form, with response values labeled by form field. This tool never changes the submission.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class GetSubmissionTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpSubmissionService $submissions): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'submission_id' => ['required', 'integer', 'min:1'],
+        ]);
+
+        return Response::structured([
+            'submission' => $submissions->get(
+                $this->user($request),
+                $validated['form_id'],
+                $validated['submission_id'],
+            ),
+        ]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'submission_id' => $schema->integer()->min(1)->required(),
+        ];
+    }
+}

--- a/api/app/Mcp/Tools/ListSubmissionsTool.php
+++ b/api/app/Mcp/Tools/ListSubmissionsTool.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Service\Forms\McpSubmissionService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Name('list_submissions')]
+#[Description('List and search submissions for an accessible form. Search matches response values, not field names. Filter by completed/partial status and date; results are paginated.')]
+#[IsReadOnly]
+#[IsOpenWorld(false)]
+class ListSubmissionsTool extends AuthenticatedMcpTool
+{
+    public function handle(Request $request, McpSubmissionService $submissions): ResponseFactory
+    {
+        $validated = $request->validate([
+            'form_id' => ['required', 'integer', 'min:1'],
+            'search' => ['nullable', 'string', 'max:255'],
+            'status' => ['nullable', Rule::in(['all', 'completed', 'partial'])],
+            'date_from' => ['nullable', 'date', 'before_or_equal:date_to'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        return Response::structured($submissions->list(
+            $this->user($request),
+            $validated['form_id'],
+            $validated['search'] ?? null,
+            $validated['status'] ?? 'completed',
+            $validated['date_from'] ?? null,
+            $validated['date_to'] ?? null,
+            $validated['page'] ?? 1,
+            $validated['per_page'] ?? 50,
+        ));
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'search' => $schema->string()->max(255),
+            'status' => $schema->string()->enum(['all', 'completed', 'partial'])->default('completed'),
+            'date_from' => $schema->string()->description('Inclusive ISO 8601 date.'),
+            'date_to' => $schema->string()->description('Inclusive ISO 8601 date.'),
+            'page' => $schema->integer()->min(1)->default(1),
+            'per_page' => $schema->integer()->min(1)->max(100)->default(50),
+        ];
+    }
+}

--- a/api/app/Service/Forms/McpSubmissionExportRateLimiter.php
+++ b/api/app/Service/Forms/McpSubmissionExportRateLimiter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Service\Forms;
+
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Validation\ValidationException;
+
+class McpSubmissionExportRateLimiter
+{
+    public function hit(int $userId, int $formId): void
+    {
+        $identifier = hash('sha256', $userId.':'.$formId);
+        $minuteKey = "mcp:submission-export:minute:{$identifier}";
+        $hourKey = "mcp:submission-export:hour:{$identifier}";
+        $minuteLimit = max(1, config('opnform.mcp.rate_limit.submission_exports_per_minute', 5));
+        $hourLimit = max(1, config('opnform.mcp.rate_limit.submission_exports_per_hour', 30));
+
+        if (RateLimiter::tooManyAttempts($minuteKey, $minuteLimit)
+            || RateLimiter::tooManyAttempts($hourKey, $hourLimit)) {
+            throw ValidationException::withMessages([
+                'form_id' => ['Too many submission exports were queued. Reuse the current export or try again later.'],
+            ]);
+        }
+
+        RateLimiter::hit($minuteKey, 60);
+        RateLimiter::hit($hourKey, 3600);
+    }
+}

--- a/api/app/Service/Forms/McpSubmissionService.php
+++ b/api/app/Service/Forms/McpSubmissionService.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Jobs\Form\ExportFormSubmissionsJob;
+use App\Models\Forms\Form;
+use App\Models\Forms\FormSubmission;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class McpSubmissionService
+{
+    public function __construct(
+        private readonly McpFormManagementService $forms,
+        private readonly FormSummaryService $summaries,
+        private readonly FormExportService $exports,
+        private readonly McpSubmissionExportRateLimiter $exportRateLimiter,
+    ) {
+    }
+
+    /** @return array{submissions: array<int, array<string, mixed>>, pagination: array<string, int>} */
+    public function list(
+        User $user,
+        int $formId,
+        ?string $search,
+        string $status,
+        ?string $dateFrom,
+        ?string $dateTo,
+        int $page,
+        int $perPage,
+    ): array {
+        $form = $this->forms->form($user, $formId);
+        $query = $this->submissionQuery($form, $status, $dateFrom, $dateTo);
+
+        if ($search) {
+            $driver = DB::connection()->getDriverName();
+
+            if ($driver === 'mysql') {
+                $query->whereRaw("JSON_SEARCH(data, 'one', ?) IS NOT NULL", ['%'.$search.'%']);
+            } elseif ($driver === 'sqlite') {
+                $query->whereRaw("EXISTS (
+                    SELECT 1 FROM json_each(data)
+                    WHERE CAST(json_each.value AS TEXT) LIKE ?
+                )", ['%'.$search.'%']);
+            } else {
+                $query->whereRaw("EXISTS (
+                    SELECT 1 FROM jsonb_each_text(data) AS kv(key, value)
+                    WHERE kv.value ILIKE ?
+                )", ['%'.$search.'%']);
+            }
+        }
+
+        $submissions = $query->orderByDesc('created_at')->paginate($perPage, ['*'], 'page', $page);
+
+        return [
+            'submissions' => collect($submissions->items())
+                ->map(fn (FormSubmission $submission) => $this->serialize($form, $submission))
+                ->all(),
+            'pagination' => [
+                'page' => $submissions->currentPage(),
+                'per_page' => $submissions->perPage(),
+                'total' => $submissions->total(),
+                'last_page' => $submissions->lastPage(),
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function get(User $user, int $formId, int $submissionId): array
+    {
+        $form = $this->forms->form($user, $formId);
+        $submission = $form->submissions()->find($submissionId);
+
+        if (! $submission) {
+            throw ValidationException::withMessages([
+                'submission_id' => ['Submission not found or not accessible.'],
+            ]);
+        }
+
+        return $this->serialize($form, $submission);
+    }
+
+    /** @return array<string, mixed> */
+    public function stats(
+        User $user,
+        int $formId,
+        string $status,
+        ?string $dateFrom,
+        ?string $dateTo,
+    ): array {
+        $form = $this->forms->form($user, $formId);
+        $filtered = $this->submissionQuery($form, $status, $dateFrom, $dateTo);
+        $filteredCount = (clone $filtered)->count();
+        $averageDuration = (clone $filtered)->whereNotNull('completion_time')->avg('completion_time');
+        $views = $form->views_count;
+        $completed = $form->submissions()->where('status', FormSubmission::STATUS_COMPLETED)->count();
+        $partial = $form->submissions()->where('status', FormSubmission::STATUS_PARTIAL)->count();
+
+        return [
+            'form_id' => $form->id,
+            'filters' => [
+                'status' => $status,
+                'date_from' => $dateFrom,
+                'date_to' => $dateTo,
+            ],
+            'overview' => [
+                'views' => $views,
+                'completed_submissions' => $completed,
+                'partial_submissions' => $partial,
+                'completion_rate' => $views > 0 ? round(($completed / $views) * 100, 2) : 0,
+            ],
+            'filtered_submissions' => $filteredCount,
+            'average_completion_seconds' => $averageDuration !== null ? round((float) $averageDuration, 2) : null,
+            'field_summary' => $this->summaries->generateSummary($form, $dateFrom, $dateTo, $status),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function startExport(User $user, int $formId, array $submissionIds): array
+    {
+        $form = $this->forms->form($user, $formId);
+
+        if ($submissionIds !== []) {
+            $matched = $form->submissions()->whereIn('id', $submissionIds)->count();
+
+            if ($matched !== count(array_unique($submissionIds))) {
+                throw ValidationException::withMessages([
+                    'submission_ids' => ['One or more submissions were not found in this form.'],
+                ]);
+            }
+        } elseif (! $form->submissions()->exists()) {
+            throw ValidationException::withMessages([
+                'form_id' => ['This form has no submissions to export.'],
+            ]);
+        }
+
+        $this->exportRateLimiter->hit($user->id, $form->id);
+
+        $columns = collect($form->properties)
+            ->filter(fn (array $property) => isset($property['id']) && ! str_starts_with((string) ($property['type'] ?? ''), 'nf-'))
+            ->mapWithKeys(fn (array $property) => [$property['id'] => true])
+            ->put('created_at', true)
+            ->all();
+        $jobId = $this->exports->initializeAsyncExport($form, $user->id);
+
+        ExportFormSubmissionsJob::dispatch($form, $columns, $submissionIds, $jobId, $user->id);
+
+        return [
+            'job_id' => $jobId,
+            'status' => 'queued',
+            'message' => 'Submission export queued. Poll get_submission_export until it is completed or failed.',
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function exportStatus(User $user, int $formId, string $jobId): array
+    {
+        $form = $this->forms->form($user, $formId);
+        $job = Cache::get($this->exports->getCacheKey($jobId));
+
+        if (! is_array($job)
+            || (int) ($job['user_id'] ?? 0) !== $user->id
+            || (int) ($job['form_id'] ?? 0) !== $form->id) {
+            throw ValidationException::withMessages([
+                'job_id' => ['Export not found, expired, or not accessible.'],
+            ]);
+        }
+
+        return [
+            'job_id' => $jobId,
+            'status' => $job['status'],
+            'progress' => $job['progress'],
+            'processed_submissions' => $job['processed_submissions'] ?? null,
+            'total_submissions' => $job['total_submissions'] ?? null,
+            'file_url' => $job['file_url'] ?? null,
+            'expires_at' => $job['expires_at'] ?? null,
+            'error_message' => $job['error_message'] ?? null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function serialize(Form $form, FormSubmission $submission): array
+    {
+        $responses = (new FormSubmissionFormatter($form, $submission->data ?? []))
+            ->showHiddenFields()
+            ->showRemovedFields()
+            ->useSignedUrlForFiles()
+            ->getCleanKeyValue();
+
+        $result = [
+            'id' => $submission->id,
+            'form_id' => $form->id,
+            'status' => $submission->status,
+            'created_at' => $submission->created_at?->toISOString(),
+            'updated_at' => $submission->updated_at?->toISOString(),
+            'completion_time_seconds' => $submission->completion_time,
+            'responses' => $responses,
+        ];
+
+        if ($form->enable_ip_tracking
+            && $form->workspace->hasFeature('enable_ip_tracking')
+            && ! empty($submission->meta['ip_address'] ?? null)) {
+            $result['ip_address'] = $submission->meta['ip_address'];
+        }
+
+        return $result;
+    }
+
+    private function submissionQuery(
+        Form $form,
+        string $status,
+        ?string $dateFrom,
+        ?string $dateTo,
+    ): Builder {
+        return $form->submissions()->getQuery()
+            ->when($status === 'completed', fn (Builder $query) => $query->where('status', FormSubmission::STATUS_COMPLETED))
+            ->when($status === 'partial', fn (Builder $query) => $query->where('status', FormSubmission::STATUS_PARTIAL))
+            ->when($dateFrom, fn (Builder $query) => $query->whereDate('created_at', '>=', $dateFrom))
+            ->when($dateTo, fn (Builder $query) => $query->whereDate('created_at', '<=', $dateTo));
+    }
+}

--- a/api/config/opnform.php
+++ b/api/config/opnform.php
@@ -24,6 +24,8 @@ return [
             'per_hour' => (int) env('MCP_RATE_LIMIT_PER_HOUR', 3000),
             'draft_creates_per_minute' => (int) env('MCP_DRAFT_CREATES_PER_MINUTE', 20),
             'draft_creates_per_hour' => (int) env('MCP_DRAFT_CREATES_PER_HOUR', 200),
+            'submission_exports_per_minute' => (int) env('MCP_SUBMISSION_EXPORTS_PER_MINUTE', 5),
+            'submission_exports_per_hour' => (int) env('MCP_SUBMISSION_EXPORTS_PER_HOUR', 30),
         ],
     ],
     'webhooks' => [

--- a/api/tests/Feature/Mcp/SubmissionToolsTest.php
+++ b/api/tests/Feature/Mcp/SubmissionToolsTest.php
@@ -1,0 +1,175 @@
+<?php
+
+use App\Jobs\Form\ExportFormSubmissionsJob;
+use App\Mcp\Servers\OpnFormServer;
+use App\Mcp\Tools\ExportSubmissionsTool;
+use App\Mcp\Tools\GetSubmissionExportTool;
+use App\Mcp\Tools\GetSubmissionStatsTool;
+use App\Mcp\Tools\GetSubmissionTool;
+use App\Mcp\Tools\ListSubmissionsTool;
+use App\Models\Forms\FormSubmission;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Passport\Passport;
+
+function submissionFixture(array $completedValues = ['Alice', 'Bob']): array
+{
+    $user = User::factory()->create();
+    $workspace = createUserWorkspace($user);
+    $form = createForm($user, $workspace, ['enable_partial_submissions' => true]);
+    $fieldId = $form->properties[0]['id'];
+    $submissions = collect($completedValues)->map(fn (string $value) => $form->submissions()->create([
+        'data' => [$fieldId => $value],
+        'status' => FormSubmission::STATUS_COMPLETED,
+        'completion_time' => 30,
+    ]));
+
+    return compact('user', 'workspace', 'form', 'fieldId', 'submissions');
+}
+
+it('advertises submission tools only to scoped OAuth accounts and no mutation tools', function () {
+    $payload = [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+        'params' => [],
+    ];
+    $headers = ['Accept' => 'application/json, text/event-stream'];
+
+    $this->postJson('/mcp', $payload, $headers)
+        ->assertOk()
+        ->assertDontSee('list_submissions');
+
+    $user = User::factory()->create();
+    Passport::actingAs($user, ['mcp:use'], 'mcp');
+
+    $this->postJson('/mcp', $payload, array_merge($headers, [
+        'Authorization' => 'Bearer submission-scope-token',
+    ]))->assertOk()
+        ->assertSee(['list_submissions', 'get_submission_stats', 'export_submissions'])
+        ->assertDontSee(['update_submission', 'delete_submission', 'create_submission']);
+});
+
+it('searches response values and filters submission status without leaking other forms', function () {
+    $fixture = submissionFixture(['Alice Example', 'Bob Example']);
+    $partial = $fixture['form']->submissions()->create([
+        'data' => [$fixture['fieldId'] => 'Alice Partial'],
+        'status' => FormSubmission::STATUS_PARTIAL,
+    ]);
+    $other = submissionFixture(['Alice Secret']);
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+        'search' => 'Alice',
+        'status' => 'completed',
+    ])->assertOk()
+        ->assertSee('Alice Example')
+        ->assertDontSee(['Bob Example', 'Alice Partial', 'Alice Secret']);
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+        'status' => 'partial',
+    ])->assertOk()->assertSee((string) $partial->id)->assertSee('Alice Partial');
+
+    expect($other['form']->id)->not->toBe($fixture['form']->id);
+});
+
+it('lets readonly workspace members read submissions and rejects cross-form IDs', function () {
+    $fixture = submissionFixture();
+    $readonly = User::factory()->create();
+    $fixture['workspace']->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
+    $submission = $fixture['submissions']->first();
+
+    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetSubmissionTool::class, [
+        'form_id' => $fixture['form']->id,
+        'submission_id' => $submission->id,
+    ])->assertOk()->assertSee('Alice');
+
+    $other = submissionFixture(['Outside']);
+    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetSubmissionTool::class, [
+        'form_id' => $fixture['form']->id,
+        'submission_id' => $other['submissions']->first()->id,
+    ])->assertHasErrors(['not found or not accessible']);
+});
+
+it('returns bounded existing form analytics with filtered field summaries', function () {
+    $fixture = submissionFixture(['Alice', 'Bob']);
+    $fixture['form']->submissions()->create([
+        'data' => [$fixture['fieldId'] => 'In progress'],
+        'status' => FormSubmission::STATUS_PARTIAL,
+        'completion_time' => 10,
+    ]);
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(GetSubmissionStatsTool::class, [
+        'form_id' => $fixture['form']->id,
+        'status' => 'completed',
+    ])->assertOk()
+        ->assertSee(['completed_submissions', 'partial_submissions', 'field_summary', 'processed_submissions'])
+        ->assertSee('Alice')
+        ->assertDontSee('In progress');
+});
+
+it('queues private CSV exports and scopes status polling to the requesting account', function () {
+    Queue::fake();
+    $fixture = submissionFixture();
+    $selectedId = $fixture['submissions']->first()->id;
+
+    $response = OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+        'submission_ids' => [$selectedId],
+    ]);
+    $response->assertOk()->assertSee(['job_id', 'queued', 'get_submission_export']);
+
+    Queue::assertPushed(ExportFormSubmissionsJob::class, fn (ExportFormSubmissionsJob $job) => $job->userId === $fixture['user']->id
+        && $job->form->is($fixture['form'])
+        && $job->submissionIds === [$selectedId]);
+
+    $jobId = Queue::pushed(ExportFormSubmissionsJob::class)->first()->jobId;
+    $job = Cache::get('form_export_job:'.$jobId);
+    expect($job['status'])->toBe('queued');
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(GetSubmissionExportTool::class, [
+        'form_id' => $fixture['form']->id,
+        'job_id' => $jobId,
+    ])->assertOk()->assertSee(['queued', 'progress']);
+
+    $otherMember = User::factory()->create();
+    $fixture['workspace']->users()->attach($otherMember, ['role' => User::ROLE_USER]);
+    OpnFormServer::actingAs($otherMember, 'mcp')->tool(GetSubmissionExportTool::class, [
+        'form_id' => $fixture['form']->id,
+        'job_id' => $jobId,
+    ])->assertHasErrors(['not accessible']);
+});
+
+it('rejects exports containing submission IDs from another form', function () {
+    Queue::fake();
+    $fixture = submissionFixture();
+    $other = submissionFixture(['Secret']);
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+        'submission_ids' => [$other['submissions']->first()->id],
+    ])->assertHasErrors(['not found in this form']);
+
+    Queue::assertNotPushed(ExportFormSubmissionsJob::class);
+});
+
+it('rate limits repeated heavy export requests without affecting submission reads', function () {
+    Queue::fake();
+    config()->set('opnform.mcp.rate_limit.submission_exports_per_minute', 1);
+    config()->set('opnform.mcp.rate_limit.submission_exports_per_hour', 10);
+    $fixture = submissionFixture();
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+    ])->assertOk();
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+    ])->assertHasErrors(['Too many submission exports']);
+
+    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+        'form_id' => $fixture['form']->id,
+    ])->assertOk()->assertSee('Alice');
+});

--- a/api/tests/Feature/Mcp/SubmissionToolsTest.php
+++ b/api/tests/Feature/Mcp/SubmissionToolsTest.php
@@ -44,11 +44,16 @@ it('advertises submission tools only to scoped OAuth accounts and no mutation to
     $user = User::factory()->create();
     Passport::actingAs($user, ['mcp:use'], 'oauth');
 
-    $this->postJson('/mcp', $payload, array_merge($headers, [
+    $response = $this->postJson('/mcp', $payload, array_merge($headers, [
         'Authorization' => 'Bearer submission-scope-token',
     ]))->assertOk()
         ->assertSee(['list_submissions', 'get_submission_stats', 'export_submissions'])
         ->assertDontSee(['update_submission', 'delete_submission', 'create_submission']);
+
+    $tools = collect($response->json('result.tools'))->keyBy('name');
+
+    expect($tools['list_submissions']['annotations']['readOnlyHint'])->toBeTrue()
+        ->and($tools['export_submissions']['annotations']['readOnlyHint'] ?? false)->toBeFalse();
 });
 
 it('searches response values and filters submission status without leaking other forms', function () {

--- a/api/tests/Feature/Mcp/SubmissionToolsTest.php
+++ b/api/tests/Feature/Mcp/SubmissionToolsTest.php
@@ -42,7 +42,7 @@ it('advertises submission tools only to scoped OAuth accounts and no mutation to
         ->assertDontSee('list_submissions');
 
     $user = User::factory()->create();
-    Passport::actingAs($user, ['mcp:use'], 'mcp');
+    Passport::actingAs($user, ['mcp:use'], 'oauth');
 
     $this->postJson('/mcp', $payload, array_merge($headers, [
         'Authorization' => 'Bearer submission-scope-token',
@@ -59,7 +59,7 @@ it('searches response values and filters submission status without leaking other
     ]);
     $other = submissionFixture(['Alice Secret']);
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ListSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
         'search' => 'Alice',
         'status' => 'completed',
@@ -67,7 +67,7 @@ it('searches response values and filters submission status without leaking other
         ->assertSee('Alice Example')
         ->assertDontSee(['Bob Example', 'Alice Partial', 'Alice Secret']);
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ListSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
         'status' => 'partial',
     ])->assertOk()->assertSee((string) $partial->id)->assertSee('Alice Partial');
@@ -81,13 +81,13 @@ it('lets readonly workspace members read submissions and rejects cross-form IDs'
     $fixture['workspace']->users()->attach($readonly, ['role' => User::ROLE_READONLY]);
     $submission = $fixture['submissions']->first();
 
-    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetSubmissionTool::class, [
+    OpnFormServer::actingAs($readonly, 'oauth')->tool(GetSubmissionTool::class, [
         'form_id' => $fixture['form']->id,
         'submission_id' => $submission->id,
     ])->assertOk()->assertSee('Alice');
 
     $other = submissionFixture(['Outside']);
-    OpnFormServer::actingAs($readonly, 'mcp')->tool(GetSubmissionTool::class, [
+    OpnFormServer::actingAs($readonly, 'oauth')->tool(GetSubmissionTool::class, [
         'form_id' => $fixture['form']->id,
         'submission_id' => $other['submissions']->first()->id,
     ])->assertHasErrors(['not found or not accessible']);
@@ -101,7 +101,7 @@ it('returns bounded existing form analytics with filtered field summaries', func
         'completion_time' => 10,
     ]);
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(GetSubmissionStatsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(GetSubmissionStatsTool::class, [
         'form_id' => $fixture['form']->id,
         'status' => 'completed',
     ])->assertOk()
@@ -115,7 +115,7 @@ it('queues private CSV exports and scopes status polling to the requesting accou
     $fixture = submissionFixture();
     $selectedId = $fixture['submissions']->first()->id;
 
-    $response = OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+    $response = OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ExportSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
         'submission_ids' => [$selectedId],
     ]);
@@ -129,14 +129,14 @@ it('queues private CSV exports and scopes status polling to the requesting accou
     $job = Cache::get('form_export_job:'.$jobId);
     expect($job['status'])->toBe('queued');
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(GetSubmissionExportTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(GetSubmissionExportTool::class, [
         'form_id' => $fixture['form']->id,
         'job_id' => $jobId,
     ])->assertOk()->assertSee(['queued', 'progress']);
 
     $otherMember = User::factory()->create();
     $fixture['workspace']->users()->attach($otherMember, ['role' => User::ROLE_USER]);
-    OpnFormServer::actingAs($otherMember, 'mcp')->tool(GetSubmissionExportTool::class, [
+    OpnFormServer::actingAs($otherMember, 'oauth')->tool(GetSubmissionExportTool::class, [
         'form_id' => $fixture['form']->id,
         'job_id' => $jobId,
     ])->assertHasErrors(['not accessible']);
@@ -147,7 +147,7 @@ it('rejects exports containing submission IDs from another form', function () {
     $fixture = submissionFixture();
     $other = submissionFixture(['Secret']);
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ExportSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
         'submission_ids' => [$other['submissions']->first()->id],
     ])->assertHasErrors(['not found in this form']);
@@ -161,15 +161,15 @@ it('rate limits repeated heavy export requests without affecting submission read
     config()->set('opnform.mcp.rate_limit.submission_exports_per_hour', 10);
     $fixture = submissionFixture();
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ExportSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
     ])->assertOk();
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ExportSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ExportSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
     ])->assertHasErrors(['Too many submission exports']);
 
-    OpnFormServer::actingAs($fixture['user'], 'mcp')->tool(ListSubmissionsTool::class, [
+    OpnFormServer::actingAs($fixture['user'], 'oauth')->tool(ListSubmissionsTool::class, [
         'form_id' => $fixture['form']->id,
     ])->assertOk()->assertSee('Alice');
 });


### PR DESCRIPTION
## Summary

- add OAuth-only tools to list/search and read form submissions
- expose bounded form analytics using the existing OpnForm field-summary service
- queue private CSV exports and provide account-scoped status polling with temporary URLs
- preserve readonly workspace member access without exposing any submission mutation tool

## Safety boundaries

- no create, update, or delete submission tools
- response search stays inside accessible forms and searches JSON values only
- export selections are verified against the requested form
- export status is bound to both requesting account and form
- dedicated configurable export rate limits default to 5/minute and 30/hour per account/form

## Validation

- 1907 backend tests passed, 3 skipped
- 714 frontend tests passed
- 53 MCP tests passed with 264 assertions
- Pint passed on 903 files
- ESLint passed
- targeted MCP PHPStan passed
- global PHPStan reports only the two pre-existing Workspace owners relation findings

## Review fixes

- increased MCP tool catalogue pagination so hosts receive the complete tool set by default
- added portable SQLite, PostgreSQL, and MySQL JSON value search
- added account/form-scoped export throttling

## Stack

Depends on #1254.