### PR TITLE
MCP 9/9: Consolidate form update persistence

### DIFF
--- a/api/app/Http/Controllers/Forms/FormController.php
+++ b/api/app/Http/Controllers/Forms/FormController.php
@@ -16,6 +16,7 @@ use App\Notifications\Forms\MobileEditorEmail;
 use App\Service\Billing\Feature;
 use App\Service\Forms\FormCleaner;
 use App\Service\Forms\FormCreationService;
+use App\Service\Forms\FormUpdateService;
 use App\Service\Storage\FileUploadPathService;
 use App\Service\Storage\StorageFileNameParser;
 use App\Service\Storage\UploadSecurityService;
@@ -31,8 +32,10 @@ class FormController extends Controller
 
     private FormCleaner $formCleaner;
 
-    public function __construct(private readonly FormCreationService $formCreation)
-    {
+    public function __construct(
+        private readonly FormCreationService $formCreation,
+        private readonly FormUpdateService $formUpdate,
+    ) {
         $this->middleware('auth', ['except' => ['uploadAsset']]);
         $this->formCleaner = new FormCleaner();
     }
@@ -155,26 +158,11 @@ class FormController extends Controller
     {
         $this->authorize('update', $form);
 
-        $formData = $this->formCleaner
-            ->processRequest($request)
-            ->simulateCleaning($form->workspace)
-            ->getData();
+        $updated = $this->formUpdate->update($form, $request->validated());
+        $form = $updated['form'];
 
-        // Set Removed Properties (pre-compute lookup set to avoid O(n²) complexity)
-        $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
-        $formData['removed_properties'] = array_merge(
-            $form->removed_properties,
-            collect($form->properties)->filter(function ($field) use ($newPropertyIds) {
-                return !Str::of($field['type'])->startsWith('nf-') && !isset($newPropertyIds[$field['id']]);
-            })->toArray()
-        );
-
-        $form->slug = (config('app.self_hosted') && !empty($formData['slug'])) ? $formData['slug'] : $form->slug;
-
-        $form->update($formData);
-
-        if ($this->formCleaner->hasCleaned()) {
-            $requiredUpgrade = collect($this->formCleaner->getCleaningKeys())
+        if ($updated['has_cleaned']) {
+            $requiredUpgrade = collect($updated['cleaning_keys'])
                 ->flatten()
                 ->map(fn (string $feature) => app(\App\Service\Billing\PlanAccessService::class)->getFormFeatureRequiredTier($feature))
                 ->filter()
@@ -190,7 +178,7 @@ class FormController extends Controller
 
         return $this->success([
             'message' => $message . ($form->visibility == 'draft' ? ' But other people won\'t be able to see the form since it\'s currently in draft mode' : ''),
-            'form' => (new FormResource($form))->setCleanings($this->formCleaner->getPerformedCleanings()),
+            'form' => (new FormResource($form))->setCleanings($updated['cleanings']),
         ]);
     }
 

--- a/api/app/Service/Forms/FormUpdateService.php
+++ b/api/app/Service/Forms/FormUpdateService.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Service\Forms;
+
+use App\Models\Forms\Form;
+use Illuminate\Support\Str;
+
+final class FormUpdateService
+{
+    /**
+     * @return array{form: Form, cleanings: array, cleaning_keys: array, has_cleaned: bool}
+     */
+    public function update(Form $form, array $data): array
+    {
+        $cleaner = (new FormCleaner())
+            ->processData($data, $form)
+            ->simulateCleaning($form->workspace);
+        $formData = $cleaner->getData();
+        unset($formData['schema_version']);
+
+        $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
+        $formData['removed_properties'] = array_merge(
+            $form->removed_properties ?? [],
+            collect($form->properties)
+                ->filter(fn (array $field): bool => ! Str::of($field['type'])->startsWith('nf-') && ! isset($newPropertyIds[$field['id']]))
+                ->all(),
+        );
+
+        $form->slug = config('app.self_hosted') && ! empty($formData['slug'])
+            ? $formData['slug']
+            : $form->slug;
+        $form->update($formData);
+
+        return [
+            'form' => $form,
+            'cleanings' => $cleaner->getPerformedCleanings(),
+            'cleaning_keys' => $cleaner->getCleaningKeys(),
+            'has_cleaned' => $cleaner->hasCleaned(),
+        ];
+    }
+}

--- a/api/app/Service/Forms/McpFormManagementService.php
+++ b/api/app/Service/Forms/McpFormManagementService.php
@@ -16,6 +16,7 @@ class McpFormManagementService
     public function __construct(
         private readonly AgentFormDefinition $definitions,
         private readonly FormCreationService $formCreation,
+        private readonly FormUpdateService $formUpdate,
     ) {
     }
 
@@ -146,24 +147,12 @@ class McpFormManagementService
             $definition = $this->definitions->normalizeAndValidate($definition, $form->workspace);
             $definition['visibility'] = $form->visibility;
 
-            $cleaner = (new FormCleaner())
-                ->processData($definition, $form)
-                ->simulateCleaning($form->workspace);
-            $formData = $cleaner->getData();
-            unset($formData['schema_version']);
-
-            $newPropertyIds = collect($formData['properties'])->pluck('id')->flip()->all();
-            $formData['removed_properties'] = array_merge(
-                $form->removed_properties ?? [],
-                collect($form->properties)->filter(fn (array $field) => ! Str::of($field['type'])->startsWith('nf-') && ! isset($newPropertyIds[$field['id']]))->all(),
-            );
-
-            $form->update($formData);
+            $updated = $this->formUpdate->update($form, $definition);
 
             return [
                 'message' => 'Form updated.',
-                'form' => $this->serializeForm($form->refresh()->load('workspace')),
-                'disabled_features' => $cleaner->getPerformedCleanings(),
+                'form' => $this->serializeForm($updated['form']->refresh()->load('workspace')),
+                'disabled_features' => $updated['cleanings'],
             ];
         });
     }

