### PR TITLE
Fix typo in confetti submission label

### DIFF
--- a/client/components/open/forms/components/form-components/FormCustomization.vue
+++ b/client/components/open/forms/components/form-components/FormCustomization.vue
@@ -225,7 +225,7 @@
     <toggle-switch-input
       name="confetti_on_submission"
       :form="form"
-      label="Confetti on successful submisison"
+      label="Confetti on successful submission"
       @update:model-value="onChangeConfettiOnSubmission"
     />
     <ToggleSwitchInput


### PR DESCRIPTION
Simple typo fix that was bugging me for "Confetti on successful submission" label.