### PR TITLE
Harden submission formatter URL and email links

### DIFF
--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -153,9 +153,9 @@ class FormSubmissionFormatter
             }
 
             if ($this->createLinks && $field['type'] == 'url') {
-                $returnArray[$field['name']] = '<a href="' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $returnArray[$field['name']] = $this->formatUrlLink($data[$field['id']]);
             } elseif ($this->createLinks && $field['type'] == 'email') {
-                $returnArray[$field['name']] = '<a href="mailto:' . $data[$field['id']] . '">' . $data[$field['id']] . '</a>';
+                $returnArray[$field['name']] = $this->formatEmailLink($data[$field['id']]);
             } elseif ($field['type'] == 'multi_select') {
                 $val = $data[$field['id']];
                 if ($this->outputStringsOnly && is_array($val)) {
@@ -315,13 +315,24 @@ class FormSubmissionFormatter
 
     private function formatUrlLink(mixed $value): string
     {
-        $url = is_scalar($value) ? (string) $value : '';
-
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+        if (!is_scalar($value)) {
             return $this->escapeHtmlValue($value);
         }
 
-        return $this->buildSafeHtmlLink($url, $url);
+        $label = trim((string) $value);
+        $scheme = parse_url($label, PHP_URL_SCHEME);
+
+        if ($scheme !== null && (!is_string($scheme) || !in_array(strtolower($scheme), ['http', 'https'], true))) {
+            return $this->escapeHtmlValue($label);
+        }
+
+        $url = $scheme === null ? 'https://' . $label : $label;
+
+        if (!filter_var($url, FILTER_VALIDATE_URL) || !parse_url($url, PHP_URL_HOST)) {
+            return $this->escapeHtmlValue($label);
+        }
+
+        return $this->buildSafeHtmlLink($url, $label);
     }
 
     private function formatEmailLink(mixed $value): string

--- a/api/app/Service/Forms/FormSubmissionFormatter.php
+++ b/api/app/Service/Forms/FormSubmissionFormatter.php
@@ -327,8 +327,15 @@ class FormSubmissionFormatter
         }
 
         $url = $scheme === null ? 'https://' . $label : $label;
+        $urlParts = parse_url($url);
 
-        if (!filter_var($url, FILTER_VALIDATE_URL) || !parse_url($url, PHP_URL_HOST)) {
+        if (
+            !filter_var($url, FILTER_VALIDATE_URL)
+            || !is_array($urlParts)
+            || empty($urlParts['host'])
+            || isset($urlParts['user'])
+            || isset($urlParts['pass'])
+        ) {
             return $this->escapeHtmlValue($label);
         }
 

--- a/api/tests/Unit/Service/Forms/FormSubmissionFormatterTest.php
+++ b/api/tests/Unit/Service/Forms/FormSubmissionFormatterTest.php
@@ -93,6 +93,16 @@ it('renders unsafe or invalid links as escaped text', function (string $type, mi
         'https://example.com/" onclick="alert(1)',
         'https://example.com/&quot; onclick=&quot;alert(1)',
     ],
+    'url with explicit user info' => [
+        'url',
+        'https://trusted.example@evil.example/path',
+        'https://trusted.example@evil.example/path',
+    ],
+    'url without scheme containing user info' => [
+        'url',
+        'trusted.example@evil.example/path',
+        'trusted.example@evil.example/path',
+    ],
     'invalid email' => [
         'email',
         'person@example.com" onclick="alert(1)',

--- a/api/tests/Unit/Service/Forms/FormSubmissionFormatterTest.php
+++ b/api/tests/Unit/Service/Forms/FormSubmissionFormatterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\Forms\Form;
+use App\Service\Forms\FormSubmissionFormatter;
+
+function formatterForField(string $type, mixed $value): FormSubmissionFormatter
+{
+    $fieldId = 'field-id';
+    $form = new Form([
+        'properties' => [[
+            'id' => $fieldId,
+            'name' => 'Field',
+            'type' => $type,
+        ]],
+        'removed_properties' => [],
+    ]);
+
+    return (new FormSubmissionFormatter($form, [$fieldId => $value]))
+        ->createLinks()
+        ->showHiddenFields();
+}
+
+it('formats safe submission links consistently', function (string $type, mixed $value, string $expected) {
+    $formatter = formatterForField($type, $value);
+
+    expect($formatter->getCleanKeyValue())->toBe([
+        'Field (field-id)' => $expected,
+    ]);
+
+    expect($formatter->getFieldsWithValue()[0])
+        ->toMatchArray([
+            'value' => $expected,
+            'value_is_html' => true,
+        ]);
+})->with([
+    'https url' => [
+        'url',
+        'https://example.com/path?a=1&b=2',
+        '<a href="https://example.com/path?a=1&amp;b=2">https://example.com/path?a=1&amp;b=2</a>',
+    ],
+    'http url' => [
+        'url',
+        'http://example.com/path',
+        '<a href="http://example.com/path">http://example.com/path</a>',
+    ],
+    'url without scheme' => [
+        'url',
+        'example.com/path',
+        '<a href="https://example.com/path">example.com/path</a>',
+    ],
+    'email' => [
+        'email',
+        'person@example.com',
+        '<a href="mailto:person@example.com">person@example.com</a>',
+    ],
+]);
+
+it('renders unsafe or invalid links as escaped text', function (string $type, mixed $value, string $expected) {
+    $formatter = formatterForField($type, $value);
+
+    expect($formatter->getCleanKeyValue())->toBe([
+        'Field (field-id)' => $expected,
+    ]);
+
+    expect($formatter->getFieldsWithValue()[0])
+        ->toMatchArray([
+            'value' => $expected,
+            'value_is_html' => true,
+        ]);
+})->with([
+    'javascript url' => [
+        'url',
+        'javascript://example.com/%0Aalert(1)',
+        'javascript://example.com/%0Aalert(1)',
+    ],
+    'data url' => [
+        'url',
+        'data://text/html,<script>alert(1)</script>',
+        'data://text/html,&lt;script&gt;alert(1)&lt;/script&gt;',
+    ],
+    'file url' => [
+        'url',
+        'file:///etc/passwd',
+        'file:///etc/passwd',
+    ],
+    'ftp url' => [
+        'url',
+        'ftp://example.com/file',
+        'ftp://example.com/file',
+    ],
+    'attribute injection' => [
+        'url',
+        'https://example.com/" onclick="alert(1)',
+        'https://example.com/&quot; onclick=&quot;alert(1)',
+    ],
+    'invalid email' => [
+        'email',
+        'person@example.com" onclick="alert(1)',
+        'person@example.com&quot; onclick=&quot;alert(1)',
+    ],
+    'non-scalar url' => [
+        'url',
+        ['https://example.com', '<script>alert(1)</script>'],
+        'https://example.com, &lt;script&gt;alert(1)&lt;/script&gt;',
+    ],
+]);


### PR DESCRIPTION
## Summary

This builds on the unsafe link rendering reported in #1262 and replaces raw URL/email anchor construction with the formatter's centralized escaping helpers.

It also closes the remaining URL-policy gaps that a `FILTER_VALIDATE_URL` check alone does not cover:

- only `http` and `https` URLs are rendered as clickable links
- scheme-less domains accepted by the form URL validator are normalized to HTTPS
- URLs containing user info are kept as plain text to prevent misleading links such as `trusted.example@evil.example`
- unsupported, malformed, and non-scalar values remain escaped plain text
- email links continue to require a valid email address and escape both label and href

## Why

The clean key-value formatter concatenated submitted values directly into HTML anchors. Reusing the existing helper, as proposed in #1262, prevents attribute injection, but the helper still accepted URL schemes such as `data://`, `file://`, `ftp://`, and some `javascript://` forms.

A follow-up security review also found that URL user info could make the beginning of a link look like a trusted destination while the actual host appeared after `@`. This change applies one consistent policy to both `getCleanKeyValue()` and `getFieldsWithValue()`.

## Tests

Focused Pest coverage exercises both public formatter outputs, including:

- HTTP and HTTPS URLs
- domains without a scheme
- valid email links
- HTML attribute injection
- invalid email values
- `javascript://`, `data://`, `file://`, and `ftp://`
- URLs with explicit and scheme-less user info
- non-scalar URL values

Validation performed:

- full parallel API suite — 1,879 passed, 5,616 assertions
- formatter unit suite — 13 tests, 65 assertions
- relevant email feature suites — 34 tests, 210 assertions
- client suite — 53 files, 732 tests
- Pint — 846 files
- targeted PHPStan analysis for `FormSubmissionFormatter.php`
- client lint
- `git diff --check`

Full-repository PHPStan currently reports two unrelated pre-existing relation errors in `BackfillLifetimeLicenseWorkspaceEntitlements.php`; the changed formatter passes PHPStan cleanly.