--- a/api/tests/Feature/Forms/FormUpdateServiceTest.php
+++ b/api/tests/Feature/Forms/FormUpdateServiceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Http\Resources\FormResource;
+use App\Service\Forms\FormUpdateService;
+
+it('centralizes persistence and tracks only removed input properties', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $previouslyRemoved = ['id' => 'old-email', 'name' => 'Old email', 'type' => 'email'];
+    $form = $this->createForm($user, $workspace, [
+        'properties' => [
+            ['id' => 'kept-name', 'name' => 'Name', 'type' => 'text'],
+            ['id' => 'removed-email', 'name' => 'Email', 'type' => 'email'],
+            ['id' => 'removed-copy', 'name' => 'Introduction', 'type' => 'nf-text', 'content' => '<p>Hello</p>'],
+        ],
+        'removed_properties' => [$previouslyRemoved],
+    ]);
+    $data = (new FormResource($form))->toArray(request());
+    $data['title'] = 'Updated through the canonical service';
+    $data['clear_empty_fields_on_update'] = false;
+    $data['properties'] = [
+        ['id' => 'kept-name', 'name' => 'Name', 'type' => 'text'],
+    ];
+
+    $updated = app(FormUpdateService::class)->update($form, $data);
+    $removedIds = collect($form->refresh()->removed_properties)->pluck('id')->all();
+
+    expect($updated)->toHaveKeys(['form', 'cleanings', 'cleaning_keys', 'has_cleaned'])
+        ->and($form->title)->toBe('Updated through the canonical service')
+        ->and($removedIds)->toContain('old-email', 'removed-email')
+        ->and($removedIds)->not->toContain('removed-copy');
+});

--- a/scripts/e2e-reset.sh
+++ b/scripts/e2e-reset.sh
@@ -8,6 +8,7 @@ COMPOSE_FILES="-f $ROOT_DIR/docker-compose.e2e.yml"
 docker compose $COMPOSE_FILES exec -T api sh -lc 'rm -rf storage/framework/cache/data/* storage/framework/sessions/*'
 docker compose $COMPOSE_FILES exec -T api php artisan optimize:clear
 docker compose $COMPOSE_FILES exec -T api php artisan cache:clear
+docker compose $COMPOSE_FILES exec -T api sh -lc 'mkdir -p storage/framework/cache/data storage/framework/sessions && chmod -R a+rwX storage/framework/cache storage/framework/sessions'
 docker compose $COMPOSE_FILES exec -T api php artisan migrate:fresh --seed --seeder=Database\\Seeders\\E2ETestSeeder --force
 
 echo "E2E database reset complete."


### PR DESCRIPTION
## Summary
- centralize form persistence and premium-feature cleaning in FormUpdateService
- share the same update path between the regular form API and authenticated MCP tools
- preserve MCP revision locking, visibility, authorization, and response semantics
- cover removed input tracking while excluding layout blocks

## Validation
- backend: 1964 passed, 3 skipped
- targeted MCP/form tests: 60 passed, 1 skipped
- frontend: 54 files / 735 tests passed
- frontend lint: passed
- Pint and route cache: passed
- PHPStan: no errors in changed application files; the full project retains two pre-existing billing backfill findings