### PR TITLE
Fix ChatGPT preview template discovery

### DIFF
--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -14,9 +14,11 @@ use Laravel\Mcp\Server\Ui\Csp;
 
 #[Name('form_draft_preview')]
 #[Description('Interactive preview of a temporary guest OpnForm draft with an optional editor handoff.')]
-#[Uri('ui://opnform/form-draft-preview-v7')]
+#[Uri(FormDraftPreviewApp::URI)]
 class FormDraftPreviewApp extends AppResource
 {
+    public const URI = 'ui://opnform/form-draft-preview-v8.html';
+
     public function shouldRegister(McpAvailability $availability): bool
     {
         return $availability->guestDraftsEnabled();

--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -24,6 +24,16 @@ use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 #[IsOpenWorld(false)]
 class PreviewFormDraftTool extends GuestDraftMcpTool
 {
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $this->setMeta('openai/outputTemplate', FormDraftPreviewApp::URI);
+
+        return parent::toArray();
+    }
+
     public function handle(Request $request, AgentFormDraftService $drafts): ResponseFactory
     {
         $validated = $request->validate([

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -73,7 +73,7 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->content()
         ->toResource($previewApp);
 
-    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v7')
+    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v8.html')
         ->and($previewApp->resolvedAppMeta()['domain'])
         ->toBe('http://127.0.0.1:33676')
         ->and($previewApp->resolvedAppMeta()['csp']['resourceDomains'])

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -168,7 +168,7 @@ it('hides guest draft capabilities but keeps validation and OAuth tools on self-
 
     expect($resourceUris)
         ->toContain('opnform://schemas/agent-form-definition/v1', 'opnform://reference/form-fields/v1')
-        ->not->toContain('ui://opnform/form-draft-preview-v7');
+        ->not->toContain('ui://opnform/form-draft-preview-v8.html');
 
     $this->postJson('/mcp', [
         'jsonrpc' => '2.0',

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -36,7 +36,8 @@ it('publishes a neutral draft handle contract and accurate preview annotations',
         ->and($create['outputSchema']['properties'])->not->toHaveKey('draft_token')
         ->and($create['_meta'])->not->toHaveKey('ui')
         ->and(app(PatchFormDraftTool::class)->toArray()['_meta'])->not->toHaveKey('ui')
-        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview-v7')
+        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview-v8.html')
+        ->and($preview['_meta']['openai/outputTemplate'])->toBe('ui://opnform/form-draft-preview-v8.html')
         ->and($preview['inputSchema']['properties'])->toHaveKey('draft_handle')
         ->and($preview['outputSchema']['properties'])->not->toHaveKeys([
             'editor_url',


### PR DESCRIPTION
## Summary
- publish the draft preview under a versioned .html MCP App resource URI
- expose the ChatGPT openai/outputTemplate alias alongside the standard ui.resourceUri
- keep the render tool and resource on one shared URI constant and update registration tests

## Why
Production guest draft creation works without OAuth, but ChatGPT currently shows Failed to fetch template before mounting the preview. This aligns the descriptor with the official OpenAI UI resource examples and compatibility metadata while intentionally dropping the old v7 cache key.

## Validation
- targeted MCP Pest tests: 43 passed
- full backend Pest suite: 2052 passed
- frontend Vitest suite: 752 passed
- Pint: passed
- targeted PHPStan on changed MCP classes: passed
- ESLint: passed

Global PHPStan still reports two pre-existing Workspace owners relation errors in BackfillLifetimeLicenseWorkspaceEntitlements.php; this PR does not touch that code.