### PR TITLE
Fix block settings navigation with empty page breaks

### DIFF
--- a/client/lib/forms/composables/useFormStructure.js
+++ b/client/lib/forms/composables/useFormStructure.js
@@ -77,50 +77,44 @@ export function useFormStructure(formConfig, managerState, formData, fieldState)
   })
 
   /**
-   * Calculates the start and end indices for each page.
+   * Calculates the start and end indices for each rendered page.
+   * Empty pages are ignored here just as they are in calculateFieldGroups.
    * @returns {Array<Object>} Array of boundary objects { start, end }.
    */
-    const calculatePageBoundaries = () => {
+  const calculatePageBoundaries = () => {
     const properties = form.value.properties || []
     if (properties.length === 0) {
-        return [{ start: 0, end: -1 }] // Empty form
+      return [{ start: 0, end: -1 }]
     }
 
     const boundaries = []
     let startIndex = 0
-    let visibleBreakFound = false
+    let hasRenderableField = false
 
     properties.forEach((field, index) => {
-        // Check if the field is a page break AND it's not hidden
-        if (field.type === 'nf-page-break' && !isFieldHidden(field)) {
-            visibleBreakFound = true
-            // The page ends *at* the page break field
-            boundaries.push({ start: startIndex, end: index })
-            // The next page starts *after* the page break field
-            startIndex = index + 1
+      if (field.type !== 'nf-page-break') {
+        hasRenderableField = true
+      }
+
+      if (field.type === 'nf-page-break' && !isFieldHidden(field)) {
+        if (hasRenderableField) {
+          boundaries.push({ start: startIndex, end: index })
         }
+        startIndex = index + 1
+        hasRenderableField = false
+      }
     })
 
-    // If no visible page breaks were found, the entire form is a single page
-    if (!visibleBreakFound) {
-        return [{ start: 0, end: properties.length - 1 }]
+    if (hasRenderableField) {
+      boundaries.push({ start: startIndex, end: properties.length - 1 })
     }
 
-    // Add the boundary for the last page if there are fields after the last visible break
-    if (startIndex < properties.length) {
-        boundaries.push({ start: startIndex, end: properties.length - 1 })
-    }
-    // If the last field was a visible page break, startIndex will equal properties.length,
-    // and we don't add an extra empty page boundary.
-
-    // Safety check: Ensure at least one boundary exists if properties are not empty
-    if (boundaries.length === 0 && properties.length > 0) {
-         return [{ start: 0, end: properties.length - 1 }]
+    if (boundaries.length === 0) {
+      return [{ start: 0, end: properties.length - 1 }]
     }
 
     return boundaries
-    }
-
+  }
 
   /**
    * Reactive computed property holding the page boundaries.
@@ -238,10 +232,13 @@ export function useFormStructure(formConfig, managerState, formData, fieldState)
       if (fieldIndex >= start && fieldIndex <= end) {
         return i
       }
+      // Page breaks from ignored empty pages belong to the next rendered page.
+      if (fieldIndex < start) {
+        return i
+      }
     }
 
-    // Fallback: Should technically not be reached with correct boundaries
-    console.warn(`[useFormStructure] getPageForField: Field index ${fieldIndex} not found within calculated boundaries. Returning last page index.`)
+    // A trailing page break after the final rendered page stays on that page.
     return Math.max(0, boundaries.length - 1)
   }
 
@@ -373,4 +370,4 @@ export function useFormStructure(formConfig, managerState, formData, fieldState)
     determineInsertIndex, // Calculate where to insert a new field
     setPageForField // Set the current page to the page containing the specified field
   }
-} 
+}

--- a/client/test/unit/useFormStructure.test.ts
+++ b/client/test/unit/useFormStructure.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { reactive, ref } from 'vue'
+import { useFormStructure } from '../../lib/forms/composables/useFormStructure.js'
+
+function createField(id, type = 'text') {
+  return { id, type, name: id }
+}
+
+function createStructure(properties, hiddenFieldIds = []) {
+  const managerState = reactive({ currentPage: 0 })
+  const hiddenFields = new Set(hiddenFieldIds)
+  const fieldState = {
+    getState: (field) => ({ hidden: hiddenFields.has(field.id) })
+  }
+
+  const structure = useFormStructure(
+    ref({ properties }),
+    managerState,
+    ref({}),
+    fieldState
+  )
+
+  return { managerState, structure }
+}
+
+describe('useFormStructure', () => {
+  it('maps fields to rendered pages when a leading page break is ignored', () => {
+    const properties = [
+      createField('leading-break', 'nf-page-break'),
+      createField('first-page-field'),
+      createField('page-break', 'nf-page-break'),
+      createField('last-page-field')
+    ]
+    const { managerState, structure } = createStructure(properties)
+
+    expect(structure.pageCount.value).toBe(2)
+    expect(structure.pageBoundaries.value).toEqual([
+      { start: 1, end: 2 },
+      { start: 3, end: 3 }
+    ])
+    expect(structure.getPageForField(1)).toBe(0)
+    expect(structure.getPageForField(3)).toBe(1)
+
+    managerState.currentPage = 1
+    structure.setPageForField(1)
+    expect(managerState.currentPage).toBe(0)
+  })
+
+  it('does not create phantom boundaries for consecutive page breaks', () => {
+    const properties = [
+      createField('first-page-field'),
+      createField('first-break', 'nf-page-break'),
+      createField('consecutive-break', 'nf-page-break'),
+      createField('last-page-field')
+    ]
+    const { structure } = createStructure(properties)
+
+    expect(structure.pageCount.value).toBe(2)
+    expect(structure.pageBoundaries.value).toEqual([
+      { start: 0, end: 1 },
+      { start: 3, end: 3 }
+    ])
+    expect(structure.getPageForField(0)).toBe(0)
+    expect(structure.getPageForField(2)).toBe(1)
+    expect(structure.getPageForField(3)).toBe(1)
+  })
+
+  it('keeps hidden page breaks within the surrounding rendered page', () => {
+    const properties = [
+      createField('first-field'),
+      createField('hidden-break', 'nf-page-break'),
+      createField('second-field'),
+      createField('visible-break', 'nf-page-break'),
+      createField('last-field')
+    ]
+    const { structure } = createStructure(properties, ['hidden-break'])
+
+    expect(structure.pageCount.value).toBe(2)
+    expect(structure.pageBoundaries.value).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 4 }
+    ])
+    expect(structure.getPageForField(2)).toBe(0)
+    expect(structure.getPageForField(4)).toBe(1)
+  })
+
+  it('inserts new fields on the rendered page after a leading page break', () => {
+    const properties = [
+      createField('leading-break', 'nf-page-break'),
+      createField('first-page-field'),
+      createField('page-break', 'nf-page-break'),
+      createField('last-page-field')
+    ]
+    const { structure } = createStructure(properties)
+
+    expect(structure.determineInsertIndex(null, 0, null, true)).toBe(2)
+  })
+
+  it('uses a single page for a form containing only page breaks', () => {
+    const properties = [
+      createField('first-break', 'nf-page-break'),
+      createField('second-break', 'nf-page-break')
+    ]
+    const { structure } = createStructure(properties)
+
+    expect(structure.pageCount.value).toBe(1)
+    expect(structure.pageBoundaries.value).toEqual([{ start: 0, end: 1 }])
+    expect(structure.getPageForField(0)).toBe(0)
+    expect(structure.getPageForField(1)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- align classic form page boundaries with the renderer rule that ignores empty pages
- keep block settings focused on the rendered page containing the selected block
- map ignored leading, consecutive, and trailing page breaks to the nearest rendered page
- add regression coverage for leading, consecutive, hidden, and page-break-only structures

## Root cause

The renderer has ignored pages containing only Page Break blocks since October 2025, but the separate boundary calculation still counted every visible Page Break. A leading or consecutive Page Break therefore created a phantom page index. Opening settings for a block used that shifted index and could send the preview to the last page.

## Validation

- client unit regression: 5 tests passed
- complete client suite: 59 files and 752 tests passed
- client lint passed
- backend Pest: 2,030 tests passed with a local test-only OpenAI key and 512 MB worker limit
- Pint: 941 files passed
- manual editor QA passed on the seeded Product feedback form with a leading Page Break: first-page settings remain on the first page, last-page settings navigate to the last page, and returning to a first-page block returns the preview correctly

## Existing unrelated check

PHPStan completes with a 512 MB limit but reports two existing larastan.relationExistence errors for the Workspace owners relation in BackfillLifetimeLicenseWorkspaceEntitlements.php. This PR does not modify backend code.