### PR TITLE
Add output schemas to every MCP tool

### DIFF
--- a/api/app/Mcp/Support/McpOutputSchema.php
+++ b/api/app/Mcp/Support/McpOutputSchema.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Mcp\Support;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\ObjectType;
+
+final class McpOutputSchema
+{
+    public static function draft(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'version' => $schema->integer()->min(1)->required(),
+            'schema_version' => $schema->integer()->min(1)->required(),
+            'status' => $schema->string()->required(),
+            'expires_at' => $schema->string()->format('date-time')->required(),
+            'definition' => $schema->object()->required(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function workspace(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'id' => $schema->integer()->min(1)->required(),
+            'name' => $schema->string()->required(),
+            'icon' => $schema->string()->nullable()->required(),
+            'role' => $schema->string()->nullable()->required(),
+            'can_write_forms' => $schema->boolean()->required(),
+            'plan_tier' => $schema->string()->nullable()->required(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function pagination(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'page' => $schema->integer()->min(1)->required(),
+            'per_page' => $schema->integer()->min(1)->required(),
+            'total' => $schema->integer()->min(0)->required(),
+            'last_page' => $schema->integer()->min(1)->required(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function formSummary(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'id' => $schema->integer()->min(1)->required(),
+            'workspace_id' => $schema->integer()->min(1)->required(),
+            'title' => $schema->string()->required(),
+            'visibility' => $schema->string()->required(),
+            'share_url' => $schema->string()->format('uri')->required(),
+            'submissions_count' => $schema->integer()->min(0)->required(),
+            'views_count' => $schema->integer()->min(0)->required(),
+            'created_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'updated_at' => $schema->string()->format('date-time')->nullable()->required(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function form(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'id' => $schema->integer()->min(1)->required(),
+            'workspace_id' => $schema->integer()->min(1)->required(),
+            'title' => $schema->string()->required(),
+            'visibility' => $schema->string()->required(),
+            'share_url' => $schema->string()->format('uri')->required(),
+            'submissions_count' => $schema->integer()->min(0)->required(),
+            'views_count' => $schema->integer()->min(0)->required(),
+            'created_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'updated_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'definition' => $schema->object()->required(),
+            'revision' => $schema->string()->min(64)->max(64)->required(),
+            'edit_url' => $schema->string()->format('uri')->required(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function submission(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'id' => $schema->integer()->min(1)->required(),
+            'form_id' => $schema->integer()->min(1)->required(),
+            'status' => $schema->string()->required(),
+            'created_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'updated_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'completion_time_seconds' => $schema->number()->min(0)->nullable()->required(),
+            'responses' => $schema->union(['object', 'array'])->required(),
+            'ip_address' => $schema->string(),
+        ])->withoutAdditionalProperties();
+    }
+
+    public static function fieldSummary(JsonSchema $schema): ObjectType
+    {
+        return $schema->object([
+            'total_submissions' => $schema->integer()->min(0)->required(),
+            'processed_submissions' => $schema->integer()->min(0)->required(),
+            'is_limited' => $schema->boolean()->required(),
+            'fields' => $schema->array()->items($schema->object([
+                'id' => $schema->string()->required(),
+                'name' => $schema->string()->required(),
+                'type' => $schema->string()->required(),
+                'answered_count' => $schema->integer()->min(0)->required(),
+                'total_submissions' => $schema->integer()->min(0)->required(),
+                'summary_type' => $schema->string()->required(),
+                'data' => $schema->union(['object', 'array'])->required(),
+            ])->withoutAdditionalProperties())->required(),
+        ])->withoutAdditionalProperties();
+    }
+}

--- a/api/app/Mcp/Tools/CreateFormDraftTool.php
+++ b/api/app/Mcp/Tools/CreateFormDraftTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\AgentFormDraftRateLimiter;
 use App\Service\Forms\AgentFormDraftService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -56,6 +57,15 @@ class CreateFormDraftTool extends GuestDraftMcpTool
             'definition' => $schema->object()
                 ->description('Form definition following opnform://schemas/agent-form-definition/v1. The server normalizes defaults, aliases, IDs, and visibility.')
                 ->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'draft_token' => $schema->string()->min(43)->max(43)->required(),
+            'draft' => McpOutputSchema::draft($schema)->required(),
+            'next_steps' => $schema->array()->items($schema->string())->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/CreateFormTool.php
+++ b/api/app/Mcp/Tools/CreateFormTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -41,6 +42,16 @@ class CreateFormTool extends AuthenticatedMcpTool
         return [
             'workspace_id' => $schema->integer()->description('Required only when the account has multiple workspaces.')->min(1),
             'definition' => $schema->object()->description('Canonical OpnForm agent form definition v1.')->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'message' => $schema->string()->required(),
+            'form' => McpOutputSchema::form($schema)->required(),
+            'disabled_features' => $schema->union(['object', 'array'])->required(),
+            'next_step' => $schema->string()->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/ExportSubmissionsTool.php
+++ b/api/app/Mcp/Tools/ExportSubmissionsTool.php
@@ -45,4 +45,13 @@ class ExportSubmissionsTool extends AuthenticatedMcpTool
                 ->max(1000),
         ];
     }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'job_id' => $schema->string()->format('uuid')->required(),
+            'status' => $schema->string()->required(),
+            'message' => $schema->string()->required(),
+        ];
+    }
 }

--- a/api/app/Mcp/Tools/GetAccountContextTool.php
+++ b/api/app/Mcp/Tools/GetAccountContextTool.php
@@ -2,7 +2,9 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
@@ -33,5 +35,18 @@ class GetAccountContextTool extends AuthenticatedMcpTool
             'workspaces' => $workspaces,
             'workspace_selection_required' => count($workspaces) > 1,
         ]);
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'account' => $schema->object([
+                'id' => $schema->integer()->min(1)->required(),
+                'name' => $schema->string()->required(),
+                'email' => $schema->string()->format('email')->required(),
+            ])->withoutAdditionalProperties()->required(),
+            'workspaces' => $schema->array()->items(McpOutputSchema::workspace($schema))->required(),
+            'workspace_selection_required' => $schema->boolean()->required(),
+        ];
     }
 }

