### PR TITLE
Improve Docker public URL setup

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
       - "client/**"
       - "docker/**"
       - "docker-compose*.yml"
+      - "scripts/docker-setup.sh"
+      - "scripts/setup-env.sh"
+      - "scripts/tests/setup-env-test.sh"
       - ".github/workflows/**"
   pull_request:
     paths:
@@ -17,6 +20,9 @@ on:
       - "client/**"
       - "docker/**"
       - "docker-compose*.yml"
+      - "scripts/docker-setup.sh"
+      - "scripts/setup-env.sh"
+      - "scripts/tests/setup-env-test.sh"
       - ".github/workflows/**"
   workflow_dispatch:
 
@@ -32,6 +38,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Test Docker environment setup
+        run: bash scripts/tests/setup-env-test.sh
 
       - name: Get Composer cache directory
         id: composer-cache

--- a/api/.env.docker
+++ b/api/.env.docker
@@ -3,6 +3,7 @@ APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
+FRONT_URL=http://localhost
 
 LOG_CHANNEL=errorlog
 LOG_LEVEL=debug

--- a/docs/configuration/custom-domain.mdx
+++ b/docs/configuration/custom-domain.mdx
@@ -17,7 +17,14 @@ To use a custom domain (or subdomain) with OpnForm:
 
 1. Purchase a domain (if needed)
 2. Configure DNS records to point to your OpnForm instance
-3. Update OpnForm configuration:
+3. Update an existing Docker installation with your public origin:
+
+   ```bash
+   ./scripts/docker-setup.sh --public-url https://forms.example.com
+   ```
+
+   The command updates the following configuration while preserving existing
+   keys and secrets:
    - Set both `APP_URL` and `FRONT_URL` in `api/.env`
    - Set `NUXT_PUBLIC_APP_URL` and `NUXT_PUBLIC_API_BASE` in `client/.env`
 4. Secure with SSL certificate
@@ -37,8 +44,8 @@ NUXT_PUBLIC_API_BASE=https://forms.example.com/api
 `FRONT_URL` is used by the backend when it creates frontend callback URLs,
 including OIDC callbacks. Keep it aligned with the public frontend URL.
 
