### PR TITLE
Fix select input label accessibility

### DIFF
--- a/client/components/forms/core/SelectInput.vue
+++ b/client/components/forms/core/SelectInput.vue
@@ -6,6 +6,7 @@
 
     <v-select
       v-model="compVal"
+      :id="id || name"
       :dusk="name"
       :data="finalOptions"
       :label="label"

--- a/client/components/forms/core/components/VSelect.vue
+++ b/client/components/forms/core/components/VSelect.vue
@@ -21,10 +21,12 @@
           :class="[variantSlots.anchor({ class: ui?.slots?.anchor }), inputClass]"
         >
         <button
+          :id="controlId"
           type="button"
+          :disabled="disabled"
           aria-haspopup="listbox"
           :aria-expanded="isOpen"
-          aria-labelledby="listbox-label"
+          :aria-controls="listboxId"
           :class="variantSlots.button({ class: ui?.slots?.button })"
           @click.stop="toggleDropdown"
           @focus="onFocus"
@@ -100,13 +102,14 @@
 
       <template #content>
         <div
+          :id="listboxId"
           tabindex="-1"
           role="listbox"
           ref="scrollRef"
           :class="variantSlots.dropdown({ class: ui?.slots?.dropdown })"
           class="w-(--reka-popper-anchor-width)"
           :style="popoverContentStyle"
-          :aria-activedescendant="highlightedIndex >= 0 ? `option-${highlightedIndex}` : undefined"
+          :aria-activedescendant="highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined"
           @keydown="handleDropdownKeydown"
         >
           <div
@@ -160,7 +163,7 @@
               <div
                 v-for="virtualItem in virtualizer.getVirtualItems()"
                 :key="filteredOptions[virtualItem.index] ? filteredOptions[virtualItem.index][optionKey] : virtualItem.index"
-                :id="`option-${virtualItem.index}`"
+                :id="optionId(virtualItem.index)"
                 role="option"
                 :aria-selected="filteredOptions[virtualItem.index] ? isSelected(filteredOptions[virtualItem.index]) : false"
                 :data-index="virtualItem.index"
@@ -199,7 +202,7 @@
               <div
                 v-for="(option, index) in filteredOptions"
                 :key="option[optionKey]"
-                :id="`option-${index}`"
+                :id="optionId(index)"
                 role="option"
                 :aria-selected="isSelected(option)"
                 :style="optionStyle"
