### PR TITLE
Fix OpenAI MCP preview widget origin

### DIFF
--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -14,7 +14,7 @@ use Laravel\Mcp\Server\Ui\Csp;
 
 #[Name('form_draft_preview')]
 #[Description('Interactive preview of a temporary guest OpnForm draft with an optional editor handoff.')]
-#[Uri('ui://opnform/form-draft-preview-v6')]
+#[Uri('ui://opnform/form-draft-preview-v7')]
 class FormDraftPreviewApp extends AppResource
 {
     public function shouldRegister(McpAvailability $availability): bool
@@ -50,7 +50,7 @@ class FormDraftPreviewApp extends AppResource
             Csp::make()
                 ->resourceDomains([$origin])
                 ->frameDomains([$origin]),
-        );
+        )->domain($origin);
     }
 
     private function frontOrigin(): ?string

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -73,7 +73,9 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->content()
         ->toResource($previewApp);
 
-    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v6')
+    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v7')
+        ->and($previewApp->resolvedAppMeta()['domain'])
+        ->toBe('http://127.0.0.1:33676')
         ->and($previewApp->resolvedAppMeta()['csp']['resourceDomains'])
         ->toBe(['http://127.0.0.1:33676'])
         ->and($previewApp->resolvedAppMeta()['csp']['frameDomains'])
@@ -95,6 +97,8 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
 
     expect($secureApp->resolvedAppMeta()['csp']['frameDomains'])
         ->toBe(['https://opnform.test'])
+        ->and($secureApp->resolvedAppMeta()['domain'])
+        ->toBe('https://opnform.test')
         ->and($secureApp->resolvedAppMeta()['csp']['resourceDomains'])
         ->toBe(['https://opnform.test'])
         ->and($secureResource['_meta']['openai/widgetCSP']['frame_domains'])

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -168,7 +168,7 @@ it('hides guest draft capabilities but keeps validation and OAuth tools on self-
 
     expect($resourceUris)
         ->toContain('opnform://schemas/agent-form-definition/v1', 'opnform://reference/form-fields/v1')
-        ->not->toContain('ui://opnform/form-draft-preview-v6');
+        ->not->toContain('ui://opnform/form-draft-preview-v7');
 
     $this->postJson('/mcp', [
         'jsonrpc' => '2.0',

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -36,7 +36,7 @@ it('publishes a neutral draft handle contract and accurate preview annotations',
         ->and($create['outputSchema']['properties'])->not->toHaveKey('draft_token')
         ->and($create['_meta'])->not->toHaveKey('ui')
         ->and(app(PatchFormDraftTool::class)->toArray()['_meta'])->not->toHaveKey('ui')
-        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview-v6')
+        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview-v7')
         ->and($preview['inputSchema']['properties'])->toHaveKey('draft_handle')
         ->and($preview['outputSchema']['properties'])->not->toHaveKeys([
             'editor_url',


### PR DESCRIPTION
## Summary
- publish the verified OpnForm frontend origin as the MCP App `ui.domain` instead of Laravel MCP's Claude-specific fallback domain
- bump the preview resource URI to v7 so OpenAI does not reuse the broken cached template metadata
- cover local and HTTPS widget origins in MCP tests

## Validation
- `php vendor/bin/pest tests/Feature/Mcp/AgentDraftEditorTest.php tests/Feature/Mcp/GuestDraftToolsTest.php tests/Feature/Mcp/AuthenticatedFormToolsTest.php` (43 passed, 353 assertions)
- production MCP resource/list and resource/read were verified before the fix; the resource was readable but exposed a bare `*.claudemcpcontent.com` ui.domain, matching ChatGPT's `Failed to fetch template` symptom