### PR TITLE
fix(mcp): guide users from preview to save

### DIFF
--- a/api/app/Mcp/Tools/PreviewFormDraftTool.php
+++ b/api/app/Mcp/Tools/PreviewFormDraftTool.php
@@ -17,7 +17,7 @@ use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
 #[Name('preview_form_draft')]
-#[Description('Render the final interactive preview for an existing guest draft without changing it. Call exactly once after a successful create_form_draft or patch_form_draft, and use it again only when the user explicitly asks to refresh an existing preview. The signed preview remains valid until the seven-day draft expires. This tool is read-only, safe to retry after an error, and does not create an editor link.')]
+#[Description('Render the final interactive preview for an existing guest draft without changing it. Call exactly once after a successful create_form_draft or patch_form_draft, and use it again only when the user explicitly asks to refresh an existing preview. After success, briefly summarize the result and ask one question offering two choices: modify the draft again or save it to the user\'s OpnForm account. Do not request OAuth unless the user chooses save. The signed preview remains valid until the seven-day draft expires. This tool is read-only, safe to retry after an error, and does not create an editor link.')]
 #[RendersApp(resource: FormDraftPreviewApp::class)]
 #[IsReadOnly]
 #[IsDestructive(false)]
@@ -44,6 +44,7 @@ class PreviewFormDraftTool extends GuestDraftMcpTool
         return Response::structured([
             'draft_handle' => $validated['draft_handle'],
             'draft' => $drafts->serialize($draft),
+            'next_step' => 'Briefly summarize the preview, then ask one question offering two choices: modify the draft again or save it to the user\'s OpnForm account. Do not request OAuth unless the user chooses save.',
         ])->withMeta('preview_url', $drafts->previewUrl($draft));
     }
 
@@ -63,6 +64,7 @@ class PreviewFormDraftTool extends GuestDraftMcpTool
         return [
             'draft_handle' => $schema->string()->min(43)->max(43)->required(),
             'draft' => McpOutputSchema::draft($schema)->required(),
+            'next_step' => $schema->string()->required(),
         ];
     }
 }

--- a/api/tests/Feature/Mcp/AgentDraftEditorTest.php
+++ b/api/tests/Feature/Mcp/AgentDraftEditorTest.php
@@ -38,6 +38,7 @@ it('renders a read-only MCP App preview and creates an editor link only on deman
     ])->assertOk()
         ->assertDontSee('preview_url')
         ->assertSee('draft_handle')
+        ->assertSee(['next_step', 'modify the draft again or save it', 'Do not request OAuth unless the user chooses save'])
         ->assertDontSee('editor_url')
         ->assertSee('Agent customer intake');
 

--- a/api/tests/Feature/Mcp/AgentPluginPackageTest.php
+++ b/api/tests/Feature/Mcp/AgentPluginPackageTest.php
@@ -264,9 +264,11 @@ it('guides the agent from guest preview to account save and explicit publication
     $server = file_get_contents(app_path('Mcp/Servers/OpnFormServer.php'));
     $createTool = file_get_contents(app_path('Mcp/Tools/CreateFormDraftTool.php'));
     $patchTool = file_get_contents(app_path('Mcp/Tools/PatchFormDraftTool.php'));
+    $previewTool = file_get_contents(app_path('Mcp/Tools/PreviewFormDraftTool.php'));
 
     expect($skill)
-        ->toContain('whether the user wants another change or wants to save the form')
+        ->toContain('ask exactly one question offering two choices')
+        ->toContain('A status-only response is incomplete')
         ->toContain('saved as an unpublished draft')
         ->toContain('Asking is not confirmation')
         ->and($server)
@@ -275,7 +277,11 @@ it('guides the agent from guest preview to account save and explicit publication
         ->and($createTool)
         ->toContain('data-only')
         ->and($patchTool)
-        ->toContain('data-only');
+        ->toContain('data-only')
+        ->and($previewTool)
+        ->toContain("'next_step'")
+        ->toContain('modify the draft again or save it')
+        ->toContain('Do not request OAuth unless the user chooses save');
 });
 
 it('renders a flattened and hardened form preview frame', function () {

--- a/api/tests/Feature/Mcp/GuestDraftToolsTest.php
+++ b/api/tests/Feature/Mcp/GuestDraftToolsTest.php
@@ -39,6 +39,9 @@ it('publishes a neutral draft handle contract and accurate preview annotations',
         ->and($preview['_meta']['ui']['resourceUri'])->toBe('ui://opnform/form-draft-preview.html')
         ->and($preview['_meta']['openai/outputTemplate'])->toBe('ui://opnform/form-draft-preview.html')
         ->and($preview['inputSchema']['properties'])->toHaveKey('draft_handle')
+        ->and($preview['description'])
+        ->toContain('modify the draft again or save it', 'Do not request OAuth unless the user chooses save')
+        ->and($preview['outputSchema']['properties'])->toHaveKey('next_step')
         ->and($preview['outputSchema']['properties'])->not->toHaveKeys([
             'preview_url',
             'editor_url',

--- a/plugins/opnform/skills/opnform/SKILL.md
+++ b/plugins/opnform/skills/opnform/SKILL.md
@@ -26,7 +26,7 @@ Success means the latest draft is valid and the turn contains exactly one final 
 5. For a requested revision, use `patch_form_draft` with the latest `expected_version`, then call `preview_form_draft` exactly once. Do not call the preview tool before the mutation or more than once after success.
 6. On a version conflict, call `get_form_draft`, reconcile the requested change, and retry with the current version. On a validation error, correct the operation and retry once. Never overwrite blindly.
 
-After the preview, summarize the result or change in one sentence and ask one immediate question: whether the user wants another change or wants to save the form to their OpnForm account. If the user already supplied the next instruction, perform it instead of repeating the question.
+Required final reply after each successful preview: summarize the result or change in one sentence, then ask exactly one question offering two choices—make another change or save the form to the user's OpnForm account. A status-only response is incomplete. If the user already supplied the next instruction, perform it instead of repeating the question.
 
 Use `preview_form_draft` without a mutation only when the user asks to refresh or redisplay an existing preview. A preview is read-only and remains valid until its seven-day guest draft expires.
 


### PR DESCRIPTION
## Summary
- return a structured next step from preview_form_draft so MCP-only connectors ask whether to modify or save
- make the packaged skill treat a status-only response after preview as incomplete
- keep OAuth deferred until the user explicitly chooses to save, then preserve the existing publish-confirmation flow
- cover the discovery contract, runtime response, and plugin package guidance with tests

## Validation
- 42 targeted MCP tests passed (513 assertions)
- Pint passed on the changed PHP files
- PHPStan passed on PreviewFormDraftTool
- OpnForm skill quick validation passed