@@ -271,7 +274,13 @@ export default {
   name: 'VSelect',
   components: {},
   directives: {},
+  setup() {
+    return {
+      generatedId: useId()
+    }
+  },
   props: {
+    id: { type: String, default: null },
     data: Array,
     modelValue: { default: null, type: [String, Number, Array, Object, Boolean] },
     inputClass: { type: String, default: null },
@@ -320,6 +329,12 @@ export default {
     }
   },
   computed: {
+    controlId() {
+      return this.id || `v-select-${this.generatedId}`
+    },
+    listboxId() {
+      return `${this.controlId}-listbox`
+    },
     // Resolve theme values with proper reactivity
     resolvedTheme() {
       return this.theme || 'default'
@@ -511,6 +526,9 @@ export default {
     }
   },
   methods: {
+    optionId(index) {
+      return `${this.controlId}-option-${index}`
+    },
     buildFuse () {
       if (!this.data || !Array.isArray(this.data) || this.data.length === 0) {
         this.fuse = null

--- a/client/test/nuxt/select-input-accessibility.spec.ts
+++ b/client/test/nuxt/select-input-accessibility.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SelectInput from '../../components/forms/core/SelectInput.vue'
+import VSelect from '../../components/forms/core/components/VSelect.vue'
+
+const options = [
+  { name: 'Bug', value: 'bug' },
+  { name: 'Suggestion', value: 'suggestion' },
+]
+
+const popoverStub = {
+  props: ['open'],
+  emits: ['update:open'],
+  template: '<div><slot name="anchor" /><slot name="content" /></div>',
+}
+
+describe('SelectInput accessibility', () => {
+  it('uses the field id for the select control', () => {
+    const wrapper = mount(SelectInput, {
+      props: {
+        id: 'feedback-type',
+        name: 'type_of_feedback',
+        label: 'Type of feedback',
+        options,
+      },
+      global: {
+        stubs: {
+          InputWrapper: {
+            props: ['id', 'name', 'label'],
+            template: '<div><label :for="id || name">{{ label }}</label><slot /></div>',
+          },
+          VSelect: {
+            props: ['id'],
+            template: '<button :id="id" />',
+          },
+          Icon: true,
+        },
+        provide: {
+          form: undefined,
+        },
+      },
+    })
+
+    expect(wrapper.get('label').attributes('for')).toBe('feedback-type')
+    expect(wrapper.get('button').attributes('id')).toBe('feedback-type')
+  })
+
+  it('falls back to the field name when no id is provided', () => {
+    const wrapper = mount(SelectInput, {
+      props: {
+        name: 'type_of_feedback',
+        label: 'Type of feedback',
+        options,
+      },
+      global: {
+        stubs: {
+          InputWrapper: {
+            props: ['id', 'name', 'label'],
+            template: '<div><label :for="id || name">{{ label }}</label><slot /></div>',
+          },
+          VSelect: {
+            props: ['id'],
+            template: '<button :id="id" />',
+          },
+          Icon: true,
+        },
+        provide: {
+          form: undefined,
+        },
+      },
+    })
+
+    expect(wrapper.get('label').attributes('for')).toBe('type_of_feedback')
+    expect(wrapper.get('button').attributes('id')).toBe('type_of_feedback')
+  })
+})
+
+describe('VSelect accessibility', () => {
+  it('connects the control, listbox, and active option with unique ids', async () => {
+    const wrapper = mount(VSelect, {
+      props: {
+        id: 'feedback-type',
+        data: options,
+        optionKey: 'value',
+      },
+      global: {
+        stubs: {
+          UPopover: popoverStub,
+          Icon: true,
+          Loader: true,
+        },
+      },
+    })
+
+    const button = wrapper.get('button[aria-haspopup="listbox"]')
+    const listbox = wrapper.get('[role="listbox"]')
+    const renderedOptions = wrapper.findAll('[role="option"]')
+
+    expect(button.attributes('id')).toBe('feedback-type')
+    expect(button.attributes('aria-controls')).toBe('feedback-type-listbox')
+    expect(button.attributes('aria-labelledby')).toBeUndefined()
+    expect(listbox.attributes('id')).toBe('feedback-type-listbox')
+    expect(renderedOptions.map(option => option.attributes('id'))).toEqual([
+      'feedback-type-option-0',
+      'feedback-type-option-1',
+    ])
+
+    await button.trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.vm.$nextTick()
+
+    expect(listbox.attributes('aria-activedescendant')).toBe('feedback-type-option-0')
+  })
+
+  it('uses native button disabling', () => {
+    const wrapper = mount(VSelect, {
+      props: {
+        id: 'feedback-type',
+        data: options,
+        disabled: true,
+      },
+      global: {
+        stubs: {
+          UPopover: popoverStub,
+          Icon: true,
+          Loader: true,
+        },
+      },
+    })
+
+    expect(wrapper.get('button[aria-haspopup="listbox"]').attributes('disabled')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

- connect `SelectInput` labels to the actual `VSelect` trigger button
- replace the invalid hard-coded `aria-labelledby` reference with unique control, listbox, and option IDs
- use the native disabled state on the select trigger
- add regression coverage for explicit IDs, name fallbacks, ARIA relationships, keyboard highlighting, and disabled controls

## Scope

This fixes the confirmed label/accessibility defect reported on the customer form. It intentionally does not claim to fix the separately observed intermittent slow initial load, which still needs evidence before changing loading or chunk-recovery behavior.

## Validation

- `npm run lint`
- `npm run test -- --run` (61 files, 759 tests)
- `npm run build`
- `git diff --check`