### PR TITLE
Fix MCP widget templates for existing OpenAI conversations

### DIFF
--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -17,7 +17,11 @@ use Laravel\Mcp\Server\Ui\Csp;
 #[Uri(FormDraftPreviewApp::URI)]
 class FormDraftPreviewApp extends AppResource
 {
-    public const URI = 'ui://opnform/form-draft-preview-v8.html';
+    /**
+     * This URI is persisted by OpenAI plugin versions and existing conversations.
+     * Keep it stable for non-breaking widget changes and continue serving old URIs.
+     */
+    public const URI = 'ui://opnform/form-draft-preview.html';
 
     public function shouldRegister(McpAvailability $availability): bool
     {

--- a/api/app/Mcp/Apps/FormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/FormDraftPreviewApp.php
@@ -30,7 +30,11 @@ class FormDraftPreviewApp extends AppResource
 
     public function handle(Request $request): Response
     {
-        $response = Response::view('mcp.form-draft-preview-app');
+        $response = Response::view('mcp.form-draft-preview-app')
+            ->withMeta(
+                'openai/widgetDescription',
+                'Interactive private preview of the current OpnForm draft, with zoom controls and an Edit in OpnForm action.',
+            );
         $origin = $this->frontOrigin();
 
         if ($origin !== null) {
@@ -49,14 +53,14 @@ class FormDraftPreviewApp extends AppResource
     {
         $origin = $this->frontOrigin();
         if ($origin === null) {
-            return AppMeta::make();
+            return AppMeta::make()->prefersBorder(false);
         }
 
         return AppMeta::make()->csp(
             Csp::make()
                 ->resourceDomains([$origin])
                 ->frameDomains([$origin]),
-        )->domain($origin);
+        )->domain($origin)->prefersBorder(false);
     }
 
     private function frontOrigin(): ?string

--- a/api/app/Mcp/Apps/LegacyFormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/LegacyFormDraftPreviewApp.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Mcp\Apps;
+
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Attributes\Name;
+use Laravel\Mcp\Server\Contracts\HasUriTemplate;
+use Laravel\Mcp\Support\UriTemplate;
+
+#[Name('legacy_form_draft_preview')]
+#[Description('Compatibility resource for OpnForm preview templates referenced by existing plugin versions and conversations.')]
+class LegacyFormDraftPreviewApp extends FormDraftPreviewApp implements HasUriTemplate
+{
+    public function uriTemplate(): UriTemplate
+    {
+        return new UriTemplate('ui://opnform/form-draft-preview-{version}');
+    }
+}

--- a/api/app/Mcp/Apps/LegacyFormDraftPreviewApp.php
+++ b/api/app/Mcp/Apps/LegacyFormDraftPreviewApp.php
@@ -4,15 +4,12 @@ namespace App\Mcp\Apps;
 
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
-use Laravel\Mcp\Server\Contracts\HasUriTemplate;
-use Laravel\Mcp\Support\UriTemplate;
+use Laravel\Mcp\Server\Attributes\Uri;
 
-#[Name('legacy_form_draft_preview')]
-#[Description('Compatibility resource for OpnForm preview templates referenced by existing plugin versions and conversations.')]
-class LegacyFormDraftPreviewApp extends FormDraftPreviewApp implements HasUriTemplate
+#[Name('legacy_form_draft_preview_v8')]
+#[Description('Compatibility resource for the form preview URI published by the current OpenAI plugin snapshot.')]
+#[Uri(LegacyFormDraftPreviewApp::URI)]
+class LegacyFormDraftPreviewApp extends FormDraftPreviewApp
 {
-    public function uriTemplate(): UriTemplate
-    {
-        return new UriTemplate('ui://opnform/form-draft-preview-{version}');
-    }
+    public const URI = 'ui://opnform/form-draft-preview-v8.html';
 }

--- a/api/app/Mcp/Servers/OpnFormServer.php
+++ b/api/app/Mcp/Servers/OpnFormServer.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Servers;
 
 use App\Mcp\Apps\FormDraftPreviewApp;
+use App\Mcp\Apps\LegacyFormDraftPreviewApp;
 use App\Mcp\Methods\CallTool;
 use App\Mcp\Resources\FormDefinitionSchemaResource;
 use App\Mcp\Resources\FormFieldCatalogResource;
@@ -67,6 +68,7 @@ class OpnFormServer extends Server
         FormDefinitionSchemaResource::class,
         FormFieldCatalogResource::class,
         FormDraftPreviewApp::class,
+        LegacyFormDraftPreviewApp::class,
     ];
 
     protected function boot(): void

--- a/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
+++ b/api/app/Mcp/Tools/OpenFormDraftInEditorTool.php
@@ -45,9 +45,9 @@ class OpenFormDraftInEditorTool extends GuestDraftMcpTool
         $handoff = $drafts->issueEditorHandoff($validated['draft_handle']);
 
         return Response::structured([
-            'editor_url' => $handoff['editor_url'],
+            'editor_handoff_ready' => true,
             'expires_at' => $handoff['expires_at'],
-        ]);
+        ])->withMeta('editor_url', $handoff['editor_url']);
     }
 
     public function schema(JsonSchema $schema): array
