### PR TITLE
fix(formatter): safely validate and escape url and email links in cle…

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -153,9 +153,9 @@ class FormSubmissionFormatter
             }
 
             if ($this->createLinks && $field['type'] == 'url') {
-                $returnArray[$field['name']] = '<a href="' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $returnArray[$field['name']] = $this->formatUrlLink($data[$field['id']]);
             } elseif ($this->createLinks && $field['type'] == 'email') {
-                $returnArray[$field['name']] = '<a href="mailto:' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $returnArray[$field['name']] = $this->formatEmailLink($data[$field['id']]);
             } elseif ($field['type'] == 'multi_select') {
                 $val = $data[$field['id']];
                 if ($this->outputStringsOnly && is_array($val)) {


### PR DESCRIPTION
…an key-value outputs

In FormSubmissionFormatter::getCleanKeyValue(), url and email fields with createLinks enabled were directly concatenating raw submitted values into HTML anchor tags without escaping or validating. Replaced with formatUrlLink() and formatEmailLink() to ensure URL/email validation and proper HTML escaping with buildSafeHtmlLink().