--- a/api/app/Mcp/Tools/GetFormDraftTool.php
+++ b/api/app/Mcp/Tools/GetFormDraftTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\AgentFormDraftService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -40,5 +41,10 @@ class GetFormDraftTool extends GuestDraftMcpTool
                 ->max(43)
                 ->required(),
         ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return ['draft' => McpOutputSchema::draft($schema)->required()];
     }
 }

--- a/api/app/Mcp/Tools/GetFormTool.php
+++ b/api/app/Mcp/Tools/GetFormTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -31,5 +32,10 @@ class GetFormTool extends AuthenticatedMcpTool
     public function schema(JsonSchema $schema): array
     {
         return ['form_id' => $schema->integer()->min(1)->required()];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return ['form' => McpOutputSchema::form($schema)->required()];
     }
 }

--- a/api/app/Mcp/Tools/GetSubmissionExportTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionExportTool.php
@@ -41,4 +41,18 @@ class GetSubmissionExportTool extends AuthenticatedMcpTool
             'job_id' => $schema->string()->description('Export job UUID returned by export_submissions.')->required(),
         ];
     }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'job_id' => $schema->string()->format('uuid')->required(),
+            'status' => $schema->string()->required(),
+            'progress' => $schema->integer()->min(0)->max(100)->required(),
+            'processed_submissions' => $schema->integer()->min(0)->nullable()->required(),
+            'total_submissions' => $schema->integer()->min(0)->nullable()->required(),
+            'file_url' => $schema->string()->format('uri')->nullable()->required(),
+            'expires_at' => $schema->string()->format('date-time')->nullable()->required(),
+            'error_message' => $schema->string()->nullable()->required(),
+        ];
+    }
 }

--- a/api/app/Mcp/Tools/GetSubmissionStatsTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionStatsTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpSubmissionService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\Rule;
@@ -46,6 +47,27 @@ class GetSubmissionStatsTool extends AuthenticatedMcpTool
             'status' => $schema->string()->enum(['all', 'completed', 'partial'])->default('completed'),
             'date_from' => $schema->string()->description('Inclusive ISO 8601 date.'),
             'date_to' => $schema->string()->description('Inclusive ISO 8601 date.'),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'form_id' => $schema->integer()->min(1)->required(),
+            'filters' => $schema->object([
+                'status' => $schema->string()->required(),
+                'date_from' => $schema->string()->nullable()->required(),
+                'date_to' => $schema->string()->nullable()->required(),
+            ])->withoutAdditionalProperties()->required(),
+            'overview' => $schema->object([
+                'views' => $schema->integer()->min(0)->required(),
+                'completed_submissions' => $schema->integer()->min(0)->required(),
+                'partial_submissions' => $schema->integer()->min(0)->required(),
+                'completion_rate' => $schema->number()->min(0)->required(),
+            ])->withoutAdditionalProperties()->required(),
+            'filtered_submissions' => $schema->integer()->min(0)->required(),
+            'average_completion_seconds' => $schema->number()->min(0)->nullable()->required(),
+            'field_summary' => McpOutputSchema::fieldSummary($schema)->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/GetSubmissionTool.php
+++ b/api/app/Mcp/Tools/GetSubmissionTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpSubmissionService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -42,5 +43,10 @@ class GetSubmissionTool extends AuthenticatedMcpTool
             'form_id' => $schema->integer()->min(1)->required(),
             'submission_id' => $schema->integer()->min(1)->required(),
         ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return ['submission' => McpOutputSchema::submission($schema)->required()];
     }
 }

--- a/api/app/Mcp/Tools/GetWorkspaceTool.php
+++ b/api/app/Mcp/Tools/GetWorkspaceTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -32,5 +33,10 @@ class GetWorkspaceTool extends AuthenticatedMcpTool
     public function schema(JsonSchema $schema): array
     {
         return ['workspace_id' => $schema->integer()->min(1)->required()];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return ['workspace' => McpOutputSchema::workspace($schema)->required()];
     }
 }

--- a/api/app/Mcp/Tools/ListFormsTool.php
+++ b/api/app/Mcp/Tools/ListFormsTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Models\Forms\Form;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -50,6 +51,14 @@ class ListFormsTool extends AuthenticatedMcpTool
             'visibility' => $schema->string()->enum(Form::VISIBILITY),
             'page' => $schema->integer()->min(1)->default(1),
             'per_page' => $schema->integer()->min(1)->max(100)->default(20),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'forms' => $schema->array()->items(McpOutputSchema::formSummary($schema))->required(),
+            'pagination' => McpOutputSchema::pagination($schema)->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/ListSubmissionsTool.php
+++ b/api/app/Mcp/Tools/ListSubmissionsTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpSubmissionService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Validation\Rule;
@@ -55,6 +56,14 @@ class ListSubmissionsTool extends AuthenticatedMcpTool
             'date_to' => $schema->string()->description('Inclusive ISO 8601 date.'),
             'page' => $schema->integer()->min(1)->default(1),
             'per_page' => $schema->integer()->min(1)->max(100)->default(50),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'submissions' => $schema->array()->items(McpOutputSchema::submission($schema))->required(),
+            'pagination' => McpOutputSchema::pagination($schema)->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/ListWorkspacesTool.php
+++ b/api/app/Mcp/Tools/ListWorkspacesTool.php
@@ -2,7 +2,9 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\ResponseFactory;
@@ -24,5 +26,12 @@ class ListWorkspacesTool extends AuthenticatedMcpTool
         return Response::structured([
             'workspaces' => $forms->listWorkspaces($this->user($request)),
         ]);
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'workspaces' => $schema->array()->items(McpOutputSchema::workspace($schema))->required(),
+        ];
     }
 }

--- a/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
+++ b/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
@@ -35,4 +35,13 @@ class OpenFormDraftInEditorTool extends GuestDraftMcpTool
             'draft_token' => $schema->string()->min(43)->max(43)->required(),
         ];
     }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'handoff_token' => $schema->string()->min(43)->max(43)->required(),
+            'editor_url' => $schema->string()->format('uri')->required(),
+            'expires_at' => $schema->string()->format('date-time')->required(),
+        ];
+    }
 }

--- a/api/app/Mcp/Tools/PatchFormDraftTool.php
+++ b/api/app/Mcp/Tools/PatchFormDraftTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\AgentFormDraftService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -70,6 +71,14 @@ class PatchFormDraftTool extends GuestDraftMcpTool
                 ->min(1)
                 ->max(100)
                 ->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'draft' => McpOutputSchema::draft($schema)->required(),