-After changing these files, recreate the containers; a restart alone does not
-load new environment values. See [Updating Environment Variables](./environment-variables#updating-environment-variables).
+If you change these files manually, recreate the containers; a restart alone
+does not load new environment values. See [Updating Environment Variables](./environment-variables#updating-environment-variables).
 
 <Note>
     If an OIDC connection already exists, edit it afterwards, use **Use current

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -14,6 +14,13 @@ production.
 
 For a standard Docker deployment available at `https://forms.example.com`:
 
+```bash
+./scripts/docker-setup.sh --public-url https://forms.example.com
+```
+
+The setup command creates or updates the following values while preserving
+existing application keys and secrets:
+
 | File | Variable | Value |
 | --- | --- | --- |
 | `api/.env` | `APP_URL` | `https://forms.example.com` |
@@ -27,11 +34,9 @@ same origin under `/api`, which is why `NUXT_PUBLIC_API_BASE` ends in `/api`.
 If your API is exposed on a separate public origin, use that browser-accessible
 API URL instead.
 
-<Warning>
-    After changing either `.env` file in Docker, recreate the affected
-    containers. `docker compose restart` does not reload environment values.
-    See [Updating Environment Variables](#updating-environment-variables).
-</Warning>
+If you configure these values manually, recreate the affected containers.
+`docker compose restart` does not reload environment values. See
+[Updating Environment Variables](#updating-environment-variables).
 
 For the deployment workflow, see [Docker Deployment](../deployment/docker#configure-your-public-instance-url).
 For the OIDC-specific checklist, see [OIDC SSO Configuration](./oidc-sso#prerequisites).

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -34,36 +34,52 @@ import CloudVersion from "/snippets/cloud-version.mdx";
 
     ```bash
     chmod +x scripts/docker-setup.sh
-    ./scripts/docker-setup.sh
+    ./scripts/docker-setup.sh --public-url https://forms.example.com
     ```
+
+    Replace `https://forms.example.com` with the origin that users enter in
+    their browser. Do not include a path or trailing slash. Use HTTPS for a
+    production deployment.
 
     The script will:
 
     - Create necessary environment files
+    - Configure the public backend and frontend URLs
     - Pull required Docker images
     - Start all containers in production mode
     - Display access information
 
-3. Access your OpnForm instance at `http://localhost`
+3. Access your OpnForm instance at the public URL you provided.
+
+<Note>
+    To evaluate OpnForm only on the local machine, omit `--public-url` and open
+    `http://localhost`. The script warns when the generated configuration still
+    points to localhost.
+</Note>
 
 ### Configure your public instance URL
 
-The setup script creates the environment files, but it cannot know the public
-domain where your instance will be available. Before configuring OIDC, OAuth,
-or using the instance in production, set the public URL in both files:
+Pass the public origin to the setup script to configure all required values in
+one command. You can run the same command again to update an existing
+installation; existing application keys and secrets are preserved.
+
+```bash
+./scripts/docker-setup.sh --public-url https://forms.example.com
+```
+
+The command sets these values:
 
 | File | Required variables |
 | --- | --- |
 | `api/.env` | `APP_URL` and `FRONT_URL` |
 | `client/.env` | `NUXT_PUBLIC_APP_URL` and `NUXT_PUBLIC_API_BASE` |
 
-For example, an instance available at `https://forms.example.com` uses
-`https://forms.example.com` for `APP_URL`, `FRONT_URL`, and
-`NUXT_PUBLIC_APP_URL`, plus `https://forms.example.com/api` for
-`NUXT_PUBLIC_API_BASE`.
+An instance available at `https://forms.example.com` uses that origin for
+`APP_URL`, `FRONT_URL`, and `NUXT_PUBLIC_APP_URL`, plus
+`https://forms.example.com/api` for `NUXT_PUBLIC_API_BASE`.
 
-After changing these variables, recreate the containers; `docker compose
-restart` does not load new environment values.
+If you edit either `.env` file manually, recreate the containers; `docker
+compose restart` does not load new environment values.
 
 ```bash
 docker compose down

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -23,6 +23,7 @@ echo -e "${NC}"
 # Default values
 DEV_MODE=false
 PUBLIC_URL=""
+PUBLIC_URL_PROVIDED=false
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
@@ -31,6 +32,7 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --dev) DEV_MODE=true ;;
         --public-url)
+            PUBLIC_URL_PROVIDED=true
             if [[ "$#" -lt 2 ]]; then
                 echo "Missing value for --public-url."
                 exit 1
@@ -38,13 +40,21 @@ while [[ "$#" -gt 0 ]]; do
             PUBLIC_URL="$2"
             shift
             ;;
-        --public-url=*) PUBLIC_URL="${1#*=}" ;;
+        --public-url=*)
+            PUBLIC_URL_PROVIDED=true
+            PUBLIC_URL="${1#*=}"
+            ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
 
-if [[ "$DEV_MODE" == true && -n "$PUBLIC_URL" ]]; then
+if [[ "$PUBLIC_URL_PROVIDED" == true && -z "$PUBLIC_URL" ]]; then
+    echo "--public-url cannot be empty."
+    exit 1
+fi
+
+if [[ "$DEV_MODE" == true && "$PUBLIC_URL_PROVIDED" == true ]]; then
     echo "--public-url is only available for production Docker setup."
     exit 1
 fi

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -97,6 +97,9 @@ if [ "$DEV_MODE" = false ]; then
         SETUP_ARGS+=(--public-url "$PUBLIC_URL")
     fi
     bash "$SCRIPT_DIR/setup-env.sh" "${SETUP_ARGS[@]}"
+    if [[ -n "$PUBLIC_URL" ]]; then
+        PUBLIC_URL="$(grep '^APP_URL=' "$PROJECT_ROOT/api/.env" | tail -n 1 | cut -d= -f2-)"
+    fi
 
     if jwt_skip_validation_disabled_in_env "$PROJECT_ROOT/api/.env"; then
         echo -e "${YELLOW}Warning: JWT User Agent validation is disabled in api/.env.${NC}"

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -22,6 +22,7 @@ echo -e "${NC}"
 
 # Default values
 DEV_MODE=false
+PUBLIC_URL=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
@@ -29,10 +30,24 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --dev) DEV_MODE=true ;;
+        --public-url)
+            if [[ "$#" -lt 2 ]]; then
+                echo "Missing value for --public-url."
+                exit 1
+            fi
+            PUBLIC_URL="$2"
+            shift
+            ;;
+        --public-url=*) PUBLIC_URL="${1#*=}" ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
+
+if [[ "$DEV_MODE" == true && -n "$PUBLIC_URL" ]]; then
+    echo "--public-url is only available for production Docker setup."
+    exit 1
+fi
 
 cd "$PROJECT_ROOT"
 
@@ -77,7 +92,11 @@ echo -e "${BLUE}Starting OpnForm Docker setup...${NC}"
 # Run the environment setup script with --docker flag (only for production)
 if [ "$DEV_MODE" = false ]; then
     echo -e "${GREEN}Setting up environment files...${NC}"
-    bash "$SCRIPT_DIR/setup-env.sh" --docker
+    SETUP_ARGS=(--docker)
+    if [[ -n "$PUBLIC_URL" ]]; then
+        SETUP_ARGS+=(--public-url "$PUBLIC_URL")
+    fi
+    bash "$SCRIPT_DIR/setup-env.sh" "${SETUP_ARGS[@]}"
 
     if jwt_skip_validation_disabled_in_env "$PROJECT_ROOT/api/.env"; then
         echo -e "${YELLOW}Warning: JWT User Agent validation is disabled in api/.env.${NC}"
@@ -130,5 +149,5 @@ if [ "$DEV_MODE" = true ]; then
 else
     echo -e "${BLUE}Production environment setup complete!${NC}"
     echo -e "${YELLOW}Please wait a moment for all services to start${NC}"
-    echo -e "${GREEN}Then visit: http://localhost${NC}"
+    echo -e "${GREEN}Then visit: ${PUBLIC_URL:-http://localhost}${NC}"
 fi

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -107,9 +107,7 @@ if [ "$DEV_MODE" = false ]; then
         SETUP_ARGS+=(--public-url "$PUBLIC_URL")
     fi
     bash "$SCRIPT_DIR/setup-env.sh" "${SETUP_ARGS[@]}"
-    if [[ -n "$PUBLIC_URL" ]]; then
-        PUBLIC_URL="$(grep '^APP_URL=' "$PROJECT_ROOT/api/.env" | tail -n 1 | cut -d= -f2-)"
-    fi
+    PUBLIC_URL="$(grep '^APP_URL=' "$PROJECT_ROOT/api/.env" | tail -n 1 | cut -d= -f2-)"
 
     if jwt_skip_validation_disabled_in_env "$PROJECT_ROOT/api/.env"; then
         echo -e "${YELLOW}Warning: JWT User Agent validation is disabled in api/.env.${NC}"

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -15,6 +15,7 @@ CLIENT_ENV_EXAMPLE="client/.env.example"
 # Check for Docker-specific environment settings
 USE_DOCKER_ENV=false
 PUBLIC_URL=""
+PUBLIC_URL_PROVIDED=false
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --docker)
@@ -23,6 +24,7 @@ while [[ "$#" -gt 0 ]]; do
       CLIENT_ENV_EXAMPLE="client/.env.docker"
       ;;
     --public-url)
+      PUBLIC_URL_PROVIDED=true
       if [[ "$#" -lt 2 ]]; then
         echo "Missing value for --public-url." >&2
         exit 1
@@ -31,6 +33,7 @@ while [[ "$#" -gt 0 ]]; do
       shift
       ;;
     --public-url=*)
+      PUBLIC_URL_PROVIDED=true
       PUBLIC_URL="${1#*=}"
       ;;
     *)
@@ -41,7 +44,12 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-if [[ -n "$PUBLIC_URL" && "$USE_DOCKER_ENV" != true ]]; then
+if [[ "$PUBLIC_URL_PROVIDED" == true && -z "$PUBLIC_URL" ]]; then
+  echo "--public-url cannot be empty." >&2
+  exit 1
+fi
+
+if [[ "$PUBLIC_URL_PROVIDED" == true && "$USE_DOCKER_ENV" != true ]]; then
   echo "--public-url can only be used with --docker." >&2
   exit 1
 fi

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -49,6 +49,7 @@ fi
 normalize_public_url() {
   local url="$1"
   local authority
+  local port=""
 
   while [[ "$url" == */ ]]; do
     url="${url%/}"
@@ -63,8 +64,17 @@ normalize_public_url() {
   esac
 
   authority="${url#*://}"
-  if [[ -z "$authority" || "$authority" == */* || "$authority" == *\?* || "$authority" == *\#* || "$authority" == *\|* || "$authority" == *\\* || "$authority" == *\&* || "$authority" == *@* || "$authority" =~ [[:space:]] ]]; then
-    echo "The public URL must be an origin without a path, query, fragment, or credentials." >&2
+  if [[ "$authority" =~ ^\[[0-9A-Fa-f:.]+\](:([0-9]+))?$ ]]; then
+    port="${BASH_REMATCH[2]}"
+  elif [[ "$authority" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:([0-9]+))?$ ]]; then
+    port="${BASH_REMATCH[3]}"
+  else
+    echo "The public URL must contain a valid hostname or IP address and no path, query, fragment, or credentials." >&2
+    return 1
+  fi
+
+  if [[ -n "$port" ]] && (( 10#$port < 1 || 10#$port > 65535 )); then
+    echo "The public URL port must be between 1 and 65535." >&2
     return 1
   fi
 

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -12,17 +12,72 @@ CLIENT_ENV_FILE="client/.env"
 ENV_EXAMPLE="api/.env.example"
 CLIENT_ENV_EXAMPLE="client/.env.example"
 
-# Check for the --docker flag to use Docker-specific environment settings
+# Check for Docker-specific environment settings
 USE_DOCKER_ENV=false
-for arg in "$@"; do
-  if [ "$arg" == "--docker" ]; then
-    USE_DOCKER_ENV=true
-    ENV_EXAMPLE="api/.env.docker"
-    CLIENT_ENV_EXAMPLE="client/.env.docker"
-    echo "OpnForm setup detected the --docker flag. Preparing Docker-specific environment..."
-    break
-  fi
+PUBLIC_URL=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --docker)
+      USE_DOCKER_ENV=true
+      ENV_EXAMPLE="api/.env.docker"
+      CLIENT_ENV_EXAMPLE="client/.env.docker"
+      ;;
+    --public-url)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Missing value for --public-url." >&2
+        exit 1
+      fi
+      PUBLIC_URL="$2"
+      shift
+      ;;
+    --public-url=*)
+      PUBLIC_URL="${1#*=}"
+      ;;
+    *)
+      echo "Unknown parameter: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
 done
+
+if [[ -n "$PUBLIC_URL" && "$USE_DOCKER_ENV" != true ]]; then
+  echo "--public-url can only be used with --docker." >&2
+  exit 1
+fi
+
+normalize_public_url() {
+  local url="$1"
+  local authority
+
+  while [[ "$url" == */ ]]; do
+    url="${url%/}"
+  done
+
+  case "$url" in
+    http://*|https://*) ;;
+    *)
+      echo "The public URL must start with http:// or https://." >&2
+      return 1
+      ;;
+  esac
+
+  authority="${url#*://}"
+  if [[ -z "$authority" || "$authority" == */* || "$authority" == *\?* || "$authority" == *\#* || "$authority" == *\|* || "$authority" == *\\* || "$authority" == *\&* || "$authority" == *@* || "$authority" =~ [[:space:]] ]]; then
+    echo "The public URL must be an origin without a path, query, fragment, or credentials." >&2
+    return 1
+  fi
+
+  printf '%s' "$url"
+}
+
+if [[ -n "$PUBLIC_URL" ]]; then
+  PUBLIC_URL="$(normalize_public_url "$PUBLIC_URL")"
+fi
+
+if [[ "$USE_DOCKER_ENV" == true ]]; then
+  echo "OpnForm setup detected the --docker flag. Preparing Docker-specific environment..."
+fi
 
 # Function to generate a random string for secrets
 generate_secret() {
@@ -56,33 +111,72 @@ set_env_value() {
   fi
 }
 
+get_env_value() {
+  local file=$1
+  local key=$2
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  grep "^$key=" "$file" | tail -n 1 | cut -d= -f2- || true
+}
+
 # Check if the main .env file exists
 if [ -f "$ENV_FILE" ]; then
-  echo "OpnForm's main .env file is already in place. No further action is needed."
+  echo "OpnForm's main .env file is already in place. Preserving its existing secrets."
 else
   echo "Creating OpnForm's main .env file from the template..."
   cp "$ENV_EXAMPLE" "$ENV_FILE"
+fi
 
-  # Secure your OpnForm instance with a unique APP_KEY
+# Secure your OpnForm instance with a unique APP_KEY
+if [[ -z "$(get_env_value "$ENV_FILE" "APP_KEY")" ]]; then
   APP_KEY=$(generate_base64_key)
   set_env_value "$ENV_FILE" "APP_KEY" "base64:$APP_KEY"
+fi
 
-  # Generate a JWT_SECRET to sign your tokens
+# Generate a JWT_SECRET to sign your tokens
+if [[ -z "$(get_env_value "$ENV_FILE" "JWT_SECRET")" ]]; then
   JWT_SECRET=$(generate_secret)
   set_env_value "$ENV_FILE" "JWT_SECRET" "$JWT_SECRET"
+fi
 
-  # Generate a shared secret for the client
+# Generate or reuse the shared secret for the client
+SHARED_SECRET="$(get_env_value "$ENV_FILE" "FRONT_API_SECRET")"
+if [[ -z "$SHARED_SECRET" ]]; then
+  SHARED_SECRET="$(get_env_value "$CLIENT_ENV_FILE" "NUXT_API_SECRET")"
+fi
+if [[ -z "$SHARED_SECRET" ]]; then
   SHARED_SECRET=$(generate_secret)
-  set_env_value "$ENV_FILE" "FRONT_API_SECRET" "$SHARED_SECRET"
+fi
+set_env_value "$ENV_FILE" "FRONT_API_SECRET" "$SHARED_SECRET"
+
+if [[ "$USE_DOCKER_ENV" == true && -z "$(get_env_value "$ENV_FILE" "FRONT_URL")" ]]; then
+  APP_URL_VALUE="$(get_env_value "$ENV_FILE" "APP_URL")"
+  set_env_value "$ENV_FILE" "FRONT_URL" "${APP_URL_VALUE:-http://localhost}"
 fi
 
 # Check if the client .env file exists
 if [ -f "$CLIENT_ENV_FILE" ]; then
-  echo "OpnForm's client .env file is already configured. Moving on..."
+  echo "OpnForm's client .env file is already configured. Preserving its existing values."
 else
   echo "Creating OpnForm's client .env file from the template..."
   cp "$CLIENT_ENV_EXAMPLE" "$CLIENT_ENV_FILE"
+fi
+
+if [[ -z "$(get_env_value "$CLIENT_ENV_FILE" "NUXT_API_SECRET")" ]]; then
   set_env_value "$CLIENT_ENV_FILE" "NUXT_API_SECRET" "$SHARED_SECRET"
+fi
+
+if [[ -n "$PUBLIC_URL" ]]; then
+  set_env_value "$ENV_FILE" "APP_URL" "$PUBLIC_URL"
+  set_env_value "$ENV_FILE" "FRONT_URL" "$PUBLIC_URL"
+  set_env_value "$CLIENT_ENV_FILE" "NUXT_PUBLIC_APP_URL" "$PUBLIC_URL"
+  set_env_value "$CLIENT_ENV_FILE" "NUXT_PUBLIC_API_BASE" "$PUBLIC_URL/api"
+  echo "Configured OpnForm's public URL as $PUBLIC_URL."
+elif [[ "$USE_DOCKER_ENV" == true && "$(get_env_value "$ENV_FILE" "APP_URL")" == "http://localhost" ]]; then
+  echo "Warning: APP_URL still points to localhost. Before production use, rerun with --public-url https://forms.example.com." >&2
 fi
 
 echo "✅ OpnForm environment setup is now complete. Enjoy building your forms!"

--- a/scripts/tests/setup-env-test.sh
+++ b/scripts/tests/setup-env-test.sh
@@ -196,6 +196,15 @@ if [[ "$wrapper_output" != *'Then visit: https://wrapper.example.test'* ]]; then
   exit 1
 fi
 
+existing_wrapper_output="$(
+  cd "$docker_root"
+  PATH="$docker_root/bin:$PATH" bash scripts/docker-setup.sh
+)"
+if [[ "$existing_wrapper_output" != *'Then visit: https://wrapper.example.test'* ]]; then
+  echo "Expected Docker setup to display the existing public URL when no new value is provided." >&2
+  exit 1
+fi
+
 if bash "$REPOSITORY_ROOT/scripts/docker-setup.sh" --dev --public-url https://forms.example.com >/dev/null 2>&1; then
   echo "Expected --dev and --public-url to be rejected together." >&2
   exit 1

--- a/scripts/tests/setup-env-test.sh
+++ b/scripts/tests/setup-env-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT INT TERM
+
+prepare_repository() {
+  local target="$1"
+
+  mkdir -p "$target/api" "$target/client" "$target/scripts"
+  cp "$REPOSITORY_ROOT/api/.env.docker" "$target/api/.env.docker"
+  cp "$REPOSITORY_ROOT/api/.env.example" "$target/api/.env.example"
+  cp "$REPOSITORY_ROOT/client/.env.docker" "$target/client/.env.docker"
+  cp "$REPOSITORY_ROOT/client/.env.example" "$target/client/.env.example"
+  cp "$REPOSITORY_ROOT/scripts/setup-env.sh" "$target/scripts/setup-env.sh"
+}
+
+env_value() {
+  local file="$1"
+  local key="$2"
+
+  grep "^$key=" "$file" | tail -n 1 | cut -d= -f2-
+}
+
+assert_env_value() {
+  local file="$1"
+  local key="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(env_value "$file" "$key")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Expected $key=$expected in $file, got $actual." >&2
+    exit 1
+  fi
+}
+
+fresh_root="$TEST_ROOT/fresh"
+prepare_repository "$fresh_root"
+(
+  cd "$fresh_root"
+  bash scripts/setup-env.sh --docker --public-url https://forms.example.com/
+)
+
+assert_env_value "$fresh_root/api/.env" APP_URL https://forms.example.com
+assert_env_value "$fresh_root/api/.env" FRONT_URL https://forms.example.com
+assert_env_value "$fresh_root/client/.env" NUXT_PUBLIC_APP_URL https://forms.example.com
+assert_env_value "$fresh_root/client/.env" NUXT_PUBLIC_API_BASE https://forms.example.com/api
+assert_env_value "$fresh_root/client/.env" NUXT_PRIVATE_API_BASE http://ingress/api
+
+fresh_shared_secret="$(env_value "$fresh_root/api/.env" FRONT_API_SECRET)"
+if [[ -z "$fresh_shared_secret" ]]; then
+  echo "Expected setup to generate FRONT_API_SECRET." >&2
+  exit 1
+fi
+assert_env_value "$fresh_root/client/.env" NUXT_API_SECRET "$fresh_shared_secret"
+
+local_root="$TEST_ROOT/local"
+prepare_repository "$local_root"
+(
+  cd "$local_root"
+  bash scripts/setup-env.sh --docker >/dev/null
+)
+
+assert_env_value "$local_root/api/.env" APP_URL http://localhost
+assert_env_value "$local_root/api/.env" FRONT_URL http://localhost
+assert_env_value "$local_root/client/.env" NUXT_PUBLIC_APP_URL /
+assert_env_value "$local_root/client/.env" NUXT_PUBLIC_API_BASE /api
+
+generic_root="$TEST_ROOT/generic"
+prepare_repository "$generic_root"
+(
+  cd "$generic_root"
+  bash scripts/setup-env.sh >/dev/null
+)
+
+generic_shared_secret="$(env_value "$generic_root/api/.env" FRONT_API_SECRET)"
+if [[ -z "$generic_shared_secret" ]]; then
+  echo "Expected generic setup to generate FRONT_API_SECRET." >&2
+  exit 1
+fi
+assert_env_value "$generic_root/client/.env" NUXT_API_SECRET "$generic_shared_secret"
+
+existing_root="$TEST_ROOT/existing"
+prepare_repository "$existing_root"
+printf '%s\n' \
+  'APP_KEY=base64:keep-existing-key' \
+  'JWT_SECRET=keep-existing-jwt' \
+  'APP_URL=http://old.example.test' \
+  'FRONT_API_SECRET=keep-existing-shared-secret' \
+  >"$existing_root/api/.env"
+printf '%s\n' \
+  'NUXT_PUBLIC_APP_URL=/' \
+  'NUXT_PUBLIC_API_BASE=/api' \
+  'NUXT_PRIVATE_API_BASE=http://ingress/api' \
+  'NUXT_API_SECRET=keep-existing-shared-secret' \
+  >"$existing_root/client/.env"
+
+(
+  cd "$existing_root"
+  bash scripts/setup-env.sh --docker --public-url=https://new.example.test
+)
+
+assert_env_value "$existing_root/api/.env" APP_KEY base64:keep-existing-key
+assert_env_value "$existing_root/api/.env" JWT_SECRET keep-existing-jwt
+assert_env_value "$existing_root/api/.env" FRONT_API_SECRET keep-existing-shared-secret
+assert_env_value "$existing_root/api/.env" APP_URL https://new.example.test
+assert_env_value "$existing_root/api/.env" FRONT_URL https://new.example.test
+assert_env_value "$existing_root/client/.env" NUXT_PUBLIC_APP_URL https://new.example.test
+assert_env_value "$existing_root/client/.env" NUXT_PUBLIC_API_BASE https://new.example.test/api
+assert_env_value "$existing_root/client/.env" NUXT_API_SECRET keep-existing-shared-secret
+
+invalid_root="$TEST_ROOT/invalid"
+prepare_repository "$invalid_root"
+if (
+  cd "$invalid_root"
+  bash scripts/setup-env.sh --docker --public-url https://forms.example.com/path
+); then
+  echo "Expected a public URL containing a path to be rejected." >&2
+  exit 1
+fi
+
+if [[ -e "$invalid_root/api/.env" || -e "$invalid_root/client/.env" ]]; then
+  echo "Invalid input must be rejected before environment files are created." >&2
+  exit 1
+fi
+
+docker_root="$TEST_ROOT/docker-wrapper"
+prepare_repository "$docker_root"
+cp "$REPOSITORY_ROOT/scripts/docker-setup.sh" "$docker_root/scripts/docker-setup.sh"
+printf '%s\n' 'services: {}' >"$docker_root/docker-compose.yml"
+mkdir -p "$docker_root/bin"
+# The variables in the following strings belong to the generated fake Docker script.
+# shellcheck disable=SC2016
+printf '%s\n' \
+  '#!/bin/bash' \
+  'if [[ "$1" == "compose" && "$2" == "version" ]]; then exit 0; fi' \
+  'if [[ "$1" == "compose" ]]; then printf "%s\n" "$*" >"$FAKE_DOCKER_ARGS"; exit 0; fi' \
+  'exit 1' \
+  >"$docker_root/bin/docker"
+chmod +x "$docker_root/bin/docker"
+FAKE_DOCKER_ARGS="$docker_root/docker-args"
+export FAKE_DOCKER_ARGS
+(
+  cd "$docker_root"
+  PATH="$docker_root/bin:$PATH" bash scripts/docker-setup.sh --public-url https://wrapper.example.test >/dev/null
+)
+
+assert_env_value "$docker_root/api/.env" APP_URL https://wrapper.example.test
+assert_env_value "$docker_root/api/.env" FRONT_URL https://wrapper.example.test
+assert_env_value "$docker_root/client/.env" NUXT_PUBLIC_APP_URL https://wrapper.example.test
+assert_env_value "$docker_root/client/.env" NUXT_PUBLIC_API_BASE https://wrapper.example.test/api
+grep -F 'compose -f docker-compose.yml up -d' "$FAKE_DOCKER_ARGS" >/dev/null
+
+if bash "$REPOSITORY_ROOT/scripts/docker-setup.sh" --dev --public-url https://forms.example.com >/dev/null 2>&1; then
+  echo "Expected --dev and --public-url to be rejected together." >&2
+  exit 1
+fi
+
+bash -n "$REPOSITORY_ROOT/scripts/setup-env.sh"
+bash -n "$REPOSITORY_ROOT/scripts/docker-setup.sh"
+
+echo "Docker environment setup tests passed."

--- a/scripts/tests/setup-env-test.sh
+++ b/scripts/tests/setup-env-test.sh
@@ -127,6 +127,16 @@ if [[ -e "$invalid_root/api/.env" || -e "$invalid_root/client/.env" ]]; then
   exit 1
 fi
 
+invalid_port_root="$TEST_ROOT/invalid-port"
+prepare_repository "$invalid_port_root"
+if (
+  cd "$invalid_port_root"
+  bash scripts/setup-env.sh --docker --public-url https://forms.example.com:not-a-port
+); then
+  echo "Expected a non-numeric public URL port to be rejected." >&2
+  exit 1
+fi
+
 docker_root="$TEST_ROOT/docker-wrapper"
 prepare_repository "$docker_root"
 cp "$REPOSITORY_ROOT/scripts/docker-setup.sh" "$docker_root/scripts/docker-setup.sh"

--- a/scripts/tests/setup-env-test.sh
+++ b/scripts/tests/setup-env-test.sh
@@ -137,6 +137,16 @@ if (
   exit 1
 fi
 
+empty_url_root="$TEST_ROOT/empty-url"
+prepare_repository "$empty_url_root"
+if (
+  cd "$empty_url_root"
+  bash scripts/setup-env.sh --docker --public-url=
+); then
+  echo "Expected an empty public URL to be rejected." >&2
+  exit 1
+fi
+
 docker_root="$TEST_ROOT/docker-wrapper"
 prepare_repository "$docker_root"
 cp "$REPOSITORY_ROOT/scripts/docker-setup.sh" "$docker_root/scripts/docker-setup.sh"

--- a/scripts/tests/setup-env-test.sh
+++ b/scripts/tests/setup-env-test.sh
@@ -147,6 +147,24 @@ if (
   exit 1
 fi
 
+port_root="$TEST_ROOT/port"
+prepare_repository "$port_root"
+(
+  cd "$port_root"
+  bash scripts/setup-env.sh --docker --public-url http://127.0.0.1:8080 >/dev/null
+)
+assert_env_value "$port_root/api/.env" APP_URL http://127.0.0.1:8080
+
+invalid_port_range_root="$TEST_ROOT/invalid-port-range"
+prepare_repository "$invalid_port_range_root"
+if (
+  cd "$invalid_port_range_root"
+  bash scripts/setup-env.sh --docker --public-url https://forms.example.com:65536
+); then
+  echo "Expected an out-of-range public URL port to be rejected." >&2
+  exit 1
+fi
+
 docker_root="$TEST_ROOT/docker-wrapper"
 prepare_repository "$docker_root"
 cp "$REPOSITORY_ROOT/scripts/docker-setup.sh" "$docker_root/scripts/docker-setup.sh"
@@ -163,16 +181,20 @@ printf '%s\n' \
 chmod +x "$docker_root/bin/docker"
 FAKE_DOCKER_ARGS="$docker_root/docker-args"
 export FAKE_DOCKER_ARGS
-(
+wrapper_output="$(
   cd "$docker_root"
-  PATH="$docker_root/bin:$PATH" bash scripts/docker-setup.sh --public-url https://wrapper.example.test >/dev/null
-)
+  PATH="$docker_root/bin:$PATH" bash scripts/docker-setup.sh --public-url https://wrapper.example.test/
+)"
 
 assert_env_value "$docker_root/api/.env" APP_URL https://wrapper.example.test
 assert_env_value "$docker_root/api/.env" FRONT_URL https://wrapper.example.test
 assert_env_value "$docker_root/client/.env" NUXT_PUBLIC_APP_URL https://wrapper.example.test
 assert_env_value "$docker_root/client/.env" NUXT_PUBLIC_API_BASE https://wrapper.example.test/api
 grep -F 'compose -f docker-compose.yml up -d' "$FAKE_DOCKER_ARGS" >/dev/null
+if [[ "$wrapper_output" != *'Then visit: https://wrapper.example.test'* ]]; then
+  echo "Expected Docker setup to display the normalized public URL." >&2
+  exit 1
+fi
 
 if bash "$REPOSITORY_ROOT/scripts/docker-setup.sh" --dev --public-url https://forms.example.com >/dev/null 2>&1; then
   echo "Expected --dev and --public-url to be rejected together." >&2


### PR DESCRIPTION
## Summary
- add `--public-url` to the production Docker setup and populate all backend/frontend public URL variables
- update existing environment files without rotating application keys or shared secrets
- add the missing `FRONT_URL` Docker default and warn when a production setup still points to localhost
- report the normalized or existing public URL after setup
- update Docker, environment variable, and custom-domain documentation
- add shell tests and run them in CI when the setup scripts change

## Why
The previous setup generated localhost/relative defaults and reported completion, while the public URL still had to be configured manually in four places. Missing or inconsistent origins affect emails, OAuth/OIDC callbacks, and generated absolute URLs.

This is complementary to #1284: that PR makes PDF signatures independent from the proxy hostname, while this PR makes the canonical public origin explicit for features that require absolute URLs.

## Usage
```bash
./scripts/docker-setup.sh --public-url https://forms.example.com
```

Running the command again updates an existing installation while preserving its secrets.

## Testing
- `bash scripts/tests/setup-env-test.sh`
- `shellcheck scripts/setup-env.sh scripts/docker-setup.sh scripts/tests/setup-env-test.sh`
- `bash -n scripts/setup-env.sh scripts/docker-setup.sh scripts/tests/setup-env-test.sh`
- parsed `.github/workflows/ci-cd.yml` successfully with Ruby YAML