@@ -64,7 +64,7 @@ class OpenFormDraftInEditorTool extends GuestDraftMcpTool
     public function outputSchema(JsonSchema $schema): array
     {
         return [
-            'editor_url' => $schema->string()->format('uri')->required(),
+            'editor_handoff_ready' => $schema->boolean()->required(),
             'expires_at' => $schema->string()->format('date-time')->required(),
         ];
     }

--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -44,8 +44,7 @@ class PreviewFormDraftTool extends GuestDraftMcpTool
         return Response::structured([
             'draft_handle' => $validated['draft_handle'],
             'draft' => $drafts->serialize($draft),
-            'preview_url' => $drafts->previewUrl($draft),
-        ]);
+        ])->withMeta('preview_url', $drafts->previewUrl($draft));
     }
 
     public function schema(JsonSchema $schema): array
@@ -64,7 +63,6 @@ class PreviewFormDraftTool extends GuestDraftMcpTool
         return [
             'draft_handle' => $schema->string()->min(43)->max(43)->required(),
             'draft' => McpOutputSchema::draft($schema)->required(),
-            'preview_url' => $schema->string()->format('uri')->required(),
         ];
     }
 }

--- a/api/resources/views/mcp/form-draft-preview-app.blade.php
+++ b/api/resources/views/mcp/form-draft-preview-app.blade.php
@@ -119,6 +119,10 @@
                     ?? result
                     ?? {};
 
