### PR TITLE
Fix route chunk error recovery and observability

### DIFF
--- a/client/lib/chunk-error-recovery.js
+++ b/client/lib/chunk-error-recovery.js
@@ -1,0 +1,35 @@
+export const CHUNK_ERROR_RECOVERY_TAG = 'chunk-error-recovery'
+
+export function createChunkErrorRecovery ({ captureException, flush, reload }) {
+  let recoveryStarted = false
+
+  return ({ error }) => {
+    if (recoveryStarted) {
+      return false
+    }
+
+    recoveryStarted = true
+
+    try {
+      captureException(error, {
+        tags: {
+          handled_by: CHUNK_ERROR_RECOVERY_TAG,
+        },
+      })
+    } catch {
+      // Recovery must not depend on telemetry being available.
+    }
+
+    Promise.resolve()
+      .then(() => flush(500))
+      .catch(() => {})
+      .finally(() => {
+        reload({
+          persistState: true,
+          ttl: 60_000,
+        })
+      })
+
+    return true
+  }
+}

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -86,7 +86,8 @@ export default defineNuxtConfig({
   },
 
   experimental: {
-      inlineRouteRules: true
+      inlineRouteRules: true,
+      emitRouteChunkError: 'manual'
   },
 
   sentry: {

--- a/client/plugins/0.error-handler.client.js
+++ b/client/plugins/0.error-handler.client.js
@@ -1,21 +1,12 @@
+import * as Sentry from '@sentry/nuxt'
+import { createChunkErrorRecovery } from '~/lib/chunk-error-recovery.js'
+
 export default defineNuxtPlugin((nuxtApp) => {
-const router = useRouter()
+  const recover = createChunkErrorRecovery({
+    captureException: Sentry.captureException,
+    flush: Sentry.flush,
+    reload: reloadNuxtApp,
+  })
 
-    router.onError((error) => {
-        if (
-        error.message.includes('Failed to fetch dynamically imported module') ||
-        error.message.includes('Failed to load resource')
-        ) {
-        window.location.reload()
-        }
-    })
-
-    nuxtApp.hook('app:error', (error) => {
-        if (
-        error.message.includes('Loading chunk') ||
-        error.message.includes('Failed to load resource')
-        ) {
-        window.location.reload()
-        }
-    })
+  nuxtApp.hook('app:chunkError', recover)
 })

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nuxt";
+import { CHUNK_ERROR_RECOVERY_TAG } from './lib/chunk-error-recovery.js'
 
 Sentry.init({
   // If set up, you can use your runtime config here
@@ -27,12 +28,15 @@ Sentry.init({
         return null
       }
       
-      // Filter out chunk loading errors
-      if (
+      // The recovery plugin reports exact Nuxt chunk errors before reloading.
+      // Keep filtering noisy browser errors that merely resemble chunk failures.
+      const isRecoveredChunkError = event.tags?.handled_by === CHUNK_ERROR_RECOVERY_TAG
+      const resemblesChunkError =
         errorValue.includes('Failed to fetch dynamically imported module') ||
         errorValue.includes('Loading chunk') ||
         errorValue.includes('Failed to load resource')
-      ) {
+
+      if (!isRecoveredChunkError && resemblesChunkError) {
         return null
       }
     }

--- a/client/test/e2e/opnform-flows.spec.ts
+++ b/client/test/e2e/opnform-flows.spec.ts
@@ -219,15 +219,21 @@ async function openRegister(page: Page) {
 }
 
 async function selectHearAboutUs(page: Page) {
-  await page.getByRole("button", { name: "Select option", exact: true }).click()
-  await page.getByText("Friend or Colleague", { exact: true }).click()
+  const select = page.getByRole("button", { name: "How did you hear about us?", exact: true })
+
+  await expect(async () => {
+    await select.click()
+    await expect(select).toHaveAttribute("aria-expanded", "true")
+  }).toPass({ timeout: 15_000 })
+
+  await page.getByRole("option", { name: "Friend or Colleague", exact: true }).click()
 }
 
 async function registerUi(page: Page, email: string) {
   await openRegister(page)
+  await selectHearAboutUs(page)
   await page.locator('input[name="name"]').fill("Playwright User")
   await page.locator('input[name="email"]').fill(email)
-  await selectHearAboutUs(page)
   await page.locator('input[name="password"]').fill("Abcd@1234")
   await page.locator('input[name="password_confirmation"]').fill("Abcd@1234")
   await page.locator('input[name="agree_terms"]').check({ force: true })

--- a/client/test/unit/chunk-error-recovery.test.ts
+++ b/client/test/unit/chunk-error-recovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CHUNK_ERROR_RECOVERY_TAG,
+  createChunkErrorRecovery,
+} from '../../lib/chunk-error-recovery.js'
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('createChunkErrorRecovery', () => {
+  it('reports the exact chunk error before reloading with persistent loop protection', async () => {
+    const captureException = vi.fn()
+    const flush = vi.fn(() => Promise.resolve(true))
+    const reload = vi.fn()
+    const recover = createChunkErrorRecovery({ captureException, flush, reload })
+    const error = new Error('Failed to fetch dynamically imported module')
+
+    expect(recover({ error })).toBe(true)
+    await flushPromises()
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      tags: {
+        handled_by: CHUNK_ERROR_RECOVERY_TAG,
+      },
+    })
+    expect(flush).toHaveBeenCalledWith(500)
+    expect(reload).toHaveBeenCalledWith({
+      persistState: true,
+      ttl: 60_000,
+    })
+  })
+
+  it('deduplicates chunk errors while recovery is already in progress', async () => {
+    let finishFlush
+    const flush = vi.fn(() => new Promise(resolve => {
+      finishFlush = resolve
+    }))
+    const captureException = vi.fn()
+    const reload = vi.fn()
+    const recover = createChunkErrorRecovery({ captureException, flush, reload })
+
+    expect(recover({ error: new Error('first') })).toBe(true)
+    expect(recover({ error: new Error('second') })).toBe(false)
+    await Promise.resolve()
+    finishFlush(true)
+    await flushPromises()
+
+    expect(captureException).toHaveBeenCalledTimes(1)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reloads when telemetry cannot be flushed', async () => {
+    const reload = vi.fn()
+    const recover = createChunkErrorRecovery({
+      captureException: vi.fn(),
+      flush: vi.fn(() => Promise.reject(new Error('Sentry unavailable'))),
+      reload,
+    })
+
+    expect(recover({ error: new Error('chunk failure') })).toBe(true)
+    await flushPromises()
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reloads when telemetry capture throws synchronously', async () => {
+    const reload = vi.fn()
+    const recover = createChunkErrorRecovery({
+      captureException: vi.fn(() => {
+        throw new Error('Sentry unavailable')
+      }),
+      flush: vi.fn(() => Promise.resolve(true)),
+      reload,
+    })
+
+    expect(recover({ error: new Error('chunk failure') })).toBe(true)
+    await flushPromises()
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- replace broad error-message reload heuristics with Nuxt’s exact `app:chunkError` hook
- use `reloadNuxtApp` with persisted state and a 60-second cross-reload loop guard
- report the original chunk failure to Sentry and flush it before reloading
- prevent duplicate recovery attempts while one is already in progress

## Why

The previous handler called `window.location.reload()` for generic “Failed to load resource” messages. That could reload for unrelated failures, loop indefinitely when an asset remained unavailable, and the matching Sentry filter removed the evidence needed to diagnose actual chunk failures.

## Validation

- red-before-green targeted recovery test
- `npm run test -- --run` (62 files, 763 tests)
- `npm run lint`
- `npm run build`
- inspected the production bundle: the custom recovery handler is present and Nuxt’s automatic chunk reload plugin is absent, avoiding double reloads

The existing build warnings are unchanged (missing local Sentry auth token, existing Rollup circular chunk warnings, and an existing duplicate Notion key warning).