+            'next_step' => $schema->string()->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Tools;
 
 use App\Mcp\Apps\FormDraftPreviewApp;
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\AgentFormDraftService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -47,6 +48,16 @@ class PreviewFormDraftTool extends GuestDraftMcpTool
                 ->min(43)
                 ->max(43)
                 ->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'draft' => McpOutputSchema::draft($schema)->required(),
+            'preview_url' => $schema->string()->format('uri')->required(),
+            'editor_url' => $schema->string()->format('uri')->required(),
+            'editor_link_expires_at' => $schema->string()->format('date-time')->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/PublishFormTool.php
+++ b/api/app/Mcp/Tools/PublishFormTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -42,6 +43,14 @@ class PublishFormTool extends AuthenticatedMcpTool
             'form_id' => $schema->integer()->min(1)->required(),
             'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
             'confirm_publish' => $schema->boolean()->description('True only after the user explicitly confirms publication.')->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'message' => $schema->string()->required(),
+            'form' => McpOutputSchema::form($schema)->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/TrashFormTool.php
+++ b/api/app/Mcp/Tools/TrashFormTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -42,6 +43,14 @@ class TrashFormTool extends AuthenticatedMcpTool
             'form_id' => $schema->integer()->min(1)->required(),
             'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
             'confirm_trash' => $schema->boolean()->description('True only after the user explicitly confirms moving the form to trash.')->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'message' => $schema->string()->required(),
+            'form' => McpOutputSchema::formSummary($schema)->required(),
         ];
     }
 }

--- a/api/app/Mcp/Tools/UpdateFormTool.php
+++ b/api/app/Mcp/Tools/UpdateFormTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Mcp\Support\McpOutputSchema;
 use App\Service\Forms\McpFormManagementService;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -42,6 +43,15 @@ class UpdateFormTool extends AuthenticatedMcpTool
             'form_id' => $schema->integer()->min(1)->required(),
             'expected_revision' => $schema->string()->description('Exact 64-character revision returned by get_form.')->min(64)->max(64)->required(),
             'definition' => $schema->object()->description('Complete canonical OpnForm agent form definition v1.')->required(),
+        ];
+    }
+
+    public function outputSchema(JsonSchema $schema): array
+    {
+        return [
+            'message' => $schema->string()->required(),
+            'form' => McpOutputSchema::form($schema)->required(),
+            'disabled_features' => $schema->union(['object', 'array'])->required(),
         ];
     }
 }

--- a/api/tests/Feature/Mcp/McpFoundationTest.php
+++ b/api/tests/Feature/Mcp/McpFoundationTest.php
@@ -123,6 +123,25 @@ it('advertises explicit safety annotations for every MCP tool', function () {
     expect($actual)->toBe($expected);
 });
 
+it('publishes an output schema for every MCP tool', function () {
+    $response = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/list',
+        'params' => [],
+    ], [
+        'Accept' => 'application/json, text/event-stream',
+    ])->assertOk();
+
+    foreach ($response->json('result.tools') as $tool) {
+        expect($tool['outputSchema'] ?? null)
+            ->toBeArray("Tool [{$tool['name']}] must declare an output schema.")
+            ->and($tool['outputSchema']['type'] ?? null)->toBe('object')
+            ->and($tool['outputSchema']['properties'] ?? null)->toBeArray()
+            ->not->toBeEmpty();
+    }
+});
+
 it('mirrors every tool auth policy in metadata for ChatGPT compatibility', function () {
     $response = $this->postJson('/mcp', [
         'jsonrpc' => '2.0',


### PR DESCRIPTION
## Summary
- declare an output schema for all 20 OpnForm MCP tools
- share stable schemas for drafts, forms, workspaces, pagination, submissions, and analytics
- keep dynamic form definitions and response payloads permissive where their shape legitimately varies
- add a tools/list regression test so future tools cannot omit outputSchema silently

## Validation
- MCP foundation suite: 15 passed
- MCP guest, account, submission, and preview suites: 47 passed
- client Vitest: 752 passed
- Pint and ESLint: passed
- PHPStan reaches two pre-existing unrelated Workspace owners findings
- full parallel Pest is blocked by the existing 128 MB memory limit in EmailNotificationTest