+                const toolMeta = (result) => result?._meta
+                    ?? result?.meta
+                    ?? {};
+
                 const applyToolInput = (input) => {
                     const args = input?.arguments ?? input ?? {};
                     draftHandle = args.draft_handle ?? draftHandle;
@@ -127,10 +131,12 @@
 
                 const renderToolResult = (result) => {
                     const payload = toolPayload(result);
+                    const resultMeta = toolMeta(result);
                     const draft = payload.draft ?? {};
                     const definition = draft.definition ?? {};
+                    const previewUrlValue = resultMeta.preview_url;
 
-                    if (!payload.preview_url && !draft.version && !definition.title) {
+                    if (!previewUrlValue && !draft.version && !definition.title) {
                         return false;
                     }
 
@@ -141,8 +147,8 @@
                     title.textContent = definition.title ?? 'Untitled form';
                     meta.textContent = `Draft v${draft.version ?? '?'} · ${presentationStyle} layout`;
                     applyPreviewLayout();
-                    if (payload.preview_url) {
-                        const previewUrl = new URL(payload.preview_url);
+                    if (previewUrlValue) {
+                        const previewUrl = new URL(previewUrlValue);
                         previewUrl.searchParams.set('embedded', '1');
                         const nextPreviewUrl = previewUrl.toString();
                         if (currentPreviewUrl !== nextPreviewUrl) {
@@ -205,13 +211,14 @@
                         const result = await app.callServerTool('open_form_draft_in_editor', {
                             draft_handle: draftHandle,
                         });
-                        const payload = toolPayload(result);
+                        const resultMeta = toolMeta(result);
+                        const editorUrl = resultMeta.editor_url;
 
-                        if (result?.isError || !payload.editor_url) {
+                        if (result?.isError || !editorUrl) {
                             throw new Error('Editor link unavailable');
                         }
 
-                        await app.openLink({ url: payload.editor_url });
+                        await app.openLink({ url: editorUrl });
                     } catch (error) {
                         actionStatus.textContent = 'Could not open the OpnForm editor. Please try again.';
                         actionStatus.hidden = false;

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -73,7 +73,7 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->content()
         ->toResource($previewApp);
 
-    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview-v8.html')
+    expect($previewApp->uri())->toBe('ui://opnform/form-draft-preview.html')
         ->and($previewApp->resolvedAppMeta()['domain'])
         ->toBe('http://127.0.0.1:33676')
         ->and($previewApp->resolvedAppMeta()['csp']['resourceDomains'])
@@ -103,6 +103,40 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->toBe(['https://opnform.test'])
         ->and($secureResource['_meta']['openai/widgetCSP']['frame_domains'])
         ->toBe(['https://opnform.test']);
+});
+
+it('keeps preview template URIs used by existing plugin versions readable', function () {
+    $headers = ['Accept' => 'application/json, text/event-stream'];
+
+    $historicalUris = array_map(
+        fn (int $version) => "ui://opnform/form-draft-preview-v{$version}",
+        range(3, 7),
+    );
+    $historicalUris[] = 'ui://opnform/form-draft-preview-v8.html';
+
+    foreach ($historicalUris as $index => $uri) {
+
+        $this->postJson('/mcp', [
+            'jsonrpc' => '2.0',
+            'id' => $index + 1,
+            'method' => 'resources/read',
+            'params' => ['uri' => $uri],
+        ], $headers)->assertOk()
+            ->assertJsonPath('result.contents.0.uri', $uri)
+            ->assertJsonPath('result.contents.0.mimeType', 'text/html;profile=mcp-app')
+            ->assertJsonPath('result.contents.0._meta.ui.domain', 'https://opnform.test')
+            ->assertSee('Edit in OpnForm');
+    }
+
+    $resourceTemplatesResponse = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 8,
+        'method' => 'resources/templates/list',
+        'params' => [],
+    ], $headers)->assertOk();
+
+    expect(collect($resourceTemplatesResponse->json('result.resourceTemplates'))->pluck('uriTemplate'))
+        ->toContain('ui://opnform/form-draft-preview-{version}');
 });
 
 it('serves preview data only through a valid signed URL without exposing capabilities', function () {

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\AgentFormDraftController;
+use App\Mcp\Apps\FormDraftPreviewApp;
+use App\Mcp\Apps\LegacyFormDraftPreviewApp;
 use App\Mcp\Servers\OpnFormServer;
 use App\Mcp\Tools\OpenFormDraftInEditorTool;
 use App\Mcp\Tools\PreviewFormDraftTool;
@@ -34,7 +36,7 @@ it('renders a read-only MCP App preview and creates an editor link only on deman
     OpnFormServer::tool(PreviewFormDraftTool::class, [
         'draft_handle' => $created['token'],
     ])->assertOk()
-        ->assertSee('preview_url')
+        ->assertDontSee('preview_url')
         ->assertSee('draft_handle')
         ->assertDontSee('editor_url')
         ->assertSee('Agent customer intake');
@@ -53,7 +55,8 @@ it('renders a read-only MCP App preview and creates an editor link only on deman
     OpnFormServer::tool(OpenFormDraftInEditorTool::class, [
         'draft_handle' => $created['token'],
     ])->assertOk()
-        ->assertSee('editor_url')
+        ->assertSee('editor_handoff_ready')
+        ->assertDontSee('editor_url')
         ->assertDontSee('handoff_token');
 
     $draft = $created['draft']->refresh();
@@ -62,13 +65,13 @@ it('renders a read-only MCP App preview and creates an editor link only on deman
         ->and($handoff->expires_at->isSameSecond($draft->expires_at))->toBeTrue()
         ->and(app(AgentFormDraftService::class)->issueEditorHandoff($created['token'])['editor_url'])
         ->toStartWith('https://opnform.test/agent-drafts/edit#handoff=')
-        ->and(app(\App\Mcp\Apps\FormDraftPreviewApp::class)->resolvedAppMeta()['csp']['frameDomains'])
+        ->and(app(FormDraftPreviewApp::class)->resolvedAppMeta()['csp']['frameDomains'])
         ->toBe(['https://opnform.test']);
 });
 
 it('publishes standard and ChatGPT-compatible CSP metadata with the full frontend origin', function () {
     config()->set('app.front_url', 'http://127.0.0.1:33676');
-    $previewApp = app(\App\Mcp\Apps\FormDraftPreviewApp::class);
+    $previewApp = app(FormDraftPreviewApp::class);
     $resource = $previewApp->handle(new \Laravel\Mcp\Request())
         ->content()
         ->toResource($previewApp);
@@ -80,7 +83,11 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->toBe(['http://127.0.0.1:33676'])
         ->and($previewApp->resolvedAppMeta()['csp']['frameDomains'])
         ->toBe(['http://127.0.0.1:33676'])
+        ->and($previewApp->resolvedAppMeta()['prefersBorder'])
+        ->toBeFalse()
         ->and($resource['text'])->not->toContain('native-preview')
+        ->and($resource['_meta']['openai/widgetDescription'])
+        ->toBe('Interactive private preview of the current OpnForm draft, with zoom controls and an Edit in OpnForm action.')
         ->and($resource['_meta']['openai/widgetCSP'])
         ->toBe([
             'connect_domains' => [],
@@ -90,7 +97,7 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ]);
 
     config()->set('app.front_url', 'https://opnform.test');
-    $secureApp = app(\App\Mcp\Apps\FormDraftPreviewApp::class);
+    $secureApp = app(FormDraftPreviewApp::class);
     $secureResource = $secureApp->handle(new \Laravel\Mcp\Request())
         ->content()
         ->toResource($secureApp);
@@ -105,17 +112,32 @@ it('publishes standard and ChatGPT-compatible CSP metadata with the full fronten
         ->toBe(['https://opnform.test']);
 });
 
-it('keeps preview template URIs used by existing plugin versions readable', function () {
+it('keeps signed editor URLs private to the widget result metadata', function () {
+    $created = app(AgentFormDraftService::class)->create(editorDraftDefinition());
+
+    $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'open_form_draft_in_editor',
+            'arguments' => ['draft_handle' => $created['token']],
+        ],
+    ], ['Accept' => 'application/json, text/event-stream'])->assertOk()
+        ->assertJsonPath('result.isError', false)
+        ->assertJsonPath('result.structuredContent.editor_handoff_ready', true)
+        ->assertJsonPath('result.structuredContent.expires_at', fn (string $expiresAt): bool => $expiresAt !== '')
+        ->assertJsonMissingPath('result.structuredContent.editor_url')
+        ->assertJsonPath('result._meta.editor_url', fn (string $url): bool => str_starts_with(
+            $url,
+            'https://opnform.test/agent-drafts/edit#handoff=',
+        ));
+});
+
+it('keeps the current OpenAI snapshot preview URI readable without a catch-all template', function () {
     $headers = ['Accept' => 'application/json, text/event-stream'];
 
-    $historicalUris = array_map(
-        fn (int $version) => "ui://opnform/form-draft-preview-v{$version}",
-        range(3, 7),
-    );
-    $historicalUris[] = 'ui://opnform/form-draft-preview-v8.html';
-
-    foreach ($historicalUris as $index => $uri) {
-
+    foreach ([FormDraftPreviewApp::URI, LegacyFormDraftPreviewApp::URI] as $index => $uri) {
         $this->postJson('/mcp', [
             'jsonrpc' => '2.0',
             'id' => $index + 1,
@@ -128,6 +150,16 @@ it('keeps preview template URIs used by existing plugin versions readable', func
             ->assertSee('Edit in OpnForm');
     }
 
+    $resourcesResponse = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 7,
+        'method' => 'resources/list',
+        'params' => [],
+    ], $headers)->assertOk();
+
+    expect(collect($resourcesResponse->json('result.resources'))->pluck('uri'))
+        ->toContain(FormDraftPreviewApp::URI, LegacyFormDraftPreviewApp::URI);
+
     $resourceTemplatesResponse = $this->postJson('/mcp', [
         'jsonrpc' => '2.0',
         'id' => 8,
@@ -136,7 +168,7 @@ it('keeps preview template URIs used by existing plugin versions readable', func
     ], $headers)->assertOk();
 
     expect(collect($resourceTemplatesResponse->json('result.resourceTemplates'))->pluck('uriTemplate'))
-        ->toContain('ui://opnform/form-draft-preview-{version}');
+        ->not->toContain('ui://opnform/form-draft-preview-{version}');
 });
 
 it('serves preview data only through a valid signed URL without exposing capabilities', function () {

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -168,7 +168,10 @@ it('hides guest draft capabilities but keeps validation and OAuth tools on self-
 
     expect($resourceUris)
         ->toContain('opnform://schemas/agent-form-definition/v1', 'opnform://reference/form-fields/v1')
-        ->not->toContain('ui://opnform/form-draft-preview.html');
+        ->not->toContain(
+            'ui://opnform/form-draft-preview.html',
+            'ui://opnform/form-draft-preview-v8.html',
+        );
 
     $resourceTemplatesResponse = $this->postJson('/mcp', [
         'jsonrpc' => '2.0',

--- a/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
+++ b/api/tests/Feature/Mcp/AuthenticatedFormToolsTest.php
@@ -168,11 +168,22 @@ it('hides guest draft capabilities but keeps validation and OAuth tools on self-
 
     expect($resourceUris)
         ->toContain('opnform://schemas/agent-form-definition/v1', 'opnform://reference/form-fields/v1')
-        ->not->toContain('ui://opnform/form-draft-preview-v8.html');
+        ->not->toContain('ui://opnform/form-draft-preview.html');
+
+    $resourceTemplatesResponse = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 3,
+        'method' => 'resources/templates/list',
+        'params' => [],
+    ], $headers)->assertOk();
+    $resourceTemplateUris = collect($resourceTemplatesResponse->json('result.resourceTemplates'))->pluck('uriTemplate');
+
+    expect($resourceTemplateUris)
+        ->not->toContain('ui://opnform/form-draft-preview-{version}');
 
     $this->postJson('/mcp', [
         'jsonrpc' => '2.0',
-        'id' => 3,
+        'id' => 4,
         'method' => 'tools/call',
         'params' => [
             'name' => 'create_form_draft',

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -36,8 +36,8 @@ it('publishes a neutral draft handle contract and accurate preview annotations',
         ->and($create['outputSchema']['properties'])->not->toHaveKey('draft_token')
         ->and($create['_meta'])->not->toHaveKey('ui')
         ->and(app(PatchFormDraftTool::class)->toArray()['_meta'])->not->toHaveKey('ui')
-        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview-v8.html')
-        ->and($preview['_meta']['openai/outputTemplate'])->toBe('ui://opnform/form-draft-preview-v8.html')
+        ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview.html')
+        ->and($preview['_meta']['openai/outputTemplate'])->toBe('ui://opnform/form-draft-preview.html')
         ->and($preview['inputSchema']['properties'])->toHaveKey('draft_handle')
         ->and($preview['outputSchema']['properties'])->not->toHaveKeys([
             'editor_url',

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -40,11 +40,14 @@ it('publishes a neutral draft handle contract and accurate preview annotations',
         ->and($preview['_meta']['openai/outputTemplate'])->toBe('ui://opnform/form-draft-preview.html')
         ->and($preview['inputSchema']['properties'])->toHaveKey('draft_handle')
         ->and($preview['outputSchema']['properties'])->not->toHaveKeys([
+            'preview_url',
             'editor_url',
             'editor_link_expires_at',
         ])
         ->and($preview['annotations']['readOnlyHint'])->toBeTrue()
         ->and($open['_meta']['ui']['visibility'])->toBe(['model', 'app'])
+        ->and($open['outputSchema']['properties'])->toHaveKey('editor_handoff_ready')
+        ->and($open['outputSchema']['properties'])->not->toHaveKey('editor_url')
         ->and($open['outputSchema']['properties'])->not->toHaveKey('handoff_token');
 });
 

--- a/api/tests/Feature/Mcp/McpOAuthTest.php
+++ b/api/tests/Feature/Mcp/McpOAuthTest.php
@@ -154,7 +154,8 @@ it('creates and previews a guest form over HTTP without an OAuth challenge', fun
     ], mcpHeaders())->assertOk()
         ->assertJsonPath('result.isError', false)
         ->assertJsonPath('result.structuredContent.draft.definition.title', 'Contact form')
-        ->assertJsonPath('result.structuredContent.preview_url', fn (string $url): bool => str_starts_with($url, 'https://opnform.test/'))
+        ->assertJsonMissingPath('result.structuredContent.preview_url')
+        ->assertJsonPath('result._meta.preview_url', fn (string $url): bool => str_starts_with($url, 'https://opnform.test/'))
         ->assertJsonPath('result.structuredContent.draft_handle', $draftHandle)
         ->assertJsonMissingPath('result.structuredContent.editor_url')
         ->assertJsonMissingPath('result._meta.mcp/www_authenticate');


### PR DESCRIPTION
## Summary
- keep historical OpnForm preview resource URIs readable for existing OpenAI plugin versions and conversations
- use one stable, unversioned canonical URI for all future non-breaking widget updates
- preserve strict self-hosted behavior by withholding the compatibility resource when guest MCP is unavailable

## Root cause
OpenAI persists the widget resource URI in plugin versions and existing conversations. OpnForm had replaced and removed v3 through v7 whenever the widget changed, so those immutable pointers now return `Resource not found` even though the current v8 resource is healthy.

The compatibility resource resolves historical v3 through v8 pointers through the current MCP App resource. New tool metadata now uses the permanent `ui://opnform/form-draft-preview.html` URI. A breaking UI contract may introduce a new exact URI without removing prior resources.

## Validation
- `php vendor/bin/pest tests/Feature/Mcp/AgentDraftEditorTest.php tests/Feature/Mcp/GuestDraftToolsTest.php tests/Feature/Mcp/AuthenticatedFormToolsTest.php` (44 tests, 388 assertions)
- `npm run test --if-present` (59 files, 752 tests)
- `npm run lint`
- `./vendor/bin/pint --test`
- `./vendor/bin/phpstan analyse --memory-limit=512M` reaches completion; only two pre-existing unrelated `Workspace::owners` findings remain in `BackfillLifetimeLicenseWorkspaceEntitlements.php`
- full parallel backend suite remains blocked by a pre-existing 128 MB child-worker exhaustion in `EmailNotificationTest.php`
