### PR TITLE
fix: preserve strikethrough in form help text

### DIFF
--- a/api/config/purify.php
+++ b/api/config/purify.php
@@ -40,7 +40,7 @@ return [
     'configs' => [
 
         'default' => [
-            'HTML.Allowed' => 'h1,h2,b,u,strong,i,em,a[href|title],ul,ol,li,p,br,span[mention|mention-field-id|mention-field-name|mention-fallback],*[style]',
+            'HTML.Allowed' => 'h1,h2,b,u,s,strong,i,em,a[href|title],ul,ol,li,p,br,span[mention|mention-field-id|mention-field-name|mention-fallback],*[style]',
             'HTML.ForbiddenElements' => '',
             'CSS.AllowedProperties' => 'font,font-size,font-weight,font-style,text-decoration,color,text-align',
 

--- a/api/tests/Feature/Forms/FormTest.php
+++ b/api/tests/Feature/Forms/FormTest.php
@@ -182,6 +182,22 @@ it('can update a form', function () {
     ]);
 });
 
+it('preserves strikethrough formatting when updating field help text', function () {
+    $user = $this->actingAsUser();
+    $workspace = $this->createUserWorkspace($user);
+    $form = $this->createForm($user, $workspace);
+
+    $formData = (new \App\Http\Resources\FormResource($form))->toArray(request());
+    $formData['properties'][0]['help'] = '<p><s onclick="alert(1)">Unavailable option</s></p>';
+
+    $this->putJson(route('open.forms.update', $form->id), $formData)
+        ->assertSuccessful()
+        ->assertJsonPath('form.properties.0.help', '<p><s>Unavailable option</s></p>');
+
+    expect($form->fresh()->properties[0]['help'])
+        ->toBe('<p><s>Unavailable option</s></p>');
+});
+
 it('truncates form titles longer than the database limit when updating a form', function () {
     $user = $this->actingAsUser();
     $workspace = $this->createUserWorkspace($user);

--- a/api/tests/Unit/Service/Forms/FormDataNormalizerTest.php
+++ b/api/tests/Unit/Service/Forms/FormDataNormalizerTest.php
@@ -27,3 +27,17 @@ it('uses one normalization path for form titles, properties, and select options'
         ->and($normalized['properties'][0]['select']['options'][0]['id'])->toBe('First')
         ->and($normalized['properties'][0]['id'])->toBeString()->not->toBeEmpty();
 });
+
+it('preserves strikethrough help text while removing unsafe markup', function () {
+    $normalized = app(FormDataNormalizer::class)->normalizeProperties([
+        [
+            'type' => 'select',
+            'help' => '<p><s onclick="alert(1)">Unavailable option</s></p><script>alert(1)</script>',
+        ],
+    ]);
+
+    expect($normalized[0]['help'])
+        ->toContain('<s>Unavailable option</s>')
+        ->not->toContain('onclick')
+        ->not->toContain('<script>');
+});


### PR DESCRIPTION
## Summary

- preserve Quill `<s>` markup when form help text is normalized
- keep the existing HTML sanitization boundary and continue stripping event handlers and scripts
- cover both the normalizer and the form update endpoint with regression tests

## Reproduction

Before this change, applying strikethrough to field help text rendered correctly in the editor, but publishing removed the `<s>` element. Reopening the form showed plain text because HTMLPurifier did not allow the tag emitted by Quill.

## Testing

- `./vendor/bin/pest tests/Unit/Service/Forms/FormDataNormalizerTest.php tests/Feature/Forms/FormTest.php --filter="preserves strikethrough|uses one normalization"`
- full backend suite: 2,034 passed, 6,416 assertions
- client suite: 59 files and 752 tests passed
- `./vendor/bin/pint --test`: 941 files passed
- `npm run lint`
- `./vendor/bin/phpstan analyse --memory-limit=512M`: only the two existing `Workspace::owners` relation diagnostics outside this diff
- manual browser regression: publish, reopen editor, and confirm `<p><s>Strikethrough survives publish</s></p>` remains in both